### PR TITLE
[Data manager] Speed up + "Refresh session state" and "Batch preproc" buttons

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -685,7 +685,7 @@ def _download_preprocess_upload_sessions_from(window,
                                               data_manager,
                                               session_container_prefixes,
                                               session_prefixes):
-  """Preprocess and upload sessions that are not remotely preprocessed."""
+  """Preprocess & upload sessions that aren't remotely preprocessed, in batch."""
   container_prefix = _get_container_prefix(window, session_container_prefixes)
   session_prefix = _get_session_prefix(
       window, session_container_prefixes, session_prefixes)
@@ -716,6 +716,8 @@ def _download_preprocess_upload_sessions_from(window,
                    len(task_session_prefixes)).strip()
     if answer in ("y", "n"):
       break
+  if answer == "n":
+    return "Batch preprocessing and uploading is canceled.", False
   for session_prefix in task_session_prefixes:
     print("")
     local_status = data_manager.get_local_session_folder_status(session_prefix)


### PR DESCRIPTION
- Speed up listing of sessions by using `paginator.search()`. Measurement on my workstation: 3.x s --> 2.x s. (~30% speed up)
- Add "Refresh session state" button to allow refreshing the state of a single session in the session list without going through all sessions
- Keep scroll state when updating session lists
- Add button "Preprocess and upload sessions from here on" to support batch downloading, preprocessing and uploading of sessions.

Fixes #137 