### PR TITLE
[Observer] Add code for online ASR & diarization

### DIFF
--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -26,7 +26,7 @@ namespace SpeakFasterObserver
         // see:
         // https://cloud.google.com/speech-to-text/docs/libraries#setting_up_authentication
         private AudioAsr audioAsr;
-        private readonly bool useAudioAsr = true;
+        private readonly bool useAudioAsr = false;
 
         public AudioInput(string dataDir) {
             this.dataDir = dataDir;

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -26,7 +26,7 @@ namespace SpeakFasterObserver
         // see:
         // https://cloud.google.com/speech-to-text/docs/libraries#setting_up_authentication
         private AudioAsr audioAsr;
-        private readonly bool useAudioAsr = false;
+        private readonly bool useAudioAsr = true;
 
         public AudioInput(string dataDir) {
             this.dataDir = dataDir;

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -19,7 +19,14 @@ namespace SpeakFasterObserver
         private int[] buffer = null;
         private volatile bool isRecording = false;
         private static readonly object flacLock = new object();
-        private SpeechAnalyzer speechAnalyzer;
+        // For speech recognition, diarization, and other real-time analyses 
+        // on the audio input stream. Currently it is disabled by default. To
+        // enable it, change useAudioAsr to true and make sure that the Google
+        // Cloud credentials for authentication are set properly. For details,
+        // see:
+        // https://cloud.google.com/speech-to-text/docs/libraries#setting_up_authentication
+        private AudioAsr audioAsr;
+        private readonly bool useAudioAsr = false;
 
         public AudioInput(string dataDir) {
             this.dataDir = dataDir;
@@ -41,7 +48,10 @@ namespace SpeakFasterObserver
             {
                 WaveFormat = waveFormat
             };
-            speechAnalyzer = new SpeechAnalyzer(waveFormat);
+            if (useAudioAsr)
+            {
+                audioAsr = new AudioAsr(waveFormat);
+            }
             if (waveIn.WaveFormat.BitsPerSample != AUDIO_BITS_PER_SAMPLE)
             {
                 // TODO(#64): Handle this exception add the app level.
@@ -86,9 +96,9 @@ namespace SpeakFasterObserver
                 MaybeCreateFlacWriter();
                 flacWriter.WriteSamples(buffer);
             }
-            if (speechAnalyzer != null)
+            if (audioAsr != null)
             {
-                speechAnalyzer.addSamples(e.Buffer, e.BytesRecorded);
+                audioAsr.AddSamples(e.Buffer, e.BytesRecorded);
             }
         }
 

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -19,6 +19,7 @@ namespace SpeakFasterObserver
         private int[] buffer = null;
         private volatile bool isRecording = false;
         private static readonly object flacLock = new object();
+        private SpeechAnalyzer speechAnalyzer;
 
         public AudioInput(string dataDir) {
             this.dataDir = dataDir;
@@ -35,10 +36,12 @@ namespace SpeakFasterObserver
             {
                 return;
             }
+            WaveFormat waveFormat = new(AUDIO_SAMPLE_RATE_HZ, AUDIO_NUM_CHANNELS);
             waveIn = new WaveIn
             {
-                WaveFormat = new WaveFormat(AUDIO_SAMPLE_RATE_HZ, AUDIO_NUM_CHANNELS)
+                WaveFormat = waveFormat
             };
+            speechAnalyzer = new SpeechAnalyzer(waveFormat);
             if (waveIn.WaveFormat.BitsPerSample != AUDIO_BITS_PER_SAMPLE)
             {
                 // TODO(#64): Handle this exception add the app level.
@@ -82,6 +85,10 @@ namespace SpeakFasterObserver
                 }
                 MaybeCreateFlacWriter();
                 flacWriter.WriteSamples(buffer);
+            }
+            if (speechAnalyzer != null)
+            {
+                speechAnalyzer.addSamples(e.Buffer, e.BytesRecorded);
             }
         }
 

--- a/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
+++ b/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.7.0.17" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.0.18" />
     <PackageReference Include="FlacBox" Version="1.0.1" />
+    <PackageReference Include="Google.Cloud.Speech.V1" Version="2.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
     <PackageReference Include="libjpeg-turbo-native-win" Version="2.0.15" />
     <PackageReference Include="libjpeg-turbo-net" Version="2.0.15" />

--- a/Observer/SpeakFasterObserver/SpeechAnalyzer.cs
+++ b/Observer/SpeakFasterObserver/SpeechAnalyzer.cs
@@ -36,17 +36,20 @@ namespace SpeakFasterObserver
         public void addSamples(byte[] samples, int numBytes)
         {
             recogBuffer.AddSamples(samples, 0, numBytes);
-            float bufferedSeconds = (float) recogBuffer.BufferedBytes / (audioFormat.BitsPerSample / 8) / audioFormat.SampleRate;
+            float bufferedSeconds = (float) recogBuffer.BufferedBytes / (
+                audioFormat.BitsPerSample / 8) / audioFormat.SampleRate;
             if (bufferedSeconds >= RECOG_PERIOD_SECONDS)
             {
-                byte[] frameBuffer = new byte[recogBuffer.BufferedBytes];
-                recogBuffer.Read(frameBuffer, 0, numBytes);
+                int bufferNumBytes = recogBuffer.BufferedBytes;
+                byte[] frameBuffer = new byte[bufferNumBytes];
+                recogBuffer.Read(frameBuffer, 0, bufferNumBytes);
                 Debug.WriteLine("Sending streaming recog request");  // DEBUG
                 try
                 {
                     recogStream.WriteAsync(new StreamingRecognizeRequest()
                     {
-                        AudioContent = Google.Protobuf.ByteString.CopyFrom(frameBuffer, 0, numBytes)
+                        AudioContent = Google.Protobuf.ByteString.CopyFrom(
+                            frameBuffer, 0, bufferNumBytes)
                     });
                 }
                 catch (Exception ex)

--- a/Observer/SpeakFasterObserver/SpeechAnalyzer.cs
+++ b/Observer/SpeakFasterObserver/SpeechAnalyzer.cs
@@ -1,0 +1,105 @@
+﻿using Google.Cloud.Speech.V1;
+using NAudio.Wave;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+/**
+ * For speech recognition, speaker diarization, and potentially other analyses on
+ * an audio input stream.
+ */
+namespace SpeakFasterObserver
+{
+    class SpeechAnalyzer
+    {
+        private static readonly float RECOG_PERIOD_SECONDS = 2f;
+        private static readonly float STREAMING_RECOG_MAX_DURATION_SECONDS = 4 * 60f;
+        private static readonly string LANGUAGE_CODE = "en-US";
+
+        private readonly WaveFormat audioFormat;
+        private readonly SpeechClient speechClient;
+        private SpeechClient.StreamingRecognizeStream recogStream;
+        private BufferedWaveProvider recogBuffer;
+        private float cummulativeRecogSeconds;
+
+        public SpeechAnalyzer(WaveFormat audioFormat)
+        {
+            this.audioFormat = audioFormat;
+            recogBuffer = new BufferedWaveProvider(audioFormat);
+            speechClient = SpeechClient.Create();
+            reInitStreamRecognizer();
+        }
+
+        public void addSamples(byte[] samples, int numBytes)
+        {
+            recogBuffer.AddSamples(samples, 0, numBytes);
+            float bufferedSeconds = (float) recogBuffer.BufferedBytes / (audioFormat.BitsPerSample / 8) / audioFormat.SampleRate;
+            if (bufferedSeconds >= RECOG_PERIOD_SECONDS)
+            {
+                byte[] frameBuffer = new byte[recogBuffer.BufferedBytes];
+                recogBuffer.Read(frameBuffer, 0, numBytes);
+                Debug.WriteLine("Sending streaming recog request");  // DEBUG
+                try
+                {
+                    recogStream.WriteAsync(new StreamingRecognizeRequest()
+                    {
+                        AudioContent = Google.Protobuf.ByteString.CopyFrom(frameBuffer, 0, numBytes)
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Streaming recog exception: {ex.Message}");
+                }
+
+                cummulativeRecogSeconds += bufferedSeconds;
+                recogBuffer.ClearBuffer();
+                if (cummulativeRecogSeconds > STREAMING_RECOG_MAX_DURATION_SECONDS)
+                {
+                    Debug.WriteLine("Reinitializing recognizer stream");  // DEBUG
+                    reInitStreamRecognizer();
+                }
+            }
+        }
+
+        /** (Re-)initializes the Cloud-based streaming speech recognizer. */
+        private void reInitStreamRecognizer()
+        {
+            recogStream = speechClient.StreamingRecognize();
+            Debug.WriteLine($"recogStream = {recogStream}");  // DEBUG
+            recogStream.WriteAsync(new StreamingRecognizeRequest()
+            {
+                StreamingConfig = new StreamingRecognitionConfig()
+                {
+                    Config = new RecognitionConfig()
+                    {
+                        Encoding = RecognitionConfig.Types.AudioEncoding.Linear16,
+                        AudioChannelCount = 1,
+                        SampleRateHertz = audioFormat.SampleRate,
+                        LanguageCode = LANGUAGE_CODE,
+                    },
+                    SingleUtterance = false,
+                },
+            });
+            Task.Run(async () =>
+            {
+                string saidWhat = "";
+                while (await recogStream.GetResponseStream().MoveNextAsync())
+                {
+                    foreach (var result in recogStream.GetResponseStream().Current.Results)
+                    {
+                        foreach (var alternative in result.Alternatives)
+                        {
+                            saidWhat = alternative.Transcript;
+                            string timestamp = DateTime.Now.ToString();
+                            Debug.WriteLine($"Speech transcript: {timestamp}: \"{saidWhat}\"");
+                        }
+                    }
+                }
+            });
+            cummulativeRecogSeconds = 0f;
+        }
+    }
+}


### PR DESCRIPTION
based on the Google Cloud Speech-to-text API.

The new module `AudioAsr` is disabled through a boolean by default. It can be enabled by setting the boolean flag to true
and setting the proper Google Cloud credentials (see doc strings in `AudioInput.cs` for details.

The `AudioAsr` modules supports ASR (transcript only) and diarization (tagging different speakers).