### PR TITLE
[Observer] Catch System.Net.Http.HttpRequestException during S3 PUT

### DIFF
--- a/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
+++ b/Observer/SpeakFasterObserver/Properties/Settings.Designer.cs
@@ -37,7 +37,7 @@ namespace SpeakFasterObserver.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool IsRecordingScreenshots {
             get {
                 return ((bool)(this["IsRecordingScreenshots"]));

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace SpeakFasterObserver
@@ -100,25 +101,32 @@ namespace SpeakFasterObserver
                 };
 
                 PutObjectResponse putResponse;
-                using (var inputStream = fileInfo.OpenRead())
+                try
                 {
-                    putRequest.InputStream = inputStream;
-                    putResponse = await _client.PutObjectAsync(putRequest);
-                }
-
-                if (putResponse.HttpStatusCode == HttpStatusCode.OK)
-                {
-                    fileInfo.Delete();
-                    // If the file that was just uploaded successfully is a session-end token, remove the session directory.
-                    if (FileNaming.IsSessionEndToken(filePath))
+                    using (var inputStream = fileInfo.OpenRead())
                     {
-                        string sessionDir = Path.GetDirectoryName(filePath);
-                        if (IsDirectoryEmpty(sessionDir))
-                        {
-                            Directory.Delete(sessionDir);
-                        }
-                        Debug.WriteLine($"Deleted directory of ended session: {sessionDir}");
+                        putRequest.InputStream = inputStream;
+                        putResponse = await _client.PutObjectAsync(putRequest);
                     }
+
+                    if (putResponse.HttpStatusCode == HttpStatusCode.OK)
+                    {
+                        fileInfo.Delete();
+                        // If the file that was just uploaded successfully is a session-end token, remove the session directory.
+                        if (FileNaming.IsSessionEndToken(filePath))
+                        {
+                            string sessionDir = Path.GetDirectoryName(filePath);
+                            if (IsDirectoryEmpty(sessionDir))
+                            {
+                                Directory.Delete(sessionDir);
+                            }
+                            Debug.WriteLine($"Deleted directory of ended session: {sessionDir}");
+                        }
+                    }
+                }
+                catch (HttpRequestException e)
+                {
+                    Debug.WriteLine($"AWS S3 PUT request experienced HttpRequestException: {e.Message}");
                 }
             }
 

--- a/Observer/SpeakFasterObserver/Upload.cs
+++ b/Observer/SpeakFasterObserver/Upload.cs
@@ -11,8 +11,8 @@ namespace SpeakFasterObserver
 {
     internal class Upload
     {
-        private const string SCHEMA_VERSION = "SPO-2105";
-        private const string BUCKET_NAME = "speak-faster";
+        private const string SCHEMA_VERSION = "SPO-2111";
+        private const string BUCKET_NAME = "speak-faster-cais-test";
 
         private static readonly AmazonS3Client _client;
 


### PR DESCRIPTION
Empirically, we've observed this exception being thrown and not caught properly when Wifi goes out in the middle of an Observer session.