### PR TITLE
[Observer Decoder] Minor improvements

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/audio_asr.py
+++ b/Observer/SpeakFasterObserver Decoder/audio_asr.py
@@ -399,7 +399,7 @@ def transcribe_audio_to_tsv_with_diarization(input_audio_paths,
     regrouped_utterances = regroup_utterances(utterances, diarized_words)
     for (regrouped_utterance,
          speaker_index, start_time_sec, end_time_sec) in regrouped_utterances:
-      line = "%.3f\t%.3f\t%s\t%s (Speaker #%d)" % (
+      line = "%.3f\t%.3f\t%s\t%s [Speaker #%d]" % (
           start_time_sec + begin_sec,
           end_time_sec + begin_sec,
           tsv_data.SPEECH_TRANSCRIPT_TIER_NAME,
@@ -435,7 +435,7 @@ def async_transcribe(audio_file_paths,
   """
   tmp_audio_file = tempfile.mktemp(suffix=".flac")
   print("Temporary audio file: %s" % tmp_audio_file)
-  concatenate_audio_files(audio_file_paths, tmp_audio_file)
+  audio_duration_s = concatenate_audio_files(audio_file_paths, tmp_audio_file)
 
   storage_client = storage.Client()
   bucket = storage_client.bucket(bucket_name)
@@ -457,8 +457,12 @@ def async_transcribe(audio_file_paths,
       diarization_speaker_count=speaker_count)
 
   operation = client.long_running_recognize(config=config, audio=audio)
-  print("Waiting for async ASR operation to complete...")
-  response = operation.result(timeout=90)
+  timeout_s = int(audio_duration_s * 0.25)
+  print(
+      "Waiting for async ASR operation to complete "
+      "(audio duration: %.3f s; ASR timeout: %d s)..." %
+      (audio_duration_s, timeout_s))
+  response = operation.result(timeout=timeout_s)
   blob.delete()
   os.remove(tmp_audio_file)
 
@@ -480,7 +484,7 @@ def async_transcribe(audio_file_paths,
       f.write(tsv_data.HEADER + "\n")
     for (regrouped_utterance,
         speaker_index, start_time_sec, end_time_sec) in regrouped_utterances:
-      line = "%.3f\t%.3f\t%s\t%s (Speaker #%d)" % (
+      line = "%.3f\t%.3f\t%s\t%s [Speaker #%d]" % (
           start_time_sec + begin_sec,
           end_time_sec + begin_sec,
           tsv_data.SPEECH_TRANSCRIPT_TIER_NAME,

--- a/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
+++ b/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
@@ -101,6 +101,10 @@ def format_raw_data(input_dir,
 
 
 def read_and_concatenate_audio_files(input_dir, timezone):
+  if not glob.glob(os.path.join(input_dir, "*-MicWaveIn.flac")):
+    raise ValueError(
+        "Cannot find any *-MicWaveIn.flac audio files in directory %s. "
+        "Make sure you are pointing to a valid data directory." % input_dir)
   first_audio_path = sorted(
       glob.glob(os.path.join(input_dir, "*-MicWaveIn.flac")))[0]
   audio_start_time = file_naming.parse_timestamp_from_filename(first_audio_path)

--- a/Observer/SpeakFasterObserver Decoder/object_detection_test.py
+++ b/Observer/SpeakFasterObserver Decoder/object_detection_test.py
@@ -19,7 +19,7 @@ class ObjectDetectionTest(tf.test.TestCase):
     self.assertEqual(image_tensor.dtype, tf.uint8)
 
   def testReadImagesByGlobPattern(self):
-    generator = object_detection.read_images("testdata/*.jpg", frame_rate=4.0)
+    generator = object_detection.read_images("testdata/pic*.jpg", frame_rate=4.0)
     output = list(generator)
     self.assertLen(output, 3)
     for i in range(3):


### PR DESCRIPTION
- Use square brackets `[]` instead of parentheses `()` for speaker labels for consistency with the proposed
  data curation process.
- Avoid hardcoding GCloud Speech-to-text async timeout. Instead, calculate the timeout based on the audio duration
- Better error message for reading audio files
- Fix a broken test in object_detection_test.py

Towards #60