### PR TITLE
[Observer Decoder] Pin tensorflow-estimator version to 2.6.0

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/requirements.txt
+++ b/Observer/SpeakFasterObserver Decoder/requirements.txt
@@ -31,6 +31,7 @@ scipy==1.6.3
 six==1.15.0
 tensorflow==2.6.0
 tensorflow_hub==0.12.0
+tensorflow-estimator==2.6.0
 tensorflow-text==2.6.0
 soupsieve==2.2.1
 toml==0.10.2


### PR DESCRIPTION
This avoids a version skew issues observed during debugging with @seanholmes77 