### PR TITLE
[Data Manager GUI] Improvements and bug fixes

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -72,6 +72,12 @@ def _get_timezone(readable_timezone_name):
   elif ("Central Time (US & Canada)" in readable_timezone_name or
         readable_timezone_name == "US/Central"):
     return "US/Central"
+  elif ("Mountain Time (US & Canada)" in readable_timezone_name or
+        readable_timezone_name == "US/Mountain"):
+    return "US/Mountain"
+  elif ("Pacific Time (US & Canada)" in readable_timezone_Name or
+        readable_timezone_name == "US/Pacific"):
+    return "US/Pacific"
   else:
     raise ValueError("Unimplemented time zone: %s" % time_zone)
 


### PR DESCRIPTION
Bug fixes:
- Previously, the list_object_v2() call didn't do pagination, so it
  only returned the first 1000 objects. As a result, the UI incorrectly
  showed sessions with more than 1000 objects as "not complete". This
  is now fixed through pagination.

Improvements:
- Decreased the width and height of the window to make it easier to
  work with on screens with relatively low resolution.
- Highlight sessions that have the "PREPROCESSED" remote status
  with the blue color.
- For sessions that ended prematurely and hence lack the SessionEnd.bin
  object, pop up a PySimpleGUI text box to ask for the time zone.
- Display the total count of objects for a session
- Remove the "Show session" button. Let selection events in the session
  list automatically display session details.

Fixes #118 