### PR TITLE
Add capability to server static web content from Observer

### DIFF
--- a/Observer/SpeakFasterObserver/FormMain.cs
+++ b/Observer/SpeakFasterObserver/FormMain.cs
@@ -76,6 +76,10 @@ namespace SpeakFasterObserver
 
             Upload._dataDirectory = (dataPath);
             uploadTimer.Change(0, 60 * 1000);
+
+            // Start static content web server.
+            StaticWebServer server = new();
+            server.StartHttpServerIfStaticContentExists();
         }
 
         #region Event Handlers

--- a/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
+++ b/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
@@ -70,5 +70,29 @@ namespace SpeakFasterObserver.Properties {
                 this["SpeakerIdConfigPath"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("speakfaster-webui")]
+        public string WebUiStaticFilesDir {
+            get {
+                return ((string)(this["WebUiStaticFilesDir"]));
+            }
+            set {
+                this["WebUiStaticFilesDir"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("43737")]
+        public int WebUiPort {
+            get {
+                return ((int)(this["WebUiPort"]));
+            }
+            set {
+                this["WebUiPort"] = value;
+            }
+        }
     }
 }

--- a/Observer/SpeakFasterObserver/Properties/Settings.settings
+++ b/Observer/SpeakFasterObserver/Properties/Settings.settings
@@ -14,5 +14,11 @@
     <Setting Name="SpeakerIdConfigPath" Type="System.String" Scope="User">
       <Value Profile="(Default)">speak_faster_speaker_id_config.json</Value>
     </Setting>
+    <Setting Name="WebUiStaticFilesDir" Type="System.String" Scope="User">
+      <Value Profile="(Default)">speakfaster-webui</Value>
+    </Setting>
+    <Setting Name="WebUiPort" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">43737</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Observer/SpeakFasterObserver/StaticWebServer.cs
+++ b/Observer/SpeakFasterObserver/StaticWebServer.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+
+// A class to serve static web content (mainly to localhost) for serving
+// static webpages required for advanced text prediction features.
+// To grant the application access to the default HTTP listener port (e.g.,
+// 43737), run once as admin:
+// ```
+// netsh http add urlacl url=http://+:43737/ user=Everyone listen=yes
+// ```
+namespace SpeakFasterObserver
+{
+    class StaticWebServer
+    {
+        private readonly string staticContentDirPath;
+        private readonly string indexHtmlPath;
+        private HttpListener httpListener;
+
+        public StaticWebServer() { 
+           staticContentDirPath = Path.Join(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                Properties.Settings.Default.WebUiStaticFilesDir);
+           indexHtmlPath = Path.Join(staticContentDirPath, "index.html");
+        }
+
+        public void StartHttpServerIfStaticContentExists()
+        {
+            if (!File.Exists(indexHtmlPath))
+            {
+                // Static files directory does not exist. Do nothing.
+                return;
+            }
+            httpListener = new HttpListener();
+            string serverUrl = $"http://+:{Properties.Settings.Default.WebUiPort}/";
+            httpListener.Prefixes.Add(serverUrl);
+            httpListener.Start();
+
+            Task.Factory.StartNew(() =>
+            {
+                while (true)
+                {
+                    var context = httpListener.GetContext();
+                    Task.Factory.StartNew(() => ProcessRequest(context));
+                }
+            });
+        }
+
+        private void ProcessRequest(HttpListenerContext context)
+        {
+            if (context.Request.HttpMethod.ToUpper() != "GET")
+            {
+                context.Response.StatusDescription =
+                    $"Method not allowed {context.Request.HttpMethod}";
+                context.Response.StatusCode = 405;
+                context.Response.Close();
+                return;
+            }
+            string urlPath = context.Request.Url.AbsolutePath;
+            // Remove the leading "/".
+            urlPath = urlPath[1..];
+            if (urlPath == "")
+            {
+                urlPath = "index.html";
+            }
+            string[] urlPathParts = urlPath.Split("/");
+            string localPath = Path.Join(staticContentDirPath, Path.Join(urlPathParts));
+            if (!File.Exists(localPath))
+            {
+                context.Response.StatusDescription = "File not found";
+                context.Response.StatusCode = 404;
+                context.Response.Close();
+                return;
+            }
+            FileStream fileStream = File.Open(localPath, FileMode.Open);
+            context.Response.StatusDescription = "OK";
+            context.Response.StatusCode = 200;
+            context.Response.ContentLength64 = fileStream.Length;
+            context.Response.ContentType = GetContentTypeFromExtension(
+                new FileInfo(localPath).Extension);
+            fileStream.CopyTo(context.Response.OutputStream);
+            context.Response.Close();
+        }
+
+        private static string GetContentTypeFromExtension(string extension)
+        {
+            return extension switch
+            {
+                "html" => "text/html; charset=utf-8",
+                "css" => "text/html; charset=utf-8",
+                "js" => "text/javascript; charset=utf-8",
+                "png" => "image/png",
+                "jpg" => "image/jpeg",
+                _ => "",
+            };
+        }
+    }
+}


### PR DESCRIPTION
* As discussed offline, we need a way to serve static web
  content (e.g., an html page with some js and css files)
  for the prototype in the WebView of Talk37.
* Running a separate Python server would be a little awkward.
  Using the existing Observer application is a convenient
  solution.
* The newly created StaticWebServer.cs is a simple server that
  serves static content from a fixed local directory
  (${USER_HOME}/speakfaster-webui).

Fixes #90 