### PR TITLE
[Observer] Demonstrate how to use Azure Speaker ID in real time

### DIFF
--- a/Observer/SpeakFasterObserver/AudioAsr.cs
+++ b/Observer/SpeakFasterObserver/AudioAsr.cs
@@ -296,8 +296,10 @@ namespace SpeakFasterObserver
             if (speakerIdResponse.StatusCode != HttpStatusCode.OK)
             {
                 string errorString = await speakerIdResponse.Content.ReadAsStringAsync();
+                // TODO: throw error and catch the error in UI code to display an error
+                // message box.
                 Debug.WriteLine(
-                    $"Erorr: Speaker ID HTTP response contains error: {speakerIdResponse.StatusCode}: " +
+                    $"Erorr in Speaker ID HTTP response: {speakerIdResponse.StatusCode}: " +
                     $"{errorString}");
                 return;
             }

--- a/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
+++ b/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SpeakFasterObserver.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -56,6 +56,18 @@ namespace SpeakFasterObserver.Properties {
             }
             set {
                 this["IsRecordingMicWaveIn"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("speak_faster_speaker_id_config.json")]
+        public string SpeakerIdConfigPath {
+            get {
+                return ((string)(this["SpeakerIdConfigPath"]));
+            }
+            set {
+                this["SpeakerIdConfigPath"] = value;
             }
         }
     }

--- a/Observer/SpeakFasterObserver/Properties/Settings.settings
+++ b/Observer/SpeakFasterObserver/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="IsRecordingMicWaveIn" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="SpeakerIdConfigPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)">speak_faster_speaker_id_config.json</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
+++ b/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
@@ -53,7 +53,6 @@
     <PackageReference Include="libjpeg-turbo-native-win" Version="2.0.15" />
     <PackageReference Include="libjpeg-turbo-net" Version="2.0.15" />
     <PackageReference Include="NAudio" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Management" Version="5.0.0" />
     <PackageReference Include="Sleddog.Blink1" Version="2.0.3" />
   </ItemGroup>

--- a/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
+++ b/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
@@ -52,7 +52,6 @@
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
     <PackageReference Include="libjpeg-turbo-native-win" Version="2.0.15" />
     <PackageReference Include="libjpeg-turbo-net" Version="2.0.15" />
-    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.18.0" />
     <PackageReference Include="NAudio" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Management" Version="5.0.0" />

--- a/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
+++ b/Observer/SpeakFasterObserver/SpeakFasterObserver.csproj
@@ -52,7 +52,9 @@
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
     <PackageReference Include="libjpeg-turbo-native-win" Version="2.0.15" />
     <PackageReference Include="libjpeg-turbo-net" Version="2.0.15" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.18.0" />
     <PackageReference Include="NAudio" Version="2.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Management" Version="5.0.0" />
     <PackageReference Include="Sleddog.Blink1" Version="2.0.3" />
   </ItemGroup>


### PR DESCRIPTION
in conjunction with Google Cloud ASR and diarization to recognize known speakers.

The code assumes that speakers have been enrolled and that their profile IDs are stored in a .json file
pointed to by the `SPEAK_FASTER_SPEAKER_ID_CONFIG` environment variable.
The .json file should additionally contain the Azure speech subscription key and the Azure endpoint.

We are parking the code in Observer for now. But the code should be moved to Talk37 for context
extraction in the future.