### PR TITLE
[Observer Decoder] Accommodate UTC timestamps

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/audio_asr.py
+++ b/Observer/SpeakFasterObserver Decoder/audio_asr.py
@@ -88,11 +88,11 @@ def get_consecutive_audio_file_paths(
   total_duration_sec = 0.0
   audio_path = first_audio_path
   while candidate_paths:
-    timestamp = file_naming.parse_timestamp_from_filename(audio_path)
+    timestamp, _ = file_naming.parse_timestamp_from_filename(audio_path)
     duration_sec = get_audio_file_duration_sec(audio_path)
     durations_sec.append(duration_sec)
     total_duration_sec += duration_sec
-    next_timestamp = file_naming.parse_timestamp_from_filename(
+    next_timestamp, _ = file_naming.parse_timestamp_from_filename(
         candidate_paths[0])
     time_diff = next_timestamp - timestamp
     if np.abs(time_diff.total_seconds() - duration_sec) < tolerance_seconds:

--- a/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
+++ b/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
@@ -113,12 +113,10 @@ def read_and_concatenate_audio_files(input_dir, timezone):
         "Make sure you are pointing to a valid data directory." % input_dir)
   first_audio_path = sorted(
       glob.glob(os.path.join(input_dir, "*-MicWaveIn.flac")))[0]
-  audio_start_time = file_naming.parse_timestamp_from_filename(first_audio_path)
-  tz = pytz.timezone(timezone)
-  audio_start_time = tz.localize(audio_start_time)
-  audio_start_time_epoch = audio_start_time.timestamp()
-  print("Audio data start time: %s (%.3f)" % (
-      audio_start_time, audio_start_time_epoch))
+  audio_start_time, audio_start_time_epoch = get_epoch_time_from_file_path(
+      first_audio_path, timezone)
+  print("Audio data start time: %s (%s)" %
+        (audio_start_time, audio_start_time_epoch))
   path_groups, group_durations_sec = audio_asr.get_consecutive_audio_file_paths(
       first_audio_path)
   all_audio_paths = []
@@ -132,6 +130,17 @@ def read_and_concatenate_audio_files(input_dir, timezone):
       concatenated_audio_path, audio_duration_s))
   return (first_audio_path,
           concatenated_audio_path, audio_start_time_epoch, audio_duration_s)
+
+
+def get_epoch_time_from_file_path(file_path, timezone):
+  (audio_start_time,
+   is_utc) = file_naming.parse_timestamp_from_filename(file_path)
+  if is_utc:
+    tz = pytz.timezone("UTC")
+  else:
+    tz = pytz.timezone(timezone)
+  dt = tz.localize(audio_start_time)
+  return dt, dt.timestamp()
 
 
 DUMMY_KEYPRESS_DURATION_SEC = 0.1

--- a/Observer/SpeakFasterObserver Decoder/file_naming.py
+++ b/Observer/SpeakFasterObserver Decoder/file_naming.py
@@ -18,20 +18,30 @@ def parse_timestamp(timestamp):
 
   Returns:
     A datetime.datetime object.
+    A boolean indicating whether the timestamp is in UTC.
   """
-  return datetime.strptime(timestamp, "%Y%m%dT%H%M%S%f")
+  is_utc = timestamp.endswith("Z")
+  if is_utc:
+    timestamp = timestamp[:-1]
+  return datetime.strptime(timestamp, "%Y%m%dT%H%M%S%f"), is_utc
 
 
 def parse_timestamp_from_filename(filename):
   """Parse timestamp from a SpeakFaster Observer data filename."""
   filename = os.path.basename(filename)
-  return parse_timestamp(filename.split("-", 1)[0])
+  timestamp = filename.split("-", 1)[0]
+  return parse_timestamp(timestamp)
 
 
 def parse_epoch_seconds_from_filename(filename, timezone):
   """Parse epoch timestamp (in seconds) from filename and timezone name."""
-  tz = pytz.timezone(timezone)
-  return tz.localize(parse_timestamp_from_filename(filename)).timestamp()
+  dt, is_utc = parse_timestamp_from_filename(filename)
+  if is_utc:
+    tz = pytz.timezone("UTC")
+  else:
+    tz = pytz.timezone(timezone)
+  return tz.localize(dt).timestamp()
+
 
 def get_data_stream_name(filename):
   """Get the data stream name.

