### PR TITLE
[SpeakFaster] Print day and hour range summaries in the time table

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -62,7 +62,13 @@ def _print_time_summary_table(table):
   print("\t" + "\t".join(["%d-%d" %
       (hour_min, hour_max) for hour_min, hour_max in HOUR_RANGES]))
   for i, weekday in enumerate(WEEKDAYS):
-    print(weekday + "\t" + "\t".join(["%d" % n for n in table[i, :].tolist()]))
+    day_line = weekday + "\t" + "\t".join(
+        ["%d" % n for n in table[i, :].tolist()])
+    day_line += "\t%d" % np.sum(table[i, :])
+    print(day_line)
+  print("-------------------------------------------")
+  print("   \t" +
+        "\t".join(["%d" % n for n in np.sum(table, axis=0).tolist()]))
 
 
 def parse_args():


### PR DESCRIPTION
Related to #128

New summary table contains a sum over the days of the week and over the hour ranges, e.g.,

```
=== Distribution of session start times ===
	0-3	3-6	6-9	9-12	12-15	15-18	18-21	21-24
Mon	0	0	0	0	0	2	2	12	16
Tue	0	0	0	7	15	10	7	6	45
Wed	0	0	0	17	5	3	6	1	32
Thu	0	0	1	3	1	1	4	5	15
Fri	0	0	0	2	1	0	0	0	3
Sat	0	0	0	2	0	0	0	1	3
Sun	0	0	0	0	0	0	0	0	0
-------------------------------------------
   	0	0	1	31	22	16	19	25
```