### PR TITLE
[Decoder] Add script for transcribing speech in audio

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/README.md
+++ b/Observer/SpeakFasterObserver Decoder/README.md
@@ -47,6 +47,23 @@ license and are obtained from the URLs such as:
 - https://search.creativecommons.org/photos/10590078-2f13-4caf-b96d-5d1db14eccd4
 - https://search.creativecommons.org/photos/832045ea-53f3-4a3d-9c35-9b51f9add43d
 
+## Automatic Speech Recognitino (ASR, Speech-to-text) on audio files
+
+The SpeakFaster Observer writes audio data to .flac files that are approximately
+60 second each in length. To transcribe a consecutive series of such .flac files,
+fine the path to the first .flac file in the series and feed it to the audio_asr.py
+script. Additionally, provide path to the  output .tsv file. For example:
+
+```sh
+python audio_asr.py data/20210710T095258428-MicWaveIn.flac /tmp/speech_transcript.tsv
+```
+
+The script automatically finds consecutive audio files in the same directory as the
+first audio file based on the length of each audio file and the timestamps in the
+file names.
+
+# TOOD(cais): Add instructions for Google Cloud credentials.
+
 ## Running unit tests in this folder
 
 Use:

--- a/Observer/SpeakFasterObserver Decoder/README.md
+++ b/Observer/SpeakFasterObserver Decoder/README.md
@@ -51,7 +51,7 @@ license and are obtained from the URLs such as:
 
 The SpeakFaster Observer writes audio data to .flac files that are approximately
 60 second each in length. To transcribe a consecutive series of such .flac files,