--- a/Observer/SpeakFasterObserver Decoder/file_naming_test.py
+++ b/Observer/SpeakFasterObserver Decoder/file_naming_test.py
@@ -13,7 +13,8 @@ import file_naming
 class ParseTimestampTest(tf.test.TestCase):
 
   def testParsesTimestamp_resultsCorrectResult_beforeNoon(self):
-    out = file_naming.parse_timestamp("20210710T095258428")
+    out, is_utc = file_naming.parse_timestamp("20210710T095258428")
+    self.assertFalse(is_utc)
     self.assertEqual(out.year, 2021)
     self.assertEqual(out.month, 7)
     self.assertEqual(out.day, 10)
@@ -23,11 +24,23 @@ class ParseTimestampTest(tf.test.TestCase):
     self.assertEqual(out.microsecond, 428000)
 
   def testParsesTimestamp_resultsCorrectResult_afterNoon(self):
-    out = file_naming.parse_timestamp("20210710T235258428")
+    out, is_utc = file_naming.parse_timestamp("20210710T235258428")
+    self.assertFalse(is_utc)
     self.assertEqual(out.year, 2021)
     self.assertEqual(out.month, 7)
     self.assertEqual(out.day, 10)
     self.assertEqual(out.hour, 23)
+    self.assertEqual(out.minute, 52)
+    self.assertEqual(out.second, 58)
+    self.assertEqual(out.microsecond, 428000)
+
+  def testParseTimestamp_utc(self):
+    out, is_utc = file_naming.parse_timestamp("20210710T095258428Z")
+    self.assertTrue(is_utc)
+    self.assertEqual(out.year, 2021)
+    self.assertEqual(out.month, 7)
+    self.assertEqual(out.day, 10)
+    self.assertEqual(out.hour, 9)
     self.assertEqual(out.minute, 52)
     self.assertEqual(out.second, 58)
     self.assertEqual(out.microsecond, 428000)
@@ -43,8 +56,9 @@ class ParseTimestampTest(tf.test.TestCase):
 class ParseTimestampFromFilenameTest(tf.test.TestCase):
 
   def testParse_basenameOnly_returnsCorrectValue(self):
-    out = file_naming.parse_timestamp_from_filename(
+    out, is_utc = file_naming.parse_timestamp_from_filename(
         "20210710T095258428-MicWaveIn.flac")
+    self.assertFalse(is_utc)
     self.assertEqual(out.year, 2021)
     self.assertEqual(out.month, 7)
     self.assertEqual(out.day, 10)
@@ -54,8 +68,9 @@ class ParseTimestampFromFilenameTest(tf.test.TestCase):
     self.assertEqual(out.microsecond, 428000)
 
   def testParse_fullPath_returnsCorrectValue(self):
-    out = file_naming.parse_timestamp_from_filename(
-        os.path.join("tmp", "data", "20210710T095258428-MicWaveIn.flac"))
+    out, is_utc = file_naming.parse_timestamp_from_filename(
+        os.path.join("tmp", "data", "20210710T095258428Z-MicWaveIn.flac"))
+    self.assertTrue(is_utc)
     self.assertEqual(out.year, 2021)
     self.assertEqual(out.month, 7)
     self.assertEqual(out.day, 10)

--- a/Observer/SpeakFasterObserver Decoder/video.py
+++ b/Observer/SpeakFasterObserver Decoder/video.py
@@ -55,9 +55,9 @@ def stitch_images_into_mp4(image_paths,
     initial_frame_image_path = os.path.join(tmp_dir, "first_frame.jpg")
     Image.new("RGB", (image_width, image_height)).save(initial_frame_image_path)
 
-  timestamp0 = file_naming.parse_timestamp_from_filename(image_paths[0])
+  timestamp0, _ = file_naming.parse_timestamp_from_filename(image_paths[0])
   for image_path in image_paths[1:]:
-    timestamp = file_naming.parse_timestamp_from_filename(image_path)
+    timestamp, _ = file_naming.parse_timestamp_from_filename(image_path)
     if timestamp < timestamp0:
       raise ValueError(
           "Timestamp of image file is out of order: %s" % image_path)


### PR DESCRIPTION
This change makes the date parsing functions work with UTC timestamps
such as 20211015T183436163Z.

Related to #76 