### PR TITLE
[Observer] Save data files into session subdirectories

### DIFF
--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -64,6 +64,12 @@ namespace SpeakFasterObserver
             isRecording = true;
         }
 
+        /** Sets the directory in which the audio data files will be stored. */
+        public void SetDataDirectory(string directoryPath)
+        {
+
+        }
+
         /**
          * Stops any ongoing recording from microphone.
          * 

--- a/Observer/SpeakFasterObserver/AudioInput.cs
+++ b/Observer/SpeakFasterObserver/AudioInput.cs
@@ -64,12 +64,6 @@ namespace SpeakFasterObserver
             isRecording = true;
         }
 
-        /** Sets the directory in which the audio data files will be stored. */
-        public void SetDataDirectory(string directoryPath)
-        {
-
-        }
-
         /**
          * Stops any ongoing recording from microphone.
          * 

--- a/Observer/SpeakFasterObserver/FileNaming.cs
+++ b/Observer/SpeakFasterObserver/FileNaming.cs
@@ -13,8 +13,7 @@ namespace SpeakFasterObserver
         private const string IN_PROGRESS_SUFFIX = ".InProgress";
         private const string SESSION_END_TOKEN_SUFFIX = "-SessionEnd.bin";
         private const string SESSION_DIR_PREFIX = "session-";
-        // TODO(cais): Change to 10. DO NOT SUBMIT.
-        private const double SESSION_DIR_DEBOUNCE_TIMESPAN_MINUTES = 2.0;
+        private const double SESSION_DIR_DEBOUNCE_TIMESPAN_MINUTES = 10.0;
         private static readonly object SESSION_LOCK = new object();
 
         private static string _cmfCache;

--- a/Observer/SpeakFasterObserver/FileNaming.cs
+++ b/Observer/SpeakFasterObserver/FileNaming.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Globalization;
 using System.Management;
 using System.Security.Cryptography;
 using System.Text;
@@ -9,6 +10,9 @@ namespace SpeakFasterObserver
     class FileNaming
     {
         private const string IN_PROGRESS_SUFFIX = ".InProgress";
+        private const string SESSION_DIR_PREFIX = "session-";
+        // TODO(cais): Maybe change to 10.0 minutes.
+        private const double SESSION_DIR_DEBOUNCE_TIMESPAN_MINUTES = 1.0;
 
         private static string _cmfCache;
         public static string ComputerManufacturerFamily
@@ -44,31 +48,41 @@ namespace SpeakFasterObserver
             return $"{DateTime.Now:yyyyMMddTHHmmssfff}";
         }
 
+        public static string GetTimestampUtc()
+        {
+            return $"{DateTime.UtcNow:yyyyMMddTHHmmssfffZ}";
+        }
+
         public static string GetMicWavInFilePath(string dataDir)
         {
-            return Path.Combine(dataDir, $"{GetTimestamp()}-MicWaveIn.flac");
+            string dirName = GetCurrentSessionDirectory(dataDir);
+            return Path.Combine(dirName, $"{GetTimestamp()}-MicWaveIn.flac");
         }
 
         public static string GetScreenshotFilePath(string dataDir, string timestamp = null)
         {
             string actualTimestamp = timestamp ?? GetTimestamp();
-            return Path.Combine(dataDir, $"{actualTimestamp}-Screenshot.jpg");
+            string dirName = GetCurrentSessionDirectory(dataDir);
+            return Path.Combine(dirName, $"{actualTimestamp}-Screenshot.jpg");
         }
 
         public static string GetSpeechScreenshotFilePath(string dataDir, string timestamp = null)
         {
             string actualTimestamp = timestamp ?? GetTimestamp();
-            return Path.Combine(dataDir, $"{actualTimestamp}-SpeechScreenshot.jpg");
+            string dirName = GetCurrentSessionDirectory(dataDir);
+            return Path.Combine(dirName, $"{actualTimestamp}-SpeechScreenshot.jpg");
         }
 
         public static string GetKeypressesProtobufFilePath(string dataDir)
         {
-            return Path.Combine(dataDir, $"{GetTimestamp()}-Keypresses.protobuf");
+            string dirName = GetCurrentSessionDirectory(dataDir);
+            return Path.Combine(dirName, $"{GetTimestamp()}-Keypresses.protobuf");
         }
 
-        public static string CloudStoragePath(FileInfo fileInfo, string gazeDevice, string salt)
+        public static string CloudStoragePath(string[] relativePathParts, string gazeDevice, string salt)
         {
-            return $"{ComputerManufacturerFamily}/{gazeDevice}/{CreateUserIdHash(salt)}/{fileInfo.Name}".Replace(' ', '_');
+            string relativePath = String.Join("/", relativePathParts);
+            return $"{ComputerManufacturerFamily}/{gazeDevice}/{CreateUserIdHash(salt)}/{relativePath}".Replace(' ', '_');
         }
 
         public static bool IsInProgress(String filePath)
@@ -92,6 +106,42 @@ namespace SpeakFasterObserver
                 return filePath.Substring(0, filePath.Length - IN_PROGRESS_SUFFIX.Length);
             }
             return filePath;
+        }
+
+        private static string sessionDirectoryName = $"{SESSION_DIR_PREFIX}{GetTimestampUtc()}";
+
+        /**
+         * Gets the current session directory. 
+         * 
+         * Creates the session directory if it doesn't already exist.
+         * 
+         * Args:
+         *   dataDir: Root directory under which the session directory will reside.
+         */
+        private static string GetCurrentSessionDirectory(string dataDir)
+        {
+            string sessionDirectory = Path.Combine(dataDir, sessionDirectoryName);
+            // Create the directory if and only if it doesn't exist yet.
+            Directory.CreateDirectory(sessionDirectory);
+            return sessionDirectory;
+        }
+
+        public static void RotateSessionDirectory(bool debounce = false)
+        {
+            if (debounce)
+            {
+                string timestamp = sessionDirectoryName.Substring(SESSION_DIR_PREFIX.Length);
+                DateTime prevDateTime;
+                DateTime.TryParseExact(
+                    timestamp, "yyyyMMddTHHmmssfffZ", CultureInfo.CurrentCulture, DateTimeStyles.None,
+                    out prevDateTime);
+                var elapsed = DateTime.UtcNow.Subtract(prevDateTime);
+                if (elapsed.CompareTo(TimeSpan.FromMinutes(SESSION_DIR_DEBOUNCE_TIMESPAN_MINUTES)) < 0)
+                {
+                    return;
+                }
+            }
+            sessionDirectoryName = $"session-{GetTimestampUtc()}";
         }
     }
 }