-fine the path to the first .flac file in the series and feed it to the audio_asr.py
+find the path to the first .flac file in the series and feed it to the audio_asr.py
 script. Additionally, provide path to the  output .tsv file. For example:
 
 ```sh

--- a/Observer/SpeakFasterObserver Decoder/audio_asr.py
+++ b/Observer/SpeakFasterObserver Decoder/audio_asr.py
@@ -10,6 +10,7 @@ import os
 import pathlib
 import struct
 
+from absl import logging
 import numpy as np
 import pydub
 from google.cloud import speech_v1p1beta1 as speech
@@ -108,7 +109,7 @@ def audio_data_generator(input_audio_paths, config):
       data = load_audio_data(file_path, config)
       yield speech.StreamingRecognizeRequest(audio_content=data)
     except pydub.exceptions.CouldntDecodeError:
-      pass  # TODO(cais): Log an error.
+      logging.warn("Failed to read audio data from file %s", file_path)
 
 
 def parse_args():
@@ -177,6 +178,8 @@ def transcribe_audio_to_tsv(input_audio_paths,
       # TODO(cais): The default transcript result doesn't include the start
       # time stamp, so we currently pretend that each recognizer output phrase
       # is exactly 1 second.
+      # TODO(cais): Should we use absolute timestamps such as epoch time, instead of
+      # time relative to the beginning of the first file?
       start_time_sec = end_time_sec - 1
       line = "%.3f\t%.3f\t%s\t%s" % (
           start_time_sec, end_time_sec, SPEECH_TRANSCRIPT_TIER_NAME, best_transcript)

--- a/Observer/SpeakFasterObserver Decoder/audio_asr.py
+++ b/Observer/SpeakFasterObserver Decoder/audio_asr.py
@@ -1,0 +1,197 @@
+"""Script for transcribing speech in input audio files."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import glob
+import io
+import os
+import pathlib
+import struct
+
+import numpy as np
+import pydub
+from google.cloud import speech_v1p1beta1 as speech
+
+import file_naming
+
+
+def get_audio_file_duration_sec(file_path):
+  """Get the duration of given audio file, in seconds."""
+  pure_path = pathlib.PurePath(file_path)
+  audio_seg = pydub.AudioSegment.from_file(pure_path, pure_path.suffix[1:])
+  return audio_seg.duration_seconds
+
+
+def get_consecutive_audio_file_paths(
+    first_audio_path, tolerance_seconds=1.0):
+  """Get the paths to the consecutive audio files.
+
+  It is assumed that the audio basename of the file path has the format:
+      yyyymmddThhmmssf-{DataStream}.{Extension}.
+
+  NOTE: It is assumed that there is no interleaving of more than one series
+      of audio files.
+  """
+  if not os.path.exists(first_audio_path):
+    raise ValueError("Nonexist audio file path: %s" % first_audio_path)
+  data_stream_name = file_naming.get_data_stream_name(first_audio_path)
+  ext = os.path.splitext(first_audio_path)[-1]
+  candidate_paths = sorted(glob.glob(os.path.join(
+      os.path.dirname(first_audio_path), "*-%s%s" % (data_stream_name, ext))))
+  candidate_paths = [
+      file for file in candidate_paths if file > first_audio_path]
+
+  output_paths = [first_audio_path]
+  total_duration_sec = 0.0
+  audio_path = first_audio_path
+  while candidate_paths:
+    timestamp = file_naming.parse_timestamp_from_filename(audio_path)
+    duration_sec = get_audio_file_duration_sec(audio_path)
+    total_duration_sec += duration_sec
+    next_timestamp = file_naming.parse_timestamp_from_filename(
+        candidate_paths[0])
+    time_diff = next_timestamp - timestamp
+    if np.abs(time_diff.total_seconds() - duration_sec) < tolerance_seconds:
+      output_paths.append(candidate_paths[0])
+      audio_path = candidate_paths[0]
+      del candidate_paths[0]
+    else:
+      break
+  return output_paths, total_duration_sec
+
+
+def load_audio_data(file_path, config):
+  """Load the audio data from given audio file.
+
+  Args:
+    file_path: Path to the audio file, as a str.
+    config: An instance of google.cloud.speech.RecognitionConfig, used to check
+        audio file specs including sample rate and channel count.
+
+  Returns:
+    The int16 (LINEAR16) binary buffer for all audio samples in the file.
+  """
+  pure_path = pathlib.PurePath(file_path)
+  audio_seg = pydub.AudioSegment.from_file(pure_path, pure_path.suffix[1:])
+  if audio_seg.frame_rate != config.sample_rate_hertz:
+    raise ValueError("Mismatch in sample rate: expected: %d; got: %d" % (
+        config.sample_rate_hertz, audio_seg.frame_rate))
+  if audio_seg.channels != config.audio_channel_count:
+    raise ValueError(
+        "Mismatch in audio channel count: expected: %d; got: %d" % (
+        config.audio_channel_count, audio_seg.channels))
+  samples = list(audio_seg.get_array_of_samples())
+  # NOTE(cais): We currently use LINEAR16 in the stream requests regardless of
+  # the original audio file format. Is it possible to avoid converting FLAC to
+  # LINEAR16 during these cloud requests?
+  return struct.pack('<%dh' % len(samples), *samples)
+
+
+def audio_data_generator(input_audio_paths, config):
+  """A generator for audio data of all files at the specified file path glob pattern.
+
+  Args:
+    input_audio_paths: Paths of input audio files.
+    config: An instance of google.cloud.speech.RecognitionConfig, used to check
+        audio file specs including sample rate and channel count.
+
+  Yields:
+    Instances of `google.cloud.speech.StreamingRecognizeRequest`. These instances
+        correspond to the order in `input_audio_paths`.
+  """
+  if not input_audio_paths:
+    raise ValueError("Empty paths")
+  for file_path in input_audio_paths:
+    try:
+      data = load_audio_data(file_path, config)
+      yield speech.StreamingRecognizeRequest(audio_content=data)
+    except pydub.exceptions.CouldntDecodeError:
+      pass  # TODO(cais): Log an error.
+
+
+def parse_args():
+  parser = argparse.ArgumentParser("Transcribe speech in audio input files")
+  parser.add_argument(
+      "first_audio_path",
+      type=str,
+      help="Path to the first audio file in the series. The series will be "
+      "automatically determined based on the timestamps.")
+  parser.add_argument(
+      "output_tsv_path",
+      type=str,
+      help="Path to the output .tsv file that contains the transcripts")
+  parser.add_argument(
+      "--sample_rate",
+      type=int,
+      default=16000,
+      help="The asserted sample rate of the input audio files (Hz).")
+  parser.add_argument(
+      "--language_code",
+      type=str,
+      default="en-US",
+      help="Language code used for speech transcription.")
+  return parser.parse_args()
+
+
+SPEECH_TRANSCRIPT_TIER_NAME = "SpeechTranscript"
+
+
+def transcribe_audio_to_tsv(input_audio_paths,
+                            output_tsv_path,
+                            sample_rate,
+                            language_code):
+  """Transcribe speech in input audio files and write results to .tsv file."""
+  client = speech.SpeechClient()
+  config = speech.RecognitionConfig(
+      encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+      sample_rate_hertz=sample_rate,
+      audio_channel_count=1,
+      language_code=language_code)
+  streaming_config = speech.StreamingRecognitionConfig(
+      config=config, interim_results=False)
+  requests = audio_data_generator(input_audio_paths, config)
+  responses = client.streaming_recognize(streaming_config, requests)
+
+  with open(output_tsv_path, "w") as f:
+    # Write the TSV header.
+    f.write("tBegin\ttEnd\tTier\tContent\n")
+
+    for response in responses:
+      if not response.results:
+        continue
+      results = [result for result in response.results if result.is_final]
+      max_confidence = -1
+      best_transcript = None
+      result_end_time = None
+      for result in results:
+        for alt in result.alternatives:
+          if alt.confidence > max_confidence:
+            max_confidence = alt.confidence
+            best_transcript = alt.transcript.strip()
+            result_end_time = result.result_end_time
+      if not best_transcript:
+        continue
+      end_time_sec = result_end_time.total_seconds()
+      # TODO(cais): The default transcript result doesn't include the start
+      # time stamp, so we currently pretend that each recognizer output phrase
+      # is exactly 1 second.
+      start_time_sec = end_time_sec - 1
+      line = "%.3f\t%.3f\t%s\t%s" % (
+          start_time_sec, end_time_sec, SPEECH_TRANSCRIPT_TIER_NAME, best_transcript)
+      print(line)
+      f.write(line + "\n")
+
+
+if __name__ == "__main__":
+  args = parse_args()
+  audio_file_paths, total_duration_sec = get_consecutive_audio_file_paths(
+      args.first_audio_path)
+  print("Transcribing %d consecutive audio files (%f seconds):\n\t%s" % (
+      len(audio_file_paths), total_duration_sec, "\n\t".join(audio_file_paths)))
+  transcribe_audio_to_tsv(
+      audio_file_paths,
+      args.output_tsv_path,
+      args.sample_rate,
+      args.language_code)

--- a/Observer/SpeakFasterObserver Decoder/audio_asr_test.py
+++ b/Observer/SpeakFasterObserver Decoder/audio_asr_test.py
@@ -1,0 +1,110 @@
+"""Unit tests for the audio_asr script."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+from google.cloud import speech_v1p1beta1 as speech
+import numpy as np
+from scipy.io import wavfile
+import tensorflow as tf
+
+import audio_asr
+
+
+class GetAudioFileDurationSecTest(tf.test.TestCase):
+
+  def testGetAudioFileDuration_returnsCorrectValueForWavFile(self):
+    wav_path = os.path.join(self.get_temp_dir(), "a1.wav")
+    wavfile.write(wav_path, 16000, np.zeros(24000))
+    self.assertAllClose(audio_asr.get_audio_file_duration_sec(wav_path), 1.5)
+
+
+class GetConsecutiveAudioFilePathsTest(tf.test.TestCase):
+
+  def testGetConsecutiveAudioFilePaths_findsCorrectPathsSkippingWrongOnes(self):
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T060000000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 1))  # This file should be ignored.
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T080000000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 10))  # This is the first file.
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T080010000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 5))
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T080015000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 1))
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T120000000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 1))
+
+    paths, total_duration_sec = audio_asr.get_consecutive_audio_file_paths(
+        os.path.join(self.get_temp_dir(), "20210710T080000000-MicWavIn.wav"))
+    self.assertEqual(paths, [
+        os.path.join(self.get_temp_dir(), "20210710T080000000-MicWavIn.wav"),
+        os.path.join(self.get_temp_dir(), "20210710T080010000-MicWavIn.wav"),
+        os.path.join(self.get_temp_dir(), "20210710T080015000-MicWavIn.wav")])
+    self.assertEqual(total_duration_sec, 10 + 5 + 1)
+
+  def testGetConsecutiveAudioFilePaths_findsASingleFile(self):
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T060000000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 1))  # This file should be ignored.
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T080000000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 10))  # This is the first file.
+    wavfile.write(
+        os.path.join(self.get_temp_dir(), "20210710T090000000-MicWavIn.wav"),
+        16000, np.zeros(16000 * 5))
+
+    paths, total_duration_sec = audio_asr.get_consecutive_audio_file_paths(
+        os.path.join(self.get_temp_dir(), "20210710T080000000-MicWavIn.wav"))
+    self.assertEqual(paths, [
+        os.path.join(self.get_temp_dir(), "20210710T080000000-MicWavIn.wav")])
+    self.assertEqual(total_duration_sec, 10)
+
+
+class LoadAudioDataTest(tf.test.TestCase):
+
+  def testLoadAudioData_succeeds(self):
+    audio_path = os.path.join(self.get_temp_dir(), "a1.wav")
+    wavfile.write(audio_path, 16000, np.zeros(16000 * 1, dtype=np.int16))
+    buffer = audio_asr.load_audio_data(audio_path, speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+        sample_rate_hertz=16000,
+        audio_channel_count=1,
+        language_code="en-US"))
+    self.assertLen(buffer, 16000 * 2)
+
+  def testLoadAudioData_incorrecSampleRate_raiseValueError(self):
+    audio_path = os.path.join(self.get_temp_dir(), "a1.wav")
+    wavfile.write(audio_path, 16000, np.zeros(16000 * 1, dtype=np.int16))
+    with self.assertRaises(ValueError):
+      audio_asr.load_audio_data(audio_path, speech.RecognitionConfig(
+          encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+          sample_rate_hertz=44100,
+          audio_channel_count=1,
+          language_code="en-US"))
+
+
+class AudioDataGeneratorTest(tf.test.TestCase):
+
+  def testTwoFiles(self):
+    audio_path_1 = os.path.join(self.get_temp_dir(), "a1.wav")
+    wavfile.write(audio_path_1, 16000, np.zeros(16000 * 1, dtype=np.int16))
+    audio_path_2 = os.path.join(self.get_temp_dir(), "a2.wav")
+    wavfile.write(audio_path_2, 16000, np.zeros(16000 * 1, dtype=np.int16))
+    audio_paths = [audio_path_1, audio_path_2]
+    config =  speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+        sample_rate_hertz=16000,
+        audio_channel_count=1,
+        language_code="en-US")
+    generator = audio_asr.audio_data_generator(audio_paths, config)
+    self.assertLen(list(generator), 2)
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/Observer/SpeakFasterObserver Decoder/file_naming.py
+++ b/Observer/SpeakFasterObserver Decoder/file_naming.py
@@ -1,0 +1,42 @@
+"""Module for timestamp related utilities."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from datetime import datetime
+import os
+
+
+def parse_timestamp(timestamp):
+  """Parse timestamp into a Python datetime.datetime object.
+
+  Args:
+    timestamp: Input timestamp string. Assumed to be in the
+        yyyymmddThhmmssf format.
+
+  Returns:
+    A datetime.datetime object.
+  """
+  return datetime.strptime(timestamp, "%Y%m%dT%H%M%S%f")
+
+
+def parse_timestamp_from_filename(filename):
+  """Parse timestamp from a SpeakFaster Observer data filename."""
+  filename = os.path.basename(filename)
+  return parse_timestamp(filename.split("-", 1)[0])
+
+
+def get_data_stream_name(filename):
+  """Get the data stream name.
+
+  Args:
+    filename: file path, the basename of which is assumed to have the
+        yyyymmddThhmmssf-{DataStream}.{Extension} format.
+
+  Returns:
+    The name of the data stream as a str.
+  """
+  basename = os.path.basename(filename)
+  if basename.count("-") != 1:
+    raise ValueError("Invalid file name format: %s" % basename)
+  return os.path.splitext(basename)[0].split("-")[-1]

--- a/Observer/SpeakFasterObserver Decoder/file_naming_test.py
+++ b/Observer/SpeakFasterObserver Decoder/file_naming_test.py
@@ -1,0 +1,88 @@
+"""Unit tests for the file_naming module."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import tensorflow as tf
+
+import file_naming
+
+
+class ParseTimestampTest(tf.test.TestCase):
+
+  def testParsesTimestamp_resultsCorrectResult_beforeNoon(self):
+    out = file_naming.parse_timestamp("20210710T095258428")
+    self.assertEqual(out.year, 2021)
+    self.assertEqual(out.month, 7)
+    self.assertEqual(out.day, 10)
+    self.assertEqual(out.hour, 9)
+    self.assertEqual(out.minute, 52)
+    self.assertEqual(out.second, 58)
+    self.assertEqual(out.microsecond, 428000)
+
+  def testParsesTimestamp_resultsCorrectResult_afterNoon(self):
+    out = file_naming.parse_timestamp("20210710T235258428")
+    self.assertEqual(out.year, 2021)
+    self.assertEqual(out.month, 7)
+    self.assertEqual(out.day, 10)
+    self.assertEqual(out.hour, 23)
+    self.assertEqual(out.minute, 52)
+    self.assertEqual(out.second, 58)
+    self.assertEqual(out.microsecond, 428000)
+
+  def testRaisesErrorForInvalidInputs(self):
+    with self.assertRaises(ValueError):
+      file_naming.parse_timestamp("20210710235258428")
+    with self.assertRaises(ValueError):
+      file_naming.parse_timestamp("20210710T23")
+    with self.assertRaises(ValueError):
+      file_naming.parse_timestamp("20210710T235258428-")
+
+class ParseTimestampFromFilenameTest(tf.test.TestCase):
+
+  def testParse_basenameOnly_returnsCorrectValue(self):
+    out = file_naming.parse_timestamp_from_filename(
+        "20210710T095258428-MicWaveIn.flac")
+    self.assertEqual(out.year, 2021)
+    self.assertEqual(out.month, 7)
+    self.assertEqual(out.day, 10)
+    self.assertEqual(out.hour, 9)
+    self.assertEqual(out.minute, 52)
+    self.assertEqual(out.second, 58)
+    self.assertEqual(out.microsecond, 428000)
+
+  def testParse_fullPath_returnsCorrectValue(self):
+    out = file_naming.parse_timestamp_from_filename(
+        os.path.join("tmp", "data", "20210710T095258428-MicWaveIn.flac"))
+    self.assertEqual(out.year, 2021)
+    self.assertEqual(out.month, 7)
+    self.assertEqual(out.day, 10)
+    self.assertEqual(out.hour, 9)
+    self.assertEqual(out.minute, 52)
+    self.assertEqual(out.second, 58)
+    self.assertEqual(out.microsecond, 428000)
+
+
+class GetDataStreamNameTest(tf.test.TestCase):
+
+  def testGetDataStreamName_basenameOnly_returnsCorrectName(self):
+    name = file_naming.get_data_stream_name("20210710T095258428-MicWaveIn.flac")
+    self.assertEqual(name, "MicWaveIn")
+
+  def testGetDataStreamName_dirnameAndBasename_returnsCorrectName(self):
+    name = file_naming.get_data_stream_name(
+        os.path.join("foo", "bar", "20210710T095258428-MicWaveIn.flac"))
+    self.assertEqual(name, "MicWaveIn")
+
+  def testGetDataStreamName_raisesErrorForInvalidFormat(self):
+    with self.assertRaisesRegex(ValueError, r"Invalid file name format"):
+      file_naming.get_data_stream_name("20210710T095258428.dat")
+    with self.assertRaisesRegex(ValueError, r"Invalid file name format"):
+      file_naming.get_data_stream_name(
+          os.path.join("foo", "20210710T095258428.dat"))
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/Observer/SpeakFasterObserver Decoder/requirements.txt
+++ b/Observer/SpeakFasterObserver Decoder/requirements.txt
@@ -5,6 +5,7 @@ black==21.5b1
 click==8.0.1
 colorama==0.4.4
 google==3.0.0
+google-cloud-speech==2.5.0
 importlib-metadata==4.0.1
 isort==5.8.0
 jsonpickle==2.0.0
@@ -19,6 +20,7 @@ pylint==2.8.2
 regex==2021.4.4
 setuptools==47.1.0
 numpy==1.19.5
+pydub==0.25.1
 scipy==1.6.3
 six==1.15.0
 tensorflow==2.5.0


### PR DESCRIPTION
by using Google Cloud Speech-to-Text service.
  - it works with a series of .wav or .flac files
  - it performs streaming recognition to avoid unnecessary file
    uploading
  - the results are written to a .tsv file with a format like in the
    the following example:

```
tBegin  tEnd    Tier    Content
11.830  12.830  SpeechTranscript        would you like to sit down
15.500  16.500  SpeechTranscript        no I'm fine standing up
19.170  20.170  SpeechTranscript        are you sure you don't want to sit down
```

- add supporting module file_naming to parse data file names, including
  timestamp and data stream name.
- add unit tests

Pair programming with @vsubhashini 
This PR is related to the offline analysis for #59 and #60