### PR TITLE
[Observer Decoder] Support downloading, preproc & uploading in data_manager.py

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/audio_asr.py
+++ b/Observer/SpeakFasterObserver Decoder/audio_asr.py
@@ -563,13 +563,16 @@ def async_transcribe(audio_file_paths,
     diarized_words = [(
         word.word, word.speaker_tag, word.start_time.total_seconds(),
         word.end_time.total_seconds()) for word in alt.words]
-    # print("Confidence: {}".format(result.alternatives[0].confidence))
 
-  regrouped_utterances = regroup_utterances(utterances, diarized_words)
   with open(output_tsv_path, "w" if not begin_sec else "a") as f:
     if not begin_sec:
       # Write the TSV header.
       f.write(tsv_data.HEADER + "\n")
+    if not utterances:
+      print("ASR produced no recognized speech utterances. "
+            "Generated empty asr.tsv file.")
+      return
+    regrouped_utterances = regroup_utterances(utterances, diarized_words)
     utterance_counter = 0
     for (regrouped_utterance,
         speaker_index, start_time_sec, end_time_sec) in regrouped_utterances:

--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -187,12 +187,12 @@ class DataManager(object):
     return (time_zone, start_time, duration_s, num_keypresses, num_audio_files,
             num_screenshots, object_keys)
 
-  def _get_session_basename(self, session_prefix):
+  def get_session_basename(self, session_prefix):
     path_items = session_prefix.split("/")
     return path_items[-1] if path_items[-1] else path_items[-2]
 
   def _get_local_session_dir(self, session_prefix):
-    session_basename = self._get_session_basename(session_prefix)
+    session_basename = self.get_session_basename(session_prefix)
     return os.path.join(self._local_data_root, session_basename)
 
   def _nonempty_file_exists(self, file_path):
@@ -345,8 +345,10 @@ def _show_session_info(window,
   if not session_prefix:
     return
   (time_zone, start_time, duration_s, num_keypresses, num_audio_files,
-    num_screenshots,
-    object_keys) = data_manager.get_session_details(session_prefix)
+   num_screenshots,
+   object_keys) = data_manager.get_session_details(session_prefix)
+  window.Element("SESSION_NAME").Update(
+      data_manager.get_session_basename(session_prefix))
   window.Element("IS_SESSION_COMPLETE").Update("Yes" if time_zone else "No")
   if time_zone:
     window.Element("TIME_ZONE").Update(time_zone)
@@ -409,6 +411,10 @@ def main():
           sg.Button("Show session", key="SHOW_SESSION_INFO"),
       ],
       [
+          [
+              sg.Text("Session name", size=(15, 1)),
+              sg.InputText("", key="SESSION_NAME", readonly=True),
+          ],
           [
               sg.Text("Is complete?", size=(15, 1)),
               sg.InputText("", key="IS_SESSION_COMPLETE", readonly=True),

--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -14,9 +14,13 @@ python data_manager.py --s3_bucket_name=my-bucket-name
 """
 import argparse
 import datetime
+import glob
 import os
+import pathlib
 import pytz
+import subprocess
 import tempfile
+import time
 
 import boto3
 import PySimpleGUI as sg
@@ -29,6 +33,11 @@ DEFAULT_PROFILE_NAME = "spo"
 DEFAULT_S3_BUCKET_NAME = "speak-faster"
 OBSERVER_DATA_PREFIX = "observer_data"
 DATA_SCHEMA_NAME = "SPO-2111"
+POSSIBLE_DATA_ROOT_DIRS = (
+    os.path.join("/", "SpeakFasterObs", "data"),
+    os.path.join(pathlib.Path.home(), "SpeakFasterObs", "data"),
+    os.path.join(pathlib.Path.home(), "sf_observer_data"),
+)
 
 
 def parse_args():
@@ -45,11 +54,32 @@ def parse_args():
   return parser.parse_args()
 
 
+def infer_local_data_root():
+  for root_dir in POSSIBLE_DATA_ROOT_DIRS:
+    if os.path.isdir(root_dir):
+      return root_dir
+  raise ValueError(
+      "Cannot find a root directory for data among these possible paths: %s. "
+      "Create one first." % (POSSIBLE_DATA_ROOT_DIRS,))
+
+
+
+def _get_timezone(readable_timezone_name):
+  if "Eastern Time (US & Canada)" in readable_timezone_name:
+    return "US/Eastern"
+  elif "Central Time (US & Canada)" in readable_timezone_name:
+    return "US/Central"
+  else:
+    raise ValueError("Unimplemented time zone: %s" % time_zone)
+
+
 class DataManager(object):
 
-  def __init__(self, aws_profile_name, s3_bucket_name):
+  def __init__(self, aws_profile_name, s3_bucket_name, local_data_root):
     self._s3_client = boto3.Session(profile_name=aws_profile_name).client("s3")
+    self._aws_profile_name = aws_profile_name
     self._s3_bucket_name = s3_bucket_name
+    self._local_data_root = local_data_root
 
   def get_session_container_prefixes(self):
     """Find the prefixes that hold the session folders as children.
@@ -110,6 +140,7 @@ class DataManager(object):
         Bucket=self._s3_bucket_name, Prefix=session_prefix)
     print("get_session_details(): is_truncated = %s" % response["IsTruncated"])
     objects = response["Contents"]
+    object_keys = []
     time_zone = None
     first_timestamp = datetime.datetime.now().timestamp()
     last_timestamp = 0
@@ -120,6 +151,7 @@ class DataManager(object):
     num_screenshots = 0
     for obj in objects:
       obj_key = obj["Key"]
+      object_keys.append(obj_key[len(session_prefix):])
       data_stream_name = file_naming.get_data_stream_name(obj_key)
       if data_stream_name == "MicWaveIn":
         num_audio_files += 1
@@ -146,17 +178,68 @@ class DataManager(object):
         keypresses = process_keypresses.load_keypresses_from_file(tmp_filepath)
         num_keypresses += len(keypresses.keyPresses)
     if time_zone:
-      if "Eastern Time (US & Canada)" in time_zone:
-        tz = pytz.timezone("US/Eastern")
-      elif "Central Time (US & Canada)" in time_zone:
-        tz = pytz.timezone("US/Central")
-      else:
-        raise ValueError("Unimplemented time zone: %s" % time_zone)
+      tz = pytz.timezone(_get_timezone(time_zone))
       start_time = utc_timezone.localize(
           datetime.datetime.fromtimestamp(first_timestamp)).astimezone(tz)
       duration_s = last_timestamp - first_timestamp
     return (time_zone, start_time, duration_s, num_keypresses, num_audio_files,
-            num_screenshots)
+            num_screenshots, object_keys)
+
+  def _get_session_basename(self, session_prefix):
+    path_items = session_prefix.split("/")
+    return path_items[-1] if path_items[-1] else path_items[-2]
+
+  def _get_local_session_dir(self, session_prefix):
+    session_basename = self._get_session_basename(session_prefix)
+    return os.path.join(self._local_data_root, session_basename)
+
+  def _nonempty_file_exists(self, file_path):
+    if not os.path.isfile(file_path):
+      return False
+    return os.path.getsize(file_path) > 0
+
+  def sync_to_local(self, session_prefix):
+    local_dest_dir = self._get_local_session_dir(session_prefix)
+    if not os.path.isdir(local_dest_dir):
+      os.makedirs(local_dest_dir)
+      print("Created session directory: %s" % local_dest_dir)
+    print("Sync'ing session to local: %s --> %s" %
+          (session_prefix, local_dest_dir))
+    command_line = [
+        "aws", "s3", "sync", "--profile=%s" % self._aws_profile_name,
+        "s3://" + self._s3_bucket_name + "/" + session_prefix, local_dest_dir]
+    print("Calling %s" % (" ".join(command_line)))
+    subprocess.check_call(command_line)
+    print("Download complete.")
+
+  def get_local_session_folder_status(self, session_prefix):
+    local_dest_dir = self._get_local_session_dir(session_prefix)
+    if not os.path.isdir(local_dest_dir):
+      return "NOT DOWNLOADED"
+    else:
+      session_end_bin_path = glob.glob(os.path.join(
+          local_dest_dir, "*-SessionEnd.bin"))
+      if (self._nonempty_file_exists(
+              os.path.join(local_dest_dir, file_naming.MERGED_TSV_FILENAME)) and
+          self._nonempty_file_exists(
+              os.path.join(local_dest_dir, file_naming.CONCATENATED_AUDIO_FILENAME)) and
+          self._nonempty_file_exists(
+              os.path.join(local_dest_dir, file_naming.SCREENSHOTS_MP4_FILENAME))):
+        return "PREPROCESSED"
+      elif glob.glob(os.path.join(local_dest_dir, "*-SessionEnd.bin")):
+          return "DOWNLOADED"
+      else:
+            return "NOT DOWNLOADED"
+
+  def run_preprocessing(self, session_prefix):
+    local_dest_dir = self._get_local_session_dir(session_prefix)
+    (readable_timezone_name,
+     _, _, _, _, _, _) = self.get_session_details(session_prefix)
+    timezone = _get_timezone(readable_timezone_name)
+    command_line = ["python", "elan_format_raw.py", local_dest_dir, timezone]
+    print("Calling %s" % (" ".join(command_line)))
+    subprocess.check_call(command_line)
+    print("Preprocessing complete.")
 
 
 def _get_container_prefix(window, session_container_prefixes):
@@ -168,9 +251,63 @@ def _get_container_prefix(window, session_container_prefixes):
   return session_container_prefixes[selection]
 
 
+def _get_session_prefix(window, session_container_prefixes, session_prefixes):
+  container_prefix = _get_container_prefix(window, session_container_prefixes)
+  if not container_prefix:
+    sg.Popup("Please select exactly 1 container first", modal=True)
+    return
+  selection = window.Element("SESSION_LIST").Widget.curselection()
+  if not selection:
+    sg.Popup("Please select exactly 1 session first", modal=True)
+    return
+  return container_prefix + session_prefixes[selection[0]]
+
+
+def _disable_all_buttons(window):
+  window.Element("LIST_SESSIONS").Update(disabled=True)
+  window.Element("SHOW_SESSION").Update(disabled=True)
+  window.Element("DOWNLOAD_SESSION_TO_LOCAL").Update(disabled=True)
+  window.Element("UPLOAD_SESSION").Update(disabled=True)
+  window.Element("SESSION_CONTAINER_LIST").Update(disabled=True)
+  window.Element("SESSION_LIST").Update(disabled=True)
+  window.Element("OBJECT_LIST").Update(disabled=True)
+
+
+def _enable_all_buttons(window):
+  window.Element("LIST_SESSIONS").Update(disabled=False)
+  window.Element("SHOW_SESSION").Update(disabled=False)
+  window.Element("DOWNLOAD_SESSION_TO_LOCAL").Update(disabled=False)
+  window.Element("UPLOAD_SESSION").Update(disabled=False)
+  window.Element("SESSION_CONTAINER_LIST").Update(disabled=False)
+  window.Element("SESSION_LIST").Update(disabled=False)
+  window.Element("OBJECT_LIST").Update(disabled=False)
+
+
+def _list_sessions(window, data_manager, session_container_prefixes):
+  container_prefix = _get_container_prefix(window, session_container_prefixes)
+  if not container_prefix:
+    return
+  session_prefixes = data_manager.get_session_prefixes(container_prefix)
+  session_prefixes_with_status = []
+  for session_prefix in session_prefixes:
+    session_prefixes_with_status.append(
+        "%s (%s)" %
+        (session_prefix,
+        data_manager.get_local_session_folder_status(
+            container_prefix + session_prefix)))
+  window.Element("SESSION_LIST").Update(session_prefixes_with_status)
+  window.Element("SESSION_TITLE").Update(
+      "Sessions:\n%d sessions" % len(session_prefixes))
+  return session_prefixes
+
+
 def main():
   args = parse_args()
-  data_manager = DataManager(args.aws_profile_name, args.s3_bucket_name)
+  local_data_root = infer_local_data_root()
+  data_manager = DataManager(args.aws_profile_name,
+                             args.s3_bucket_name,
+                             local_data_root)
+  print("Inferred local data root: %s" % local_data_root)
   session_container_prefixes = data_manager.get_session_container_prefixes()
   session_container_listbox = sg.Listbox(
       session_container_prefixes,
@@ -182,16 +319,29 @@ def main():
       size=(120, 15),
       enable_events=False,
       key="SESSION_LIST")
+  object_listbox = sg.Listbox(
+      [],
+      size=(120, 10),
+      enable_events=False,
+      key="OBJECT_LIST")
   layout = [
+      [
+          sg.Text("", size=(15, 1)),
+          sg.Text(key="STATUS_MESSAGE"),
+      ],
+      [
+          sg.Text("Local data root:", size=(15, 1)),
+          sg.Text(local_data_root),
+      ],
       [
           sg.Text("Containers:", size=(15, 1)),
           session_container_listbox,
-          sg.Button("List sessions"),
+          sg.Button("List sessions", key="LIST_SESSIONS"),
       ],
       [
           sg.Text("Sessions:", size=(15, 2), key="SESSION_TITLE"),
           session_listbox,
-          sg.Button("Show session"),
+          sg.Button("Show session", key="SHOW_SESSION"),
       ],
       [
           [
@@ -223,49 +373,88 @@ def main():
               sg.InputText("", key="NUM_SCREENSHOTS", readonly=True),
           ],
       ],
+      [
+          sg.Text("Objects:", size=(15, 2), key="OBBJECTS_TITLE"),
+          object_listbox,
+      ],
+      [
+          sg.Text("", size=(15, 2)),
+          sg.Button("Download to local", key="DOWNLOAD_SESSION_TO_LOCAL"),
+          sg.Button("Run proprocessing", key="PREPROCESS_SESSION"),
+          sg.Button("Sync to remote", key="UPLOAD_SESSION"),
+      ]
   ]
+  session_prefixes = None
   window = sg.Window(
       "SpeakFaster Data Manager", layout)
   while True:
     event, values = window.read()
     if event == sg.WIN_CLOSED:
       break
-    elif event == "List sessions":
-      container_prefix = _get_container_prefix(
-          window, session_container_prefixes)
-      if not container_prefix:
+    elif event == "LIST_SESSIONS":
+      session_prefixes = _list_sessions(
+          window, data_manager, session_container_prefixes)
+    elif event == "SHOW_SESSION":
+      session_prefix = _get_session_prefix(
+          window, session_container_prefixes, session_prefixes)
+      if not session_prefix:
         continue
-      session_prefixes = data_manager.get_session_prefixes(container_prefix)
-      window.Element("SESSION_LIST").Update(session_prefixes)
-      window.Element("SESSION_TITLE").Update(
-          "Sessions:\n%d sessions" % len(session_prefixes))
-    elif event == "Show session":
-      container_prefix = _get_container_prefix(
-          window, session_container_prefixes)
-      if not container_prefix:
-        continue
-      selection = window.Element("SESSION_LIST").Widget.curselection()
-      if not selection:
-        sg.Popup("Please select exactly 1 session first", modal=True)
-        continue
-      session_prefix = container_prefix + session_prefixes[selection[0]]
       (time_zone, start_time, duration_s, num_keypresses, num_audio_files,
-       num_screenshots) = data_manager.get_session_details(session_prefix)
+       num_screenshots,
+       object_keys) = data_manager.get_session_details(session_prefix)
       window.Element("IS_SESSION_COMPLETE").Update("Yes" if time_zone else "No")
-      if not time_zone:
-        window.Element("TIME_ZONE").Update("")
-        window.Element("START_TIME").Update("")
-        window.Element("DURATION_MIN").Update("")
-        window.Element("NUM_KEYPRESSES").Update("")
-        window.Element("NUM_AUDIO_FILES").Update("")
-        window.Element("NUM_SCREENSHOTS").Update("")
-      else:
+      if time_zone:
         window.Element("TIME_ZONE").Update(time_zone)
         window.Element("START_TIME").Update("%s" % start_time)
         window.Element("DURATION_MIN").Update("%.2f" % (duration_s / 60))
         window.Element("NUM_KEYPRESSES").Update("%d" % num_keypresses)
         window.Element("NUM_AUDIO_FILES").Update("%d" % num_audio_files)
         window.Element("NUM_SCREENSHOTS").Update("%d" % num_screenshots)
+        window.Element("OBJECT_LIST").Update(object_keys)
+      else:
+        window.Element("TIME_ZONE").Update("")
+        window.Element("START_TIME").Update("")
+        window.Element("DURATION_MIN").Update("")
+        window.Element("NUM_KEYPRESSES").Update("")
+        window.Element("NUM_AUDIO_FILES").Update("")
+        window.Element("NUM_SCREENSHOTS").Update("")
+        window.Element("OBJECT_LIST").Update([])
+    elif event == "DOWNLOAD_SESSION_TO_LOCAL":
+      if not session_prefixes:
+        sg.Popup("Please list sessions first", modal=True)
+        continue
+      session_prefix = _get_session_prefix(
+          window, session_container_prefixes, session_prefixes)
+      if not session_prefix:
+        sg.Popup("Please select exactly 1 session first", modal=True)
+        continue
+      window.Element("STATUS_MESSAGE").Update("Downloading session. Please wait...")
+      window.Element("STATUS_MESSAGE").Update(text_color="yellow")
+      _disable_all_buttons(window)
+      window.refresh()
+      data_manager.sync_to_local(session_prefix)
+      window.Element("STATUS_MESSAGE").Update("Session download complete.")
+      window.Element("STATUS_MESSAGE").Update(text_color="white")
+      # Refresh all sessions after the selected session has finished downloading.
+      session_prefixes = _list_sessions(
+          window, data_manager, session_container_prefixes)
+      _enable_all_buttons(window)
+    elif event == "PREPROCESS_SESSION":
+      if not session_prefixes:
+        sg.Popup("Please list sessions first", modal=True)
+        continue
+      session_prefix = _get_session_prefix(
+          window, session_container_prefixes, session_prefixes)
+      if not session_prefix:
+        sg.Popup("Please select exactly 1 session first", modal=True)
+        continue
+      data_manager.run_preprocessing(session_prefix)
+      # Refresh all sessions after the selected session has finished downloading.
+      session_prefixes = _list_sessions(
+          window, data_manager, session_container_prefixes)
+    elif event == "UPLOAD_SESSION":
+      raise NotImplementedError()  # TODO(cais):
+
 
 
 if __name__ == "__main__":

--- a/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
+++ b/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
@@ -45,7 +45,7 @@ def format_raw_data(input_dir,
   if not os.path.isdir(input_dir):
     raise ValueError("%s is not an existing directory" % input_dir)
 
-  merged_tsv_path = os.path.join(input_dir, "merged.tsv")
+  merged_tsv_path = os.path.join(input_dir, file_naming.MERGED_TSV_FILENAME)
 
   if keypresses_only:
     # Keypresses-only: The start timestamp will be from the first keypress.
@@ -91,7 +91,8 @@ def format_raw_data(input_dir,
     screenshot_paths = sorted(
         glob.glob(os.path.join(input_dir, "*-Screenshot.jpg")))
     if screenshot_paths:
-      screenshots_video_path = os.path.join(input_dir, "screenshots.mp4")
+      screenshots_video_path = os.path.join(
+          input_dir, file_naming.SCREENSHOTS_MP4_FILENAME)
       print("Writing screenshots video...")
       video.stitch_images_into_mp4(
           screenshot_paths,
@@ -100,7 +101,8 @@ def format_raw_data(input_dir,
           screenshots_video_path)
       print("Saved screenshots video to %s\n" % screenshots_video_path)
     elif dummy_video_frame_image_path:
-      dummy_video_path = os.path.join(input_dir, "screenshots.mp4")
+      dummy_video_path = os.path.join(
+          input_dir, file_naming.SCREENSHOTS_MP4_FILENAME)
       print("Generating dummy video (duration: %.3f s) based on %s..." %
           (audio_duration_s, dummy_video_frame_image_path))
       video.make_dummy_video_file(
@@ -146,7 +148,8 @@ def read_and_concatenate_audio_files(input_dir, timezone):
       first_audio_path, timezone)
   print("Audio data start time: %s (%s)" %
         (audio_start_time, audio_start_time_epoch))
-  concatenated_audio_path = os.path.join(input_dir, "concatenated_audio.flac")
+  concatenated_audio_path = os.path.join(
+      input_dir, file_naming.CONCATENATED_AUDIO_FILENAME)
   audio_duration_s = audio_asr.concatenate_audio_files(
       all_audio_paths, concatenated_audio_path, fill_gaps=True)
   return (first_audio_path,

--- a/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
+++ b/Observer/SpeakFasterObserver Decoder/elan_format_raw.py
@@ -132,6 +132,9 @@ def format_raw_data(input_dir,
   tsv_data.merge_tsv_files(
       [keypresses_tsv_path, text_editor_navigation_tsv_path,
        audio_events_tsv_path, asr_tsv_path], merged_tsv_path)
+  print("Concatenated audio file is at: %s" % concatenated_audio_path)
+  if not skip_screenshots and screenshot_paths:
+    print("Screenshot video file is at: %s" % screenshots_video_path)
   print("Merged TSV file is at: %s" % merged_tsv_path)
 
 

--- a/Observer/SpeakFasterObserver Decoder/elan_process_curated.py
+++ b/Observer/SpeakFasterObserver Decoder/elan_process_curated.py
@@ -20,6 +20,7 @@ import re
 
 import numpy as np
 
+import file_naming
 import metadata_pb2
 import nlp
 import transcript_lib
@@ -417,7 +418,8 @@ def main():
   nlp.init()
 
   realname_to_pseudonym = load_speaker_map(args.speaker_map_tsv_path)
-  merged_tsv_path = os.path.join(args.input_dir, "merged.tsv")
+  merged_tsv_path = os.path.join(args.input_dir,
+                                 file_naming.MERGED_TSV_FILENAME)
   curated_tsv_path = os.path.join(args.input_dir, "curated.tsv")
   column_order, has_header = infer_columns(curated_tsv_path)
   rows = load_rows(curated_tsv_path, column_order, has_header=has_header)

--- a/Observer/SpeakFasterObserver Decoder/file_naming.py
+++ b/Observer/SpeakFasterObserver Decoder/file_naming.py
@@ -8,6 +8,10 @@ import os
 
 import pytz
 
+MERGED_TSV_FILENAME = "merged.tsv"
+CONCATENATED_AUDIO_FILENAME = "concatenated_audio.wav"
+SCREENSHOTS_MP4_FILENAME = "screenshots.mp4"
+
 
 def parse_timestamp(timestamp):
   """Parse timestamp into a Python datetime.datetime object.


### PR DESCRIPTION
- Support showing the objects under a session prefix in the S3 bucket
- Support downloading the objects under a session prefix to a local folder, via subprocess call of `aws s3 sync ...`
- Support running preprocessing of a downloaded session folder, via subprocess call of `python elan_format_raw.py`
- Support uploading preprocessing results to the corresponding S3 bucket
- Display remote and local status in the session list
- 
See screenshot based on a test S3 bucket:
![image](https://user-images.githubusercontent.com/16824702/142750194-acfa4487-3c74-46ec-854d-6862f6cc3db7.png)