--- a/Observer/SpeakFasterObserver/FormMain.cs
+++ b/Observer/SpeakFasterObserver/FormMain.cs
@@ -75,7 +75,9 @@ namespace SpeakFasterObserver
             keylogger = new Keylogger(KeyboardHookHandler);
 
             Upload._dataDirectory = (dataPath);
-            uploadTimer.Change(0, 60 * 1000);
+            //uploadTimer.Change(0, 60 * 1000);
+            // TODO(cais): Restore. DO NOT SUBMIT.
+            uploadTimer.Change(0, 10 * 1000);
         }
 
         #region Event Handlers
@@ -205,6 +207,8 @@ namespace SpeakFasterObserver
 
                 lastKeypressString = keypressString;
 
+                //keyloggerTimer.Change(10 * 1000, System.Threading.Timeout.Infinite);
+                // TODO(cais): Restore. DO NOT SUBMIT.
                 keyloggerTimer.Change(60 * 1000, System.Threading.Timeout.Infinite);
             }
         }
@@ -220,6 +224,9 @@ namespace SpeakFasterObserver
                                                     //&& tobiiComputerControlRunning      //  AND Tobii Computer Control
                 )
             {
+                FileNaming.RotateSessionDirectory(debounce: true);
+                // TODO(cais): Call it somewhere else. 
+                Debug.WriteLine("New session folder:.. ");  // DEBUG
                 // TODO: Optimize raw capture data to best time synchronize the captures
                 //   e.g. capture raw data to memory first, and compress/serialize/store later
 
@@ -253,6 +260,7 @@ namespace SpeakFasterObserver
                 {
                     blink1.Blink(Color.Red, new TimeSpan(0, 0, 5), 10);
                 }
+                FileNaming.RotateSessionDirectory(debounce: false);
             }
             else
             {

--- a/Observer/SpeakFasterObserver/SessionManager.cs
+++ b/Observer/SpeakFasterObserver/SessionManager.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SpeakFasterObserver
+{
+    /** A class that manageds the start and end of data sessions. */
+    class SessionManager
+    {
+        // The window before the beginning of a session to keep data for.
+        private const int SESSION_LEAD_TIME_SECONDS = 5 * 60;
+        private const int SESSION_FADE_TIME_SECONDS = 5 * 60;
+
+        private static readonly object SESSION_LOCK = new object();
+
+        private readonly TimeSpan sessionLeadTime = TimeSpan.FromSeconds(SESSION_LEAD_TIME_SECONDS);
+        private readonly TimeSpan sessionFadeTime = TimeSpan.FromSeconds(SESSION_FADE_TIME_SECONDS);
+        private readonly string dataRoot;
+        private readonly string bufferDirName;
+        private string sessionDirName = null;
+        private DateTime sessionStart;
+        private DateTime lastFocus;
+        
+        public SessionManager(string dataRoot) {
+            this.dataRoot = dataRoot;
+            bufferDirName = FileNaming.GetBufferDirPath(dataRoot);
+        }
+
+        /**
+         * Updates the boolean flag for whether the an app of interested is in focus.
+         * 
+         * The caller should call this method on a periodic basis. 
+         * 
+         * This method automatically updates the session state based on the focus flag:
+         * - If inFocus flips from false to true when there is no ongoing
+         *   session, a new session will be started.
+         * - If inFocus stays at false for longer than SESSION_FADE_TIME_SECONDS,
+         *   and there is an ongoing session, the current session will be ended.
+         *
+         * Args:
+         *   inFocus: Whether the app is currently in the "in focus" state, i.e., in a 
+         *     state where the user is in a text editor / TTS app, ready to enter keystrokes
+         *     for communication.
+         *   sessionEndAction: Actions performed at the end of a session.
+         *   sessionStartAction: Actions performed at the beginning of a new session.
+         */
+        public void SetFocusFlag(bool inFocus, Action sessionEndAction, Action sessionStartAction)
+        {
+            if (sessionDirName == null)
+            {
+                // No session is ongoing.
+                if (inFocus)
+                {
+                    sessionEndAction.Invoke();
+                    CreateNewSession();
+                    sessionStartAction.Invoke();
+                    lastFocus = DateTime.UtcNow;
+                }
+            }
+            else
+            {
+                // A session is ongoing.
+                if (inFocus)
+                {
+                    lastFocus = DateTime.UtcNow;
+                }
+                else
+                {
+                    if (DateTime.UtcNow.Subtract(lastFocus).CompareTo(sessionFadeTime) > 0)
+                    {
+                        sessionEndAction.Invoke();
+                        EndCurrentSession();
+                    }
+                }
+            }
+        }
+
+        public string GetMicWavInFilePath()
+        {
+            return FileNaming.GetMicWavInFilePath(GetTargetDirName());
+        }
+
+        public string GetScreenshotFilePath()
+        {
+            return FileNaming.GetScreenshotFilePath(GetTargetDirName());
+        }
+
+        public string GetSpeechScreenshotFilePath()
+        {
+            return FileNaming.GetSpeechScreenshotFilePath(GetTargetDirName());
+        }
+
+        public string GetKeypressesProtobufFilePath()
+        {
+            return FileNaming.GetKeypressesProtobufFilePath(GetTargetDirName());
+        }
+
+        private string GetTargetDirName()
+        {
+            lock (SESSION_LOCK)
+            {
+                if (sessionDirName == null)
+                {
+                    // Creates the buffer directory if and only if it doesn't exist.
+                    Directory.CreateDirectory(bufferDirName);
+                    return bufferDirName;
+                }
+                else
+                {
+                    return sessionDirName;
+                }
+            }
+        }
+
+        private void CreateNewSession()
+        {
+            EndCurrentSession();
+            lock (SESSION_LOCK)
+            {
+                sessionDirName = FileNaming.GetNewSessionDirPath(dataRoot);
+                Directory.CreateDirectory(sessionDirName);
+                sessionStart = DateTime.UtcNow;
+                FlushBufferDir();
+                Debug.WriteLine($"Created new session directory: {sessionDirName}");
+            }
+        }
+
+        public void EndCurrentSession()
+        {
+            lock (SESSION_LOCK)
+            {
+                if (sessionDirName == null)
+                {
+                    // There is no ongoing session.
+                    return;
+                }
+                // Put a session end token in the old session directory to indicate its end.
+                Debug.WriteLine($"Ending session in {sessionDirName}");
+                string sessionEndToken = FileNaming.GetSessionEndTokenFilePath(sessionDirName);
+                if (!File.Exists(sessionEndToken))
+                {
+                    File.Create(sessionEndToken).Dispose();
+                }
+                sessionDirName = null;
+            }
+        }
+
+        
+        /**
+         * Moves the data files in the buffer directory within the lead-time window to the current session directory.
+         * Deletes all other files in the buffer directory.
+         */
+        private void FlushBufferDir()
+        {
+            // Creates the buffer directory if and only if it doesn't exist.
+            Directory.CreateDirectory(bufferDirName);
+            List<string> filePathsToRemove = new();
+            foreach (var filePath in Directory.GetFiles(bufferDirName))
+            {
+                if (FileNaming.IsInProgress(filePath))
+                {
+                    continue;
+                }
+                DateTime fileDateTime = FileNaming.ParseDateTimeFromFileName(filePath);
+                if (sessionDirName != null && sessionStart.Subtract(fileDateTime).CompareTo(sessionLeadTime) < 0)
+                {
+                    // Within the lead-time window: Copy the file to the current session directory.
+                    string destPath = Path.Combine(sessionDirName, Path.GetFileName(filePath));
+                    File.Move(filePath, destPath);
+                    Debug.WriteLine($"Moved buffered file in lead window from {filePath} to {sessionDirName}");
+                }
+                else
+                {
+                    // Outside the lead-time window: Remove the file.
+                    filePathsToRemove.Add(filePath);                    
+                }
+            }
+            Task.Run(() =>
+            {
+                foreach (string filePath in filePathsToRemove)
+                {
+                    if (File.Exists(filePath))
+                    {
+                        File.Delete(filePath);
+                        Debug.WriteLine($"Deleted buffered file outside lead window {filePath}");
+                    }
+                }
+            });
+        }
+    }
+}

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -12,8 +12,7 @@ namespace SpeakFasterObserver
     internal class Upload
     {
         private const string SCHEMA_VERSION = "SPO-2105";
-        // TODO(cais): Restore. DO NOT SUBMIT.
-        private const string BUCKET_NAME = "speak-faster-cais-test";  
+        private const string BUCKET_NAME = "speak-faster";  
 
         private static readonly AmazonS3Client _client;
 
@@ -69,8 +68,7 @@ namespace SpeakFasterObserver
 
             Debug.Assert(_client != null);
             Debug.Assert(_dataDirectory != null);
-            // TODO(cais): Restore. DO NOT SUBMIT.
-            //Debug.Assert(_gazeDevice != null);
+            Debug.Assert(_gazeDevice != null);
 
             if (_salt == null)
             {
@@ -93,9 +91,7 @@ namespace SpeakFasterObserver
                 var putRequest = new PutObjectRequest
                 {
                     BucketName = BUCKET_NAME,
-                    Key = $"observer_data/{SCHEMA_VERSION}/{FileNaming.CloudStoragePath(relativePathParts, "foo_gaze_device", _salt)}"
-                    // TODO(cais): Restore. DO NOT SUBMIT.
-                    //Key = $"observer_data/{SCHEMA_VERSION}/{FileNaming.CloudStoragePath(fileInfo, _gazeDevice, _salt)}"
+                    Key = $"observer_data/{SCHEMA_VERSION}/{FileNaming.CloudStoragePath(relativePathParts, _gazeDevice, _salt)}"
                 };
 
                 PutObjectResponse putResponse;
@@ -118,7 +114,6 @@ namespace SpeakFasterObserver
                         }
                         Debug.WriteLine($"Deleted directory of ended session: {sessionDir}");
                     }
-                    Debug.WriteLine("Uploaded " + fileInfo.FullName);  // DEBUG
                 }
             }
 

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -12,7 +12,8 @@ namespace SpeakFasterObserver
     internal class Upload
     {
         private const string SCHEMA_VERSION = "SPO-2105";
-        private const string BUCKET_NAME = "speak-faster";
+        // TODO(cais): Restore. DO NOT SUBMIT.
+        private const string BUCKET_NAME = "speak-faster-cais-test";  
 
         private static readonly AmazonS3Client _client;
 
@@ -68,7 +69,8 @@ namespace SpeakFasterObserver
 
             Debug.Assert(_client != null);
             Debug.Assert(_dataDirectory != null);
-            Debug.Assert(_gazeDevice != null);
+            // TODO(cais): Restore. DO NOT SUBMIT.
+            //Debug.Assert(_gazeDevice != null);
 
             if (_salt == null)
             {
@@ -79,18 +81,22 @@ namespace SpeakFasterObserver
             }
 
             var dataDirectory = new DirectoryInfo(_dataDirectory);
-            foreach (var fileInfo in dataDirectory.GetFiles())
+            foreach (string filePath in Directory.EnumerateFiles(_dataDirectory, "*", SearchOption.AllDirectories))
             {
+                FileInfo fileInfo = new(filePath);
                 if (FileNaming.IsInProgress(fileInfo.FullName))
                 {
                     // Skip uploading in-progress file.
                     continue;
                 }
 
+                string[] relativePathParts = Path.GetRelativePath(_dataDirectory, filePath).Split(Path.DirectorySeparatorChar);
                 var putRequest = new PutObjectRequest
                 {
                     BucketName = BUCKET_NAME,
-                    Key = $"observer_data/{SCHEMA_VERSION}/{FileNaming.CloudStoragePath(fileInfo, _gazeDevice, _salt)}"
+                    Key = $"observer_data/{SCHEMA_VERSION}/{FileNaming.CloudStoragePath(relativePathParts, "foo_gaze_device", _salt)}"
+                    // TODO(cais): Restore. DO NOT SUBMIT.
+                    //Key = $"observer_data/{SCHEMA_VERSION}/{FileNaming.CloudStoragePath(fileInfo, _gazeDevice, _salt)}"
                 };
 
                 PutObjectResponse putResponse;
@@ -103,6 +109,8 @@ namespace SpeakFasterObserver
                 if (putResponse.HttpStatusCode == HttpStatusCode.OK)
                 {
                     fileInfo.Delete();
+                    // TODO(cais): Delete the file's parent directory if there is nothing left in it?
+                    Debug.WriteLine("Uploaded " + fileInfo.FullName);  // DEBUG
                 }
             }
 

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -86,6 +86,11 @@ namespace SpeakFasterObserver
                     // Skip uploading in-progress file.
                     continue;
                 }
