### PR TITLE
Observer: Record audio from microphone

### DIFF
--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -1,0 +1,93 @@
+﻿using FlacBox;
+using NAudio.Wave;
+using System;
+using System.IO;
+using System.Diagnostics;
+
+namespace SpeakFasterObserver
+{
+    class AudioInput
+    {
+        private static int AUDIO_NUM_CHANNELS = 1;
+        private static int AUDIO_BITS_PER_SAMPLE = 16;
+        private static int AUDIO_SAMPLE_RATE_HZ = 16000;
+        // How long each output audio file is (unit: second).
+        private static int PER_FILE_DURATION_SEC = 10;  // TODO(cais): Change to 60.
+
+        private WaveIn waveIn = null;
+        private bool isRecording = false;  // TODO(cais): Thread safety?
+        private int[] buffer = null;
+        private int bufferPointer = 0;
+
+        public AudioInput() {}
+        public void StartRecordingFromMicrophone()
+        {
+            if (isRecording)
+            {
+                throw new Exception("Already recording from microphone");
+            }
+            waveIn = new WaveIn();
+            waveIn.WaveFormat = new WaveFormat(AUDIO_SAMPLE_RATE_HZ, AUDIO_NUM_CHANNELS);
+            if (waveIn.WaveFormat.BitsPerSample != AUDIO_BITS_PER_SAMPLE)
+            {
+                throw new NotSupportedException(
+                    String.Format(
+                        "Expected wave-in bits per sample to be {0}, but got {1}",
+                        AUDIO_BITS_PER_SAMPLE, waveIn.WaveFormat.BitsPerSample));
+            }
+            waveIn.DataAvailable += new EventHandler<WaveInEventArgs>(WaveDataAvailable);
+            // TODO(cais): Do not hard code path. Remove wav file writing.
+            //waveFileWriter = new WaveFileWriter(@"C:\Temp\Test0001.wav", waveIn.WaveFormat);
+            buffer = new int[AUDIO_SAMPLE_RATE_HZ * PER_FILE_DURATION_SEC];
+            bufferPointer = 0;
+            waveIn.StartRecording();
+            isRecording = true;
+        }
+        public void StopRecordingFromMicrophone()
+        {
+            if (!isRecording)
+            {
+                throw new Exception("Not recording from microphone");
+            }
+            waveIn.StopRecording();
+            isRecording = false;
+        }
+
+        private void WaveDataAvailable(object sender, WaveInEventArgs e)
+        {
+            //int sumSquares = 0;  // TODO(cais): Clean up.
+            for (int i = 0; i < e.Buffer.Length; i += 2)
+            {
+                if (bufferPointer >= buffer.Length)
+                {
+                    WriteBufferToFlacFile();
+                    Debug.WriteLine("Wrote to .flac file");
+                    bufferPointer = 0;
+                }
+                buffer[bufferPointer++] = BitConverter.ToInt16(e.Buffer, i);
+            }
+            //if (waveFileWriter != null)  //TODO(cais): Remove this.
+            //{
+            //    waveFileWriter.Write(e.Buffer, 0, e.BytesRecorded);
+            //    waveFileWriter.Flush();
+            //}
+        }
+
+        private void WriteBufferToFlacFile()
+        {
+            using (var flacStream = File.Create(@"C:\Temp\Test0001.flac"))
+            {
+                FlacWriter flacWriter = new FlacWriter(flacStream);
+                FlacStreaminfo streamInfo = new FlacStreaminfo();
+                streamInfo.ChannelsCount = AUDIO_NUM_CHANNELS;
+                streamInfo.BitsPerSample = AUDIO_BITS_PER_SAMPLE;
+                streamInfo.SampleRate = AUDIO_SAMPLE_RATE_HZ;
+                streamInfo.TotalSampleCount = AUDIO_SAMPLE_RATE_HZ * PER_FILE_DURATION_SEC;
+                streamInfo.MaxBlockSize = AUDIO_SAMPLE_RATE_HZ;
+                flacWriter.StartStream(streamInfo);
+                flacWriter.WriteSamples(buffer);
+                flacWriter.EndStream();
+            }
+        }
+    }
+}

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -17,7 +17,7 @@ namespace SpeakFasterObserver
         private FileStream flacStream = null; 
         private FlacWriter flacWriter = null;
         private int[] buffer = null;
-        private volatile bool isRecording = false;  // TODO(cais): Thread safety?
+        private volatile bool isRecording = false;
         private static readonly object flacLock = new object();
 
         public AudioInput(string dataDir) {

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -7,21 +7,22 @@ namespace SpeakFasterObserver
 {
     class AudioInput
     {
-        private static int AUDIO_NUM_CHANNELS = 1;
-        private static int AUDIO_BITS_PER_SAMPLE = 16;
-        private static int AUDIO_SAMPLE_RATE_HZ = 16000;
-        // NOTE: Due to limited buffer size, using a write timer of with a
-        // period of 120 s or greater will cause data loss, which will throw an
-        // exception.
-        private static int MAX_BUFFER_LENGTH = AUDIO_SAMPLE_RATE_HZ * 120;
+        private static readonly int AUDIO_NUM_CHANNELS = 1;
+        private static readonly int AUDIO_BITS_PER_SAMPLE = 16;
+        private static readonly int AUDIO_SAMPLE_RATE_HZ = 16000;
 
+        private readonly string dataDir;
         private WaveIn waveIn = null;
-        private bool isRecording = false;  // TODO(cais): Thread safety?
+        private string flacFilePath = null;
+        private FileStream flacStream = null; 
+        private FlacWriter flacWriter = null;
         private int[] buffer = null;
-        private int bufferPointer = 0;
-        private static readonly object lockObj = new object();
+        private bool isRecording = false;  // TODO(cais): Thread safety?
+        private static readonly object flacLock = new object();
 
-        public AudioInput() {}
+        public AudioInput(string dataDir) {
+            this.dataDir = dataDir;
+        }
 
         public void StartRecordingFromMicrophone()
         {
@@ -29,17 +30,18 @@ namespace SpeakFasterObserver
             {
                 return;
             }
-            waveIn = new WaveIn();
-            waveIn.WaveFormat = new WaveFormat(AUDIO_SAMPLE_RATE_HZ, AUDIO_NUM_CHANNELS);
+            waveIn = new WaveIn
+            {
+                WaveFormat = new WaveFormat(AUDIO_SAMPLE_RATE_HZ, AUDIO_NUM_CHANNELS)
+            };
             if (waveIn.WaveFormat.BitsPerSample != AUDIO_BITS_PER_SAMPLE)
             {
                 throw new NotSupportedException(
                     $"Expected wave-in bits per sample to be {AUDIO_BITS_PER_SAMPLE}, " +
                     $"but got {waveIn.WaveFormat.BitsPerSample}");
             }
+            CreateFlacWriter();
             waveIn.DataAvailable += new EventHandler<WaveInEventArgs>(WaveDataAvailable);
-            buffer = new int[MAX_BUFFER_LENGTH];
-            bufferPointer = 0;
             waveIn.StartRecording();
             isRecording = true;
         }
@@ -51,49 +53,72 @@ namespace SpeakFasterObserver
                 return;
             }
             waveIn.StopRecording();
+            MaybeEndCurrentFlacWriter();
             isRecording = false;
         }
 
         private void WaveDataAvailable(object sender, WaveInEventArgs e)
         {
-            lock (lockObj)
+            lock (flacLock)
             {
+                if (buffer == null || buffer.Length != e.Buffer.Length / 2)
+                {
+                    // Reuse the buffer whenever we can.
+                    buffer = new int[e.Buffer.Length / 2];
+                }
                 for (int i = 0; i < e.Buffer.Length; i += 2)
                 {
-                    if (bufferPointer >= buffer.Length)
-                    {
-                        throw new OverflowException("Audio buffer overflowed");
-                    }
-                    buffer[bufferPointer++] = BitConverter.ToInt16(e.Buffer, i);
+                    buffer[i / 2] = BitConverter.ToInt16(e.Buffer, i);
                 }
+                flacWriter.WriteSamples(buffer);
             }
         }
 
-        public void WriteBufferToFlacFile(string flacFilePath)
+        public void RotateFlacWriter()
         {
-            lock (lockObj)
+            MaybeEndCurrentFlacWriter();
+            CreateFlacWriter();
+        }
+
+        private void MaybeEndCurrentFlacWriter()
+        {
+            lock (flacLock)
             {
-                if (bufferPointer == 0)
+                if (flacWriter == null)
                 {
-                    // No data to write.
                     return;
                 }
-                using (var flacStream = File.Create(flacFilePath))
+                flacWriter.EndStream();
+                flacStream.Close();
+                File.Move(
+                    flacFilePath,
+                    FileNaming.removeInProgressSuffix(flacFilePath));
+                flacFilePath = null;
+                flacStream = null;
+                flacWriter = null;
+            }
+        }
+
+        private void CreateFlacWriter()
+        {
+            lock (flacLock)
+            {
+                if (flacWriter != null)
                 {
-                    FlacWriter flacWriter = new FlacWriter(flacStream);
-                    FlacStreaminfo streamInfo = new FlacStreaminfo();
-                    streamInfo.ChannelsCount = AUDIO_NUM_CHANNELS;
-                    streamInfo.BitsPerSample = AUDIO_BITS_PER_SAMPLE;
-                    streamInfo.SampleRate = AUDIO_SAMPLE_RATE_HZ;
-                    streamInfo.TotalSampleCount = bufferPointer;
-                    streamInfo.MaxBlockSize = AUDIO_SAMPLE_RATE_HZ;
-                    flacWriter.StartStream(streamInfo);
-                    int[] samples = new int[bufferPointer];
-                    Array.Copy(buffer, samples, bufferPointer);
-                    flacWriter.WriteSamples(samples);
-                    flacWriter.EndStream();
+                    return;
                 }
-                bufferPointer = 0;
+                flacFilePath = flacFilePath = FileNaming.addInProgressSuffix(
+                        FileNaming.getMicWavInFilePath(dataDir));
+                flacStream = File.Create(flacFilePath);
+                flacWriter = new FlacWriter(flacStream);
+                FlacStreaminfo streamInfo = new FlacStreaminfo
+                {
+                    ChannelsCount = AUDIO_NUM_CHANNELS,
+                    BitsPerSample = AUDIO_BITS_PER_SAMPLE,
+                    SampleRate = AUDIO_SAMPLE_RATE_HZ,
+                    MaxBlockSize = AUDIO_SAMPLE_RATE_HZ,
+                };
+                flacWriter.StartStream(streamInfo);
             }
         }
     }

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -2,7 +2,6 @@
 using NAudio.Wave;
 using System;
 using System.IO;
-using System.Diagnostics;
 
 namespace SpeakFasterObserver
 {

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -25,10 +25,9 @@ namespace SpeakFasterObserver
         public AudioInput() {}
         public void StartRecordingFromMicrophone()
         {
-            // TODO(cais): Control by system tray icon click. DO NOT SUBMIT.
             if (isRecording)
             {
-                throw new Exception("Already recording from microphone");
+                return;
             }
             waveIn = new WaveIn();
             waveIn.WaveFormat = new WaveFormat(AUDIO_SAMPLE_RATE_HZ, AUDIO_NUM_CHANNELS);
@@ -48,7 +47,7 @@ namespace SpeakFasterObserver
         {
             if (!isRecording)
             {
-                throw new Exception("Not recording from microphone");
+                return;
             }
             waveIn.StopRecording();
             isRecording = false;
@@ -75,6 +74,7 @@ namespace SpeakFasterObserver
             {
                 if (bufferPointer == 0)
                 {
+                    // No data to write.
                     return;
                 }
                 using (var flacStream = File.Create(flacFilePath))
@@ -87,7 +87,9 @@ namespace SpeakFasterObserver
                     streamInfo.TotalSampleCount = bufferPointer;
                     streamInfo.MaxBlockSize = AUDIO_SAMPLE_RATE_HZ;
                     flacWriter.StartStream(streamInfo);
-                    flacWriter.WriteSamples(buffer);
+                    int[] samples = new int[bufferPointer];
+                    Array.Copy(buffer, samples, bufferPointer);
+                    flacWriter.WriteSamples(samples);
                     flacWriter.EndStream();
                 }
                 bufferPointer = 0;

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -22,6 +22,7 @@ namespace SpeakFasterObserver
         private static readonly object lockObj = new object();
 
         public AudioInput() {}
+
         public void StartRecordingFromMicrophone()
         {
             if (isRecording)
@@ -42,6 +43,7 @@ namespace SpeakFasterObserver
             waveIn.StartRecording();
             isRecording = true;
         }
+
         public void StopRecordingFromMicrophone()
         {
             if (!isRecording)

--- a/Observer/SpeakFasterObserver/FileNaming.cs
+++ b/Observer/SpeakFasterObserver/FileNaming.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+
+namespace SpeakFasterObserver
+{
+    class FileNaming
+    {
+        private static string IN_PROGRESS_SUFFIX = ".InProgress";
+        public static String getTimestamp()
+        {
+            return $"{DateTime.Now:yyyyMMddTHHmmssfff}";
+        }
+
+        public static string getAudioFileName(string dataDir)
+        {
+            return Path.Combine(dataDir, $"{getTimestamp()}-MicWaveIn.flac");
+        }
+
+        public static string getMicWavInFilePath(string dataDir)
+        {
+            return Path.Combine(dataDir, $"{getTimestamp()}-MicWaveIn.flac");
+        }
+
+        public static string getScreenshotFilePath(string dataDir, string timestamp = null)
+        {
+            String actualTimestamp = timestamp != null ? timestamp : getTimestamp();
+            return Path.Combine(dataDir, $"{actualTimestamp}-Screenshot.jpg");
+        }
+
+        public static string getSpeechScreenshotFilePath(string dataDir, string timestamp = null)
+        {
+            String actualTimestamp = timestamp != null ? timestamp : getTimestamp();
+            return Path.Combine(dataDir, $"{actualTimestamp}-SpeechScreenshot.jpg");
+        }
+
+        public static string getKeypressesProtobufFilePath(String dataDir)
+        {
+            return Path.Combine(dataDir, $"{getTimestamp()}-Keypresses.protobuf");
+        }
+        public static string addInProgressSuffix(String filePath)
+        {
+            if (filePath.EndsWith(IN_PROGRESS_SUFFIX))
+            {
+                return filePath;
+            }
+            return filePath + IN_PROGRESS_SUFFIX;
+        }
+        public static string removeInProgressSuffix(String filePath)
+        {
+            if (filePath.EndsWith(IN_PROGRESS_SUFFIX))
+            {
+                return filePath.Substring(0, filePath.Length - IN_PROGRESS_SUFFIX.Length);
+            }
+            return filePath;
+        }
+    }
+}

--- a/Observer/SpeakFasterObserver/FileNaming.cs
+++ b/Observer/SpeakFasterObserver/FileNaming.cs
@@ -12,11 +12,6 @@ namespace SpeakFasterObserver
             return $"{DateTime.Now:yyyyMMddTHHmmssfff}";
         }
 
-        public static string getAudioFileName(string dataDir)
-        {
-            return Path.Combine(dataDir, $"{getTimestamp()}-MicWaveIn.flac");
-        }
-
         public static string getMicWavInFilePath(string dataDir)
         {
             return Path.Combine(dataDir, $"{getTimestamp()}-MicWaveIn.flac");

--- a/Observer/SpeakFasterObserver/FileNaming.cs
+++ b/Observer/SpeakFasterObserver/FileNaming.cs
@@ -37,9 +37,14 @@ namespace SpeakFasterObserver
         {
             return Path.Combine(dataDir, $"{getTimestamp()}-Keypresses.protobuf");
         }
+
+        public static bool isInProgress(String filePath)
+        {
+            return filePath.EndsWith(IN_PROGRESS_SUFFIX);
+        }
         public static string addInProgressSuffix(String filePath)
         {
-            if (filePath.EndsWith(IN_PROGRESS_SUFFIX))
+            if (isInProgress(filePath))
             {
                 return filePath;
             }
@@ -47,7 +52,7 @@ namespace SpeakFasterObserver
         }
         public static string removeInProgressSuffix(String filePath)
         {
-            if (filePath.EndsWith(IN_PROGRESS_SUFFIX))
+            if (isInProgress(filePath))
             {
                 return filePath.Substring(0, filePath.Length - IN_PROGRESS_SUFFIX.Length);
             }

--- a/Observer/SpeakFasterObserver/FileNaming.cs
+++ b/Observer/SpeakFasterObserver/FileNaming.cs
@@ -6,6 +6,7 @@ namespace SpeakFasterObserver
     class FileNaming
     {
         private static string IN_PROGRESS_SUFFIX = ".InProgress";
+
         public static String getTimestamp()
         {
             return $"{DateTime.Now:yyyyMMddTHHmmssfff}";
@@ -42,6 +43,7 @@ namespace SpeakFasterObserver
         {
             return filePath.EndsWith(IN_PROGRESS_SUFFIX);
         }
+
         public static string addInProgressSuffix(String filePath)
         {
             if (isInProgress(filePath))
@@ -50,6 +52,7 @@ namespace SpeakFasterObserver
             }
             return filePath + IN_PROGRESS_SUFFIX;
         }
+
         public static string removeInProgressSuffix(String filePath)
         {
             if (isInProgress(filePath))

--- a/Observer/SpeakFasterObserver/FormMain.Designer.cs
+++ b/Observer/SpeakFasterObserver/FormMain.Designer.cs
@@ -43,6 +43,7 @@ namespace SpeakFasterObserver
             this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.notifyIconContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.RecordScreenshotsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.RecordMicWaveInToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ExitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.screenshotTimer = new System.Windows.Forms.Timer(this.components);
             this.processCheckerTimer = new System.Windows.Forms.Timer(this.components);
@@ -179,6 +180,7 @@ namespace SpeakFasterObserver
             this.notifyIconContextMenuStrip.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.notifyIconContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.RecordScreenshotsToolStripMenuItem,
+            this.RecordMicWaveInToolStripMenuItem,
             this.ExitToolStripMenuItem});
             this.notifyIconContextMenuStrip.Name = "notifyIconContextMenuStrip";
             this.notifyIconContextMenuStrip.Size = new System.Drawing.Size(297, 80);
@@ -189,6 +191,12 @@ namespace SpeakFasterObserver
             this.RecordScreenshotsToolStripMenuItem.Name = "RecordScreenshotsToolStripMenuItem";
             this.RecordScreenshotsToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.RecordScreenshotsToolStripMenuItem.Text = "Record Screenshots";
+            //
+            // RecordMicWaveInToolStripMenuItem
+            //
+            this.RecordMicWaveInToolStripMenuItem.Name = "RecordMicWaveInToolStripMenuItem";
+            this.RecordMicWaveInToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
+            this.RecordMicWaveInToolStripMenuItem.Text = "Record Audio from Microphone";
             // 
             // ExitToolStripMenuItem
             // 
@@ -250,6 +258,7 @@ namespace SpeakFasterObserver
         private System.Windows.Forms.ContextMenuStrip notifyIconContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem ExitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem RecordScreenshotsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem RecordMicWaveInToolStripMenuItem;
     }
 }
 

--- a/Observer/SpeakFasterObserver/FormMain.cs
+++ b/Observer/SpeakFasterObserver/FormMain.cs
@@ -26,7 +26,7 @@ namespace SpeakFasterObserver
         private static string lastKeypressString = String.Empty;
         Keylogger keylogger;
 
-        System.Threading.Timer uploadTimer = new(Upload.Timer_Tick);
+        System.Threading.Timer uploadTimer = new(Timer_Tick);
         static System.Threading.Timer keyloggerTimer = new((state) => { SaveKeypresses(); });
         public FormMain()
         {
@@ -126,6 +126,16 @@ namespace SpeakFasterObserver
             {
                 SetRecordingState(isRecording, !isRecordingScreenshots);
             }
+        }
+
+        public static async void Timer_Tick(object? state)
+        {
+            // Flush audio data to file.
+            var timestamp = $"{DateTime.Now:yyyyMMddTHHmmssfff}";
+            var micWaveInFilePath = Path.Combine(
+                dataPath, $"{timestamp}-MicWaveIn.flac");
+            audioInput.WriteBufferToFlacFile(micWaveInFilePath);
+            Upload.Timer_Tick(state);
         }
 
         private void screenshotTimer_Tick(object sender, EventArgs e)

--- a/Observer/SpeakFasterObserver/FormMain.cs
+++ b/Observer/SpeakFasterObserver/FormMain.cs
@@ -5,10 +5,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Text;
-using System.Windows;
-using System.Windows.Interop;
-using System.Windows.Controls;
-using System.Windows.Input;
 using System.Windows.Forms;
 
 namespace SpeakFasterObserver
@@ -136,13 +132,6 @@ namespace SpeakFasterObserver
                 SetRecordingState(isRecording, isRecordingScreenshots, !isRecordingMicWaveIn);
             }
         }
-
-        // Flush audio input data to file.
-        //private static void flushAudioInput()
-        //{
-        //    // Flush audio data to file.
-        //    audioInput.WriteBufferToFlacFile(DataFormat.getMicWavInFilePath(dataPath));
-        //}
 
         public static async void Timer_Tick(object? state)
         {

--- a/Observer/SpeakFasterObserver/FormMain.cs
+++ b/Observer/SpeakFasterObserver/FormMain.cs
@@ -7,9 +7,6 @@ using System.IO;
 using System.Text;
 using System.Windows.Forms;
 
-using NAudio.Wave;
-using FlacBox;
-
 namespace SpeakFasterObserver
 {
     public partial class FormMain : Form
@@ -24,6 +21,7 @@ namespace SpeakFasterObserver
         static bool balabolkaRunning = false;
         static bool balabolkaFocused = false;
         static bool tobiiComputerControlRunning = false;
+        static AudioInput audioInput;
         static ScreenCapture screenCapture;
         private static string lastKeypressString = String.Empty;
         Keylogger keylogger;
@@ -73,48 +71,8 @@ namespace SpeakFasterObserver
             Upload._dataDirectory = (dataPath);
             uploadTimer.Change(0, 60 * 1000);
 
-            WaveIn waveSource = new WaveIn();
-            waveSource.WaveFormat = new WaveFormat(16000, 1);
-            waveSource.DataAvailable += new EventHandler<WaveInEventArgs>(waveSource_DataAvailable);
-            waveFile = new WaveFileWriter(@"C:\Temp\Test0001.wav", waveSource.WaveFormat);
-            waveSource.StartRecording();
-
-            using (var flacStream = File.Create(@"C:\Temp\Test0001.flac"))
-            {
-                // See https://github.com/Afterster/FlacBox/blob/master/FlacBox/FlacWriter.cs
-                FlacWriter flacWriter = new FlacWriter(flacStream);
-                FlacStreaminfo streamInfo = new FlacStreaminfo();
-                streamInfo.ChannelsCount = 1;
-                streamInfo.BitsPerSample = 16;
-                streamInfo.SampleRate = 16000;
-                streamInfo.TotalSampleCount = 16000 * 60;
-                streamInfo.MaxBlockSize = 16000;
-                flacWriter.StartStream(streamInfo);
-                int[] samples = new int[16000 * 60];
-                for (int i = 0; i < samples.Length; ++i)
-                {
-                    samples[i] = (i % 16000) - 8000;
-                }
-                flacWriter.WriteSamples(samples);
-                flacWriter.EndStream();
-            }
-        }
-
-        WaveFileWriter waveFile = null;
-
-        void waveSource_DataAvailable(object sender, WaveInEventArgs e)
-        {
-            int sumSquares = 0;
-            for (int i = 0; i < e.Buffer.Length; ++i)
-            {
-                int x = ((int)e.Buffer[i]) - 128;
-                sumSquares += x * x;
-            }
-            if (waveFile != null)
-            {
-                waveFile.Write(e.Buffer, 0, e.BytesRecorded);
-                waveFile.Flush();
-            }
+            audioInput = new AudioInput();
+            audioInput.StartRecordingFromMicrophone();
         }
 
         #region Event Handlers

--- a/Observer/SpeakFasterObserver/FormMain.cs
+++ b/Observer/SpeakFasterObserver/FormMain.cs
@@ -28,6 +28,7 @@ namespace SpeakFasterObserver
 
         System.Threading.Timer uploadTimer = new(Timer_Tick);
         static System.Threading.Timer keyloggerTimer = new((state) => { SaveKeypresses(); });
+
         public FormMain()
         {
             InitializeComponent();

--- a/Observer/SpeakFasterObserver/FormMain.cs
+++ b/Observer/SpeakFasterObserver/FormMain.cs
@@ -207,21 +207,6 @@ namespace SpeakFasterObserver
                 lastKeypressString = keypressString;
 
                 keyloggerTimer.Change(60 * 1000, System.Threading.Timeout.Infinite);
-
-                //var key = Key.Enter;                    // Key to send
-                //var target = Keyboard.FocusedElement;    // Target element
-                //var routedEvent = Keyboard.KeyDownEvent; // Event to send
-                //var target = new HwndSource(0, 0, 0, 0, 0, "", IntPtr.Zero);
-                //target.RaiseEvent(
-                //     new System.Windows.Input.KeyEventArgs(
-                //       Keyboard.PrimaryDevice,
-                //       // PresentationSource.FromVisual(target),
-                //       // Keyboard.PrimaryDevice.ActiveSource,
-                //       target,
-                //       0,
-                //       key)
-                //     { RoutedEvent = routedEvent }
-                //   );
             }
         }
         #endregion

--- a/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
+++ b/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
@@ -46,5 +46,17 @@ namespace SpeakFasterObserver.Properties {
                 this["IsRecordingScreenshots"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool IsRecordingMicWaveIn {
+            get {
+                return ((bool)(this["IsRecordingMicWaveIn"]));
+            }
+            set {
+                this["IsRecordingMicWaveIn"] = value;
+            }
+        }
     }
 }

--- a/Observer/SpeakFasterObserver/Properties/Settings.settings
+++ b/Observer/SpeakFasterObserver/Properties/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="IsRecordingScreenshots" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="IsRecordingMicWaveIn" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
+++ b/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
@@ -47,9 +47,11 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.0.17" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.0.18" />
+    <PackageReference Include="FlacBox" Version="1.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
     <PackageReference Include="libjpeg-turbo-native-win" Version="2.0.15" />
     <PackageReference Include="libjpeg-turbo-net" Version="2.0.15" />
+    <PackageReference Include="NAudio" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -26,7 +26,7 @@ namespace SpeakFasterObserver
             }
 
             Debug.Assert(spo.Region != null);
-            _client = new AmazonS3Client(spo.GetAWSCredentials(sf), spo.Region);
+            //_client = new AmazonS3Client(spo.GetAWSCredentials(sf), spo.Region);
         }
 
         static bool _uploading = false;
@@ -36,7 +36,7 @@ namespace SpeakFasterObserver
             if (_uploading) return;
             _uploading = true;
 
-            Debug.Assert(_client != null);
+            //Debug.Assert(_client != null);
             Debug.Assert(_dataDirectory != null);
 
             var dataDirectory = new DirectoryInfo(_dataDirectory);
@@ -48,17 +48,17 @@ namespace SpeakFasterObserver
                     Key = $"observer_data/{_schemaVersion}/{Environment.MachineName}-{_gazeDevice ?? "none"}/{Environment.UserName}/{fileInfo.Name}"
                 };
 
-                PutObjectResponse putResponse;
-                using (var inputStream = fileInfo.OpenRead())
-                {
-                    putRequest.InputStream = inputStream;
-                    putResponse = await _client.PutObjectAsync(putRequest);
-                }
+                //PutObjectResponse putResponse;
+                //using (var inputStream = fileInfo.OpenRead())
+                //{
+                //    putRequest.InputStream = inputStream;
+                //    putResponse = await _client.PutObjectAsync(putRequest);
+                //}
 
-                if (putResponse.HttpStatusCode == HttpStatusCode.OK)
-                {
-                    fileInfo.Delete();
-                }
+                //if (putResponse.HttpStatusCode == HttpStatusCode.OK)
+                //{
+                //    fileInfo.Delete();
+                //}
             }
 
             _uploading = false;

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -40,8 +40,13 @@ namespace SpeakFasterObserver
             Debug.Assert(_dataDirectory != null);
 
             var dataDirectory = new DirectoryInfo(_dataDirectory);
-            foreach(var fileInfo in dataDirectory.GetFiles())
+            foreach (var fileInfo in dataDirectory.GetFiles())
             {
+                if (FileNaming.isInProgress(fileInfo.FullName))
+                {
+                    // Skip uploading in-progress file.
+                    continue;
+                }
                 var putRequest = new PutObjectRequest
                 {
                     BucketName = _bucketName,

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -26,7 +26,7 @@ namespace SpeakFasterObserver
             }
 
             Debug.Assert(spo.Region != null);
-            //_client = new AmazonS3Client(spo.GetAWSCredentials(sf), spo.Region);
+            _client = new AmazonS3Client(spo.GetAWSCredentials(sf), spo.Region);
         }
 
         static bool _uploading = false;
@@ -36,7 +36,7 @@ namespace SpeakFasterObserver
             if (_uploading) return;
             _uploading = true;
 
-            //Debug.Assert(_client != null);
+            Debug.Assert(_client != null);
             Debug.Assert(_dataDirectory != null);
 
             var dataDirectory = new DirectoryInfo(_dataDirectory);
@@ -48,17 +48,17 @@ namespace SpeakFasterObserver
                     Key = $"observer_data/{_schemaVersion}/{Environment.MachineName}-{_gazeDevice ?? "none"}/{Environment.UserName}/{fileInfo.Name}"
                 };
 
-                //PutObjectResponse putResponse;
-                //using (var inputStream = fileInfo.OpenRead())
-                //{
-                //    putRequest.InputStream = inputStream;
-                //    putResponse = await _client.PutObjectAsync(putRequest);
-                //}
+                PutObjectResponse putResponse;
+                using (var inputStream = fileInfo.OpenRead())
+                {
+                    putRequest.InputStream = inputStream;
+                    putResponse = await _client.PutObjectAsync(putRequest);
+                }
 
-                //if (putResponse.HttpStatusCode == HttpStatusCode.OK)
-                //{
-                //    fileInfo.Delete();
-                //}
+                if (putResponse.HttpStatusCode == HttpStatusCode.OK)
+                {
+                    fileInfo.Delete();
+                }
             }
 
             _uploading = false;


### PR DESCRIPTION
File format:
- The audio files are named in the pattern of `20210629T132215079-MicWaveIn.flac`, which is consistent with the keypresses protobuf files and the screenshot jpg files.
- The audio is sampled at 16000 Hz mono (single channel). 
- To save space, the [FLAC encoding](https://xiph.org/flac/) is used. The FLAC format is supported by services such as [Google Cloud speech-to-text](https://cloud.google.com/speech-to-text/docs/encoding)
- Each .flac file is approximately 1-minute long.

Other info:
- The added audio recording feature follows the existing on/off control based on system-tray icon clicks.

Added dependencies:
- NAudio for reading audio input from microphone
- FlacBox for FLAC encoding
