### PR TITLE
[Data Manager] Add "Upload to GCS" button

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -53,10 +53,13 @@ WEEKDAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 DEFAULT_GCS_BUCKET_NAME = "speak-faster-curated-data-shared"
 GCS_SUMMARY_PREFIX = "summary"
 GCS_POSTPROCESSED_UPLOAD_PREFIX = "postprocessed"
+
+# The set of files to upload to shared GCS folder. Must only include
+# the post-processed, curated results.
 POSTPROCESSING_FILES_TO_UPLOAD = (
-          file_naming.CURATED_PROCESSED_JSON_FILENAME,
-          file_naming.CURATED_PROCESSED_TSV_FILENAME,
-          file_naming.CURATED_PROCESSED_SPEECH_ONLY_TSV_FILENAME)
+    file_naming.CURATED_PROCESSED_JSON_FILENAME,
+    file_naming.CURATED_PROCESSED_TSV_FILENAME,
+    file_naming.CURATED_PROCESSED_SPEECH_ONLY_TSV_FILENAME)
 
 def get_hour_index(hour):
   for i, (hour_min, hour_max) in enumerate(HOUR_RANGES):

--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -760,6 +760,8 @@ def _list_sessions(window,
 
 
 def get_base_session_prefix(session_prefix):
+  if not session_prefix:
+    raise ValueError("session_prefix is empty or None")
   if session_prefix.endswith("/"):
     session_prefix = session_prefix[:-1]
   if "/" in session_prefix:

--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -52,6 +52,7 @@ WEEKDAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
 DEFAULT_GCS_BUCKET_NAME = "speak-faster-curated-data-shared"
 GCS_SUMMARY_PREFIX = "summary"
+GCS_POSTPROCESSED_UPLOAD_PREFIX = "postprocessed"
 
 def get_hour_index(hour):
   for i, (hour_min, hour_max) in enumerate(HOUR_RANGES):
@@ -166,6 +167,10 @@ class DataManager(object):
       raise ValueError(
           "It appears that you don't have aws cli installed and on the path. "
           "Please install it and make sure it is on the path.")
+
+  @property
+  def gcs_bucket_name(self):
+    return self._gcs_bucket_name
 
   def get_session_container_prefixes(self):
     """Find the prefixes that hold the session folders as children.
@@ -529,7 +534,8 @@ class DataManager(object):
       sg.Popup(failure_message, title="Postprocessing failed", modal=True)
       return "Postprocessing failed", True
 
-  def upload_session_postproc_results(self, session_prefix):
+  def upload_session_postproc_results(self, session_prefix, to_gcs=False):
+    """Upload post processing results to S3 or GCS."""
     if self.get_local_session_folder_status(session_prefix) != "POSTPROCESSED":
       sg.Popup(
           "Cannot upload the postprocessing results of session %s, "
@@ -537,7 +543,8 @@ class DataManager(object):
           modal=True)
       return "Not uploading postprocessing results", False
     to_upload = True
-    if self.get_remote_session_folder_status(session_prefix) == "POSTPROCESSED":
+    if (not to_gcs and
+        self.get_remote_session_folder_status(session_prefix) == "POSTPROCESSED"):
       answer = sg.popup_yes_no(
           "Session %s already contains postprocessing results remotely. "
           "Do you want to upload postprocessing results again?" % session_prefix)
@@ -545,18 +552,48 @@ class DataManager(object):
     if not to_upload:
       return "Uploading of postprocessing results canceled.", False
 
-    local_dest_dir = self.get_local_session_dir(session_prefix)
-    command_args = [
-        "aws", "s3", "sync", "--profile=%s" % self._aws_profile_name,
-        local_dest_dir, "s3://" + self._s3_bucket_name + "/" + session_prefix,
-        "--exclude=*", "--include=*.tsv",
-        "--include=%s" % file_naming.CURATED_PROCESSED_JSON_FILENAME,
-        "--include=%s" % file_naming.CURATED_PROCESSED_TSV_FILENAME,
-        "--include=%s" % file_naming.CURATED_PROCESSED_SPEECH_ONLY_TSV_FILENAME]
-    self._run_command_line(command_args)
-    print("Done uploading the postprocessing results for session %s" %
-          session_prefix)
-    return "Down uploading postprocessing results", True
+    local_session_dir = self.get_local_session_dir(session_prefix)
+    if to_gcs:
+      answer = sg.popup_yes_no(
+          "Are you sure you want to upload proprocessing results from session %s "
+          "to GCS bucket %s?" % (session_prefix, self.gcs_bucket_name))
+      to_upload = answer == "Yes"
+      if not to_upload:
+        return "Not uploading postprocessing results to GCS", False
+      destination_blob_prefix = "/".join(
+            [GCS_POSTPROCESSED_UPLOAD_PREFIX] +
+            [item for item in session_prefix.split("/") if item])
+      print("Destination blob prefix: %s" % destination_blob_prefix)
+      upload_file_names = (
+          file_naming.CURATED_PROCESSED_JSON_FILENAME,
+          file_naming.CURATED_PROCESSED_TSV_FILENAME,
+          file_naming.CURATED_PROCESSED_SPEECH_ONLY_TSV_FILENAME)
+      all_uploaded_already = gcloud_utils.remote_objects_exist(
+          self.gcs_bucket_name, destination_blob_prefix, upload_file_names)
+      if all_uploaded_already:
+        answer = sg.popup_yes_no(
+            "This session has already been uploaded to GCS. "
+            "Do you want to uploade it again, overwriting files?")
+        to_upload = answer == "Yes"
+        if not to_upload:
+          return "Not uploading postprocessing results to GCS", False
+      gcloud_utils.upload_files_as_objects(
+          local_session_dir, upload_file_names, self.gcs_bucket_name,
+          destination_blob_prefix)
+      return "Down uploading postprocessing results to GCS", False
+    else:
+      # Upload to S3.
+      command_args = [
+          "aws", "s3", "sync", "--profile=%s" % self._aws_profile_name,
+          local_session_dir, "s3://" + self._s3_bucket_name + "/" + session_prefix,
+          "--exclude=*", "--include=*.tsv",
+          "--include=%s" % file_naming.CURATED_PROCESSED_JSON_FILENAME,
+          "--include=%s" % file_naming.CURATED_PROCESSED_TSV_FILENAME,
+          "--include=%s" % file_naming.CURATED_PROCESSED_SPEECH_ONLY_TSV_FILENAME]
+      self._run_command_line(command_args)
+      print("Done uploading the postprocessing results for session %s to S3" %
+            session_prefix)
+      return "Down uploading postprocessing results to S3", True
 
   def _run_command_line(self, command_args):
     print("Calling: %s" % (" ".join(command_args)))
@@ -616,6 +653,7 @@ def _disable_all_buttons(window):
   window.Element("DOWNLOAD_PREPROCESS_UPLOAD_SESSIONS_BATCH").Update(disabled=True)
   window.Element("POSTPROC_CURATION").Update(disabled=True)
   window.Element("UPLOAD_POSTPROC").Update(disabled=True)
+  window.Element("UPLOAD_TO_GCS").Update(disabled=True)
   window.Element("SESSION_CONTAINER_LIST").Update(disabled=True)
   window.Element("SESSION_LIST").Update(disabled=True)
   window.Element("OBJECT_LIST").Update(disabled=True)
@@ -632,6 +670,7 @@ def _enable_all_buttons(window):
   window.Element("DOWNLOAD_PREPROCESS_UPLOAD_SESSIONS_BATCH").Update(disabled=False)
   window.Element("POSTPROC_CURATION").Update(disabled=False)
   window.Element("UPLOAD_POSTPROC").Update(disabled=False)
+  window.Element("UPLOAD_TO_GCS").Update(disabled=False)
   window.Element("SESSION_CONTAINER_LIST").Update(disabled=False)
   window.Element("SESSION_LIST").Update(disabled=False)
   window.Element("OBJECT_LIST").Update(disabled=False)
@@ -895,6 +934,7 @@ def main():
           sg.Button("Upload preprocessing data", key="UPLOAD_PREPROC"),
           sg.Button("Postprocess curation", key="POSTPROC_CURATION"),
           sg.Button("Upload postprocessed data", key="UPLOAD_POSTPROC"),
+          sg.Button("Upload to GCS", key="UPLOAD_TO_GCS"),
       ],
       [
           sg.Text("", size=(15, 2)),
@@ -940,6 +980,7 @@ def main():
         }
         summary_text = json.dumps(report, indent=2)
         print("Summary of sessions:\n%s" % summary_text)
+        report["session_prefixes"] = session_prefixes
         report["start_time_table"] = start_time_table.tolist()
         report["weekdays"] = WEEKDAYS
         report["hour_ranges"] = HOUR_RANGES
@@ -969,7 +1010,8 @@ def main():
                    "UPLOAD_PREPROC",
                    "DOWNLOAD_PREPROCESS_UPLOAD_SESSIONS_BATCH",
                    "POSTPROC_CURATION",
-                   "UPLOAD_POSTPROC"):
+                   "UPLOAD_POSTPROC",
+                   "UPLOAD_TO_GCS"):
       if not session_prefixes:
         sg.Popup("Please list sessions first", modal=True)
         continue
@@ -1009,6 +1051,10 @@ def main():
         status_message = "Postprocessing curation results. Please wait..."
       elif event == "UPLOAD_POSTPROC":
         status_message = "Uploading session postprocessing results. Please wait..."
+      elif event == "UPLOAD_TO_GCS":
+        status_message = ("Uploading postprocessing results to GCS (%s). "
+                          "Please wait..." % data_manager.gcs_bucket_name)
+
       window.Element("STATUS_MESSAGE").Update(status_message)
       window.Element("STATUS_MESSAGE").Update(text_color="yellow")
       _disable_all_buttons(window)
@@ -1031,10 +1077,10 @@ def main():
       elif event == "POSTPROC_CURATION":
         (status_message,
          sessions_changed) = data_manager.postprocess_curation(session_prefix)
-      elif event == "UPLOAD_POSTPROC":
+      elif event in ("UPLOAD_POSTPROC", "UPLOAD_TO_GCS"):
         (status_message,
          sessions_changed) = data_manager.upload_session_postproc_results(
-            session_prefix)
+            session_prefix, to_gcs=(event == "UPLOAD_TO_GCS"))
       window.Element("STATUS_MESSAGE").Update(status_message)
       window.Element("STATUS_MESSAGE").Update(text_color="white")
       _enable_all_buttons(window)

--- a/Observer/SpeakFasterObserver Decoder/data_manager_test.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager_test.py
@@ -28,6 +28,12 @@ class DataManagerTest(tf.test.TestCase):
     self.assertEqual(data_manager.get_hour_index(21), 7)
     self.assertEqual(data_manager.get_hour_index(23), 7)
 
+  def testGetBaseSessionPrefix(self):
+    self.assertEqual(
+        data_maanger.get_base_session_prefix(
+            "observer_data/SPO-2011/Surface/eyetracker/abcd0123/session-20211117T202235498Z"),
+        "session-20211117T202235498Z")
+
 
 
 if __name__ == "__main__":

--- a/Observer/SpeakFasterObserver Decoder/data_manager_test.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager_test.py
@@ -28,12 +28,30 @@ class DataManagerTest(tf.test.TestCase):
     self.assertEqual(data_manager.get_hour_index(21), 7)
     self.assertEqual(data_manager.get_hour_index(23), 7)
 
-  def testGetBaseSessionPrefix(self):
+  def testGetBaseSessionPrefix_returnsCorrectValue(self):
     self.assertEqual(
-        data_maanger.get_base_session_prefix(
+        data_manager.get_base_session_prefix(
             "observer_data/SPO-2011/Surface/eyetracker/abcd0123/session-20211117T202235498Z"),
         "session-20211117T202235498Z")
+    self.assertEqual(
+        data_manager.get_base_session_prefix(
+            "observer_data/SPO-2011/Surface/eyetracker/abcd0123/session-20211117T202235498Z/"),
+        "session-20211117T202235498Z")
+    self.assertEqual(
+        data_manager.get_base_session_prefix("session-20211117T202235498Z"),
+        "session-20211117T202235498Z")
+    self.assertEqual(
+        data_manager.get_base_session_prefix("session-20211117T202235498Z/"),
+        "session-20211117T202235498Z")
+    self.assertEqual(
+        data_manager.get_base_session_prefix("/session-20211117T202235498Z/"),
+        "session-20211117T202235498Z")
 
+  def testGetBaseSessionPrefix_raisesValueErrorOnEmptyOrNone(self):
+    with self.assertRaisesRegex(ValueError, r"empty or None"):
+      data_manager.get_base_session_prefix("")
+    with self.assertRaisesRegex(ValueError, r"empty or None"):
+      data_manager.get_base_session_prefix(None)
 
 
 if __name__ == "__main__":

--- a/Observer/SpeakFasterObserver Decoder/data_manager_test.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager_test.py
@@ -28,6 +28,12 @@ class DataManagerTest(tf.test.TestCase):
     self.assertEqual(data_manager.get_hour_index(21), 7)
     self.assertEqual(data_manager.get_hour_index(23), 7)
 
+  def testPostprocessingFilesToUpload(self):
+    self.assertIsInstance(data_manager.POSTPROCESSING_FILES_TO_UPLOAD, tuple)
+    self.assertTrue(data_manager.POSTPROCESSING_FILES_TO_UPLOAD)
+    self.assertLen(set(data_manager.POSTPROCESSING_FILES_TO_UPLOAD),
+                   len(data_manager.POSTPROCESSING_FILES_TO_UPLOAD))
+
   def testGetBaseSessionPrefix_returnsCorrectValue(self):
     self.assertEqual(
         data_manager.get_base_session_prefix(

--- a/Observer/SpeakFasterObserver Decoder/gcloud_utils.py
+++ b/Observer/SpeakFasterObserver Decoder/gcloud_utils.py
@@ -52,3 +52,50 @@ def upload_text_to_object(text, bucket_name, destination_blob_name):
     print("Uploaded text to gs://%s/%s" % (bucket_name, destination_blob_name))
   finally:
     os.remove(temp_path)
+
+
+def remote_objects_exist(bucket_name, destination_blob_prefix, file_names):
+  """Determine whether all remote file objects exist."""
+  storage_client = storage.Client()
+  bucket = storage_client.bucket(bucket_name)
+  for file_name in file_names:
+    destination_blob_name = (
+        destination_blob_prefix if destination_blob_prefix.endswith("/")
+        else destination_blob_prefix + "/")
+    destination_blob_name += "/".join(
+        [item for item in os.path.split(file_name) if item])
+    blob = bucket.blob(destination_blob_name)
+    if not blob.exists():
+      return False
+  return True
+
+
+def upload_files_as_objects(local_dir,
+                            file_names,
+                            bucket_name,
+                            destination_blob_prefix):
+  """Upload specified files in a local directory as GCS objects.
+
+  Under a common destination prefix.
+
+  Args:
+    local_dir: Path to the local directory that contains the files to upload.
+    file_names: Names of the files in the local_dir.
+    destination_blob_prefix: Destination blobl prefix.
+  """
+  storage_client = storage.Client()
+  bucket = storage_client.bucket(bucket_name)
+  for file_name in file_names:
+    file_path = os.path.join(local_dir, file_name)
+    if not os.path.isfile(file_path):
+      raise ValueError("Cannot find file at %s" % file_path)
+    destination_blob_name = (
+        destination_blob_prefix if destination_blob_prefix.endswith("/")
+        else destination_blob_prefix + "/")
+    destination_blob_name += "/".join(
+        [item for item in os.path.split(file_name) if item])
+    print("Uploading %s --> gs://%s/%s" %
+          (file_path, bucket_name, destination_blob_name))
+    blob = bucket.blob(destination_blob_name)
+    print(dir(blob))  # DEBUG
+    blob.upload_from_filename(file_path)

--- a/Observer/SpeakFasterObserver Decoder/gcloud_utils.py
+++ b/Observer/SpeakFasterObserver Decoder/gcloud_utils.py
@@ -81,6 +81,7 @@ def upload_files_as_objects(local_dir,
   Args:
     local_dir: Path to the local directory that contains the files to upload.
     file_names: Names of the files in the local_dir.
+    bucket_name: Name of the GCS bucket to upload the files to.
     destination_blob_prefix: Destination blobl prefix.
   """
   storage_client = storage.Client()

--- a/Observer/SpeakFasterObserver Decoder/gcloud_utils.py
+++ b/Observer/SpeakFasterObserver Decoder/gcloud_utils.py
@@ -97,5 +97,4 @@ def upload_files_as_objects(local_dir,
     print("Uploading %s --> gs://%s/%s" %
           (file_path, bucket_name, destination_blob_name))
     blob = bucket.blob(destination_blob_name)
-    print(dir(blob))  # DEBUG
     blob.upload_from_filename(file_path)


### PR DESCRIPTION
This button allows the user to upload a postprocessed session to the designated GCS bucket.

- When the "Upload to GCS" button is clicked, a dialog box first pops up asking the user to confirm that they intend to upload the data o the GCS bucket.
- Then it checks whether the files (curated_processed.tsv, curated_processed.json and curated_processed_speech_only.tsv) already exist in the GCS bucket and if so, pops up a dialog so the user can confirm overwriting the files.
- If the user confirms to upload and overwrite the files, the actual object uploading ensues
- After the user clicks the "Summarize" button, the session list will display the "[GCS: UPLOADED]" vs "[GCS: NOT_UPLOADED]" strings for the sessions of which the remote state is "POSTPROCESSED". The ones that have been uploaded to GCS are labeled by the gray color.