+                if (FileNaming.IsNonSessionBufferFile(fileInfo.FullName))
+                {
+                    // Skip non-session buffer files.
+                    continue;
+                }
 
                 string[] relativePathParts = Path.GetRelativePath(_dataDirectory, filePath).Split(Path.DirectorySeparatorChar);
                 var putRequest = new PutObjectRequest

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -12,7 +12,7 @@ namespace SpeakFasterObserver
     internal class Upload
     {
         private const string SCHEMA_VERSION = "SPO-2105";
-        private const string BUCKET_NAME = "speak-faster";  
+        private const string BUCKET_NAME = "speak-faster";
 
         private static readonly AmazonS3Client _client;
 


### PR DESCRIPTION
Motivation: 
- Divide the data into manageable chunks that are the sessions

General idea:
- As proposed in the discussion thread of #79, use the user event of focusing on the text editor as the candidates for the implicit session boundaries. 
- To accommodate the previous context before the focus onto the text editor, we use a rolling buffer and a leading time window of 5 minutes. Any recordings that happen within 5 minutes of the focusing event will be included in the session. 
  - Created the new class SessionManager.cs to house the logic.
- The session subdirectories have the naming convention `session-${timestamp_in_utc}`, e.g., `"session-20211014T190724113Z"`.

Also in this change:
- Add an explicit session end token named `${timestamp}-SessionEnd.bin` in the session subdir when a session has ended.
- Unify all timestamps onto UTC, including the session directories and the individual files

Fixes #76 
Fixes #79 