### PR TITLE
[WebUI] Add TextToSpeechComponent

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -81,11 +81,17 @@ export class AbbreviationComponent implements OnInit, AfterViewInit {
   }
 
   onSpeakOptionButtonClicked(event: Event, index: number) {
-    throw new Error('Not implemented yet');
-    // TODO(#49): Implement key injection with TTS trigger.
+    if (this.state !== 'CHOOSING_EXPANSION') {
+      return;
+    }
+    this.selectExpansionOption(
+        index, /* toInjectKeys= */ true,
+        /* toTriggerInAppTextToSpeech= */ true);
   }
 
-  private selectExpansionOption(index: number, toInjectKeys: boolean) {
+  private selectExpansionOption(
+      index: number, toInjectKeys: boolean,
+      toTriggerInAppTextToSpeech: boolean = false) {
     if (this._selectedAbbreviationIndex === index || !this.abbreviation) {
       return;
     }
@@ -102,6 +108,8 @@ export class AbbreviationComponent implements OnInit, AfterViewInit {
       isFinal: true,
       numKeypresses,
       numHumanKeypresses: numKeypresses,
+      inAppTextToSpeechAudioConfig:
+          toTriggerInAppTextToSpeech ? {volume_gain_db: 0} : undefined,
     });
     if (toInjectKeys) {
       const injectedKeys: Array<string|VIRTUAL_KEY> =

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -14,6 +14,10 @@ app-context-component {
   display: block;
 }
 
+app-text-to-speech-component {
+  float: right;
+}
+
 </style>
 
 <div class="content" role="main">

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -33,6 +33,11 @@ app-context-component {
       [textEntryEndSubject]="textEntryEndSubject">
   </app-metrics-component>
 
+  <app-text-to-speech-component
+      [textEntryEndSubject]="textEntryEndSubject"
+      [accessToken]="accessToken">
+  </app-text-to-speech-component>
+
   <div *ngIf="hasAccessToken()">
 
     <app-context-component

--- a/webui/src/app/app.module.ts
+++ b/webui/src/app/app.module.ts
@@ -9,6 +9,7 @@ import {ContextModule} from './context/context.module';
 import {ExternalEventsModule} from './external/external-events.module';
 import {MetricsModule} from './metrics/metrics.module';
 import {TextPredictionModule} from './text-prediction/text-prediction.module';
+import {TextToSpeechModule} from './text-to-speech/text-to-speech.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -21,6 +22,7 @@ import {TextPredictionModule} from './text-prediction/text-prediction.module';
     ExternalEventsModule,
     MetricsModule,
     TextPredictionModule,
+    TextToSpeechModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/webui/src/app/text-to-speech-service.ts
+++ b/webui/src/app/text-to-speech-service.ts
@@ -1,0 +1,63 @@
+/**
+ * Types and interfaces related to text-to-speech (speech synthesis) service.
+ */
+import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+
+export interface AudioConfig {
+  audio_encoding: 'LINEAR16';
+
+  speaking_rate: number;
+
+  // TODO(cais): Add prosody parameters such as pitch.
+}
+
+export interface TextToSpeechRequest {
+  // Text representation of the speech.
+  text: string;
+
+  // Language code for the speech (e.g., en-US).
+  language: string;
+
+  // TODO(cais): Make optional.
+  audio_config: AudioConfig;
+
+  // Authentication for using the service.
+  access_token: string;
+}
+
+export interface TextToSpeechResponse {
+  // Encoded PCM audio. Assumed to be encoded in the audio/wav;base64 format.
+  audio_content: string;
+
+  audio_config: AudioConfig;
+}
+
+export interface TextToSpeechErrorResponse {
+  error_message: string;
+}
+
+export interface TextToSpeechServiceStub {
+  synthesizeSpeech(request: TextToSpeechRequest):
+      Observable<TextToSpeechResponse>;
+}
+
+const TTS_ENDPOINT = '/tts';
+
+@Injectable()
+export class TextToSpeechService implements TextToSpeechServiceStub {
+  constructor(private http: HttpClient) {}
+
+  synthesizeSpeech(request: TextToSpeechRequest) {
+    return this.http.get<TextToSpeechResponse>(TTS_ENDPOINT, {
+      params: {
+        text: request.text,
+        language: request.language,
+        audio_encoding: request.audio_config.audio_encoding,
+        speaking_rate: request.audio_config.speaking_rate,
+        access_token: request.access_token,
+      },
+    });
+  }
+}

--- a/webui/src/app/text-to-speech/text-to-speech.component.html
+++ b/webui/src/app/text-to-speech/text-to-speech.component.html
@@ -1,0 +1,21 @@
+<style>
+.error-message {
+    color: red;
+    font-size: 20px;
+}
+</style>
+
+<audio #ttsAudio></audio>
+
+<div
+    *ngIf="audioPlaying"
+    class="audio-playing">
+  🔊
+</div>
+
+<div
+    *ngIf="errorMessage !== null"
+    class="error-message">
+  <span>TTS error:</span>
+  {{errorMessage}}
+</div>

--- a/webui/src/app/text-to-speech/text-to-speech.component.spec.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.spec.ts
@@ -1,0 +1,151 @@
+/** Unit tests for TextToSpeechComponent. */
+import {HttpClientModule} from '@angular/common/http';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {of, Subject, throwError} from 'rxjs';
+
+import {TextEntryEndEvent} from '../types/text-entry';
+
+import {TextToSpeechComponent} from './text-to-speech.component';
+import {TextToSpeechModule} from './text-to-speech.module';
+
+describe('TextToSpeechCmponent', () => {
+  let fixture: ComponentFixture<TextToSpeechComponent>;
+  let component: TextToSpeechComponent;
+  let textEntryEndSubject: Subject<TextEntryEndEvent>;
+
+  beforeEach(async () => {
+    textEntryEndSubject = new Subject();
+    // textToSpeechServiceForTest = new TextToSpeechServiceForTest();
+    await TestBed
+        .configureTestingModule({
+          imports: [TextToSpeechModule, HttpClientModule],
+          declarations: [TextToSpeechComponent],
+        })
+        .compileComponents();
+    fixture = TestBed.createComponent(TextToSpeechComponent);
+    component = fixture.componentInstance;
+    component.textEntryEndSubject = textEntryEndSubject;
+    fixture.detectChanges();
+    component.accessToken = 'test_token';
+    jasmine.getEnv().allowRespy(true);
+  });
+
+  it('Initially shows no error message', () => {
+    const errorMessage = fixture.nativeElement.querySelector('.error-message');
+    expect(errorMessage).toBeNull();
+  });
+
+  it('Initially audio element src is empty string', () => {
+    const audioElement =
+        fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+    expect(audioElement.src).toEqual('');
+  });
+
+  it('On textEntryEndEvent with TTS audio config, sets audio element src',
+     async () => {
+       const audioElement =
+           fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+       spyOn(component.textToSpeechService, 'synthesizeSpeech')
+           .and.returnValue(of({
+             audio_content: '0123abcd',
+             audio_config: {
+               audio_encoding: 'LINEAR16',
+               speaking_rate: 1.0,
+             }
+           }));
+       textEntryEndSubject.next({
+         text: 'hi, there',
+         timestampMillis: new Date().getTime(),
+         isFinal: true,
+         inAppTextToSpeechAudioConfig: {
+           volume_gain_db: 0,
+         }
+       });
+       await fixture.whenStable();
+       expect(audioElement.src).toEqual('data:audio/wav;base64,0123abcd');
+     });
+
+  it('Empty audio content: shows error message', async () => {
+    const audioElement =
+        fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+    spyOn(component.textToSpeechService, 'synthesizeSpeech')
+        .and.returnValue(of({
+          audio_content: '',
+          audio_config: {
+            audio_encoding: 'LINEAR16',
+            speaking_rate: 1.0,
+          }
+        }));
+    textEntryEndSubject.next({
+      text: 'hi, there',
+      timestampMillis: new Date().getTime(),
+      isFinal: true,
+      inAppTextToSpeechAudioConfig: {
+        volume_gain_db: 0,
+      }
+    });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const errorMessage =
+        fixture.nativeElement.querySelector('.error-message') as HTMLDivElement;
+    expect(errorMessage.innerText).toEqual('TTS error: audio is empty');
+  });
+
+  it('textEntryEndEvent without audio config does not set audio element',
+     async () => {
+       const audioElement =
+           fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+       textEntryEndSubject.next({
+         text: 'hi, there',
+         timestampMillis: new Date().getTime(),
+         isFinal: true,
+       });
+       await fixture.whenStable();
+       expect(audioElement.src).toEqual('');
+     });
+
+  it('textEntryEndEvent with audio config without access token sets error message',
+     async () => {
+       component.accessToken = '';
+       textEntryEndSubject.next({
+         text: 'hi, there',
+         timestampMillis: new Date().getTime(),
+         isFinal: true,
+         inAppTextToSpeechAudioConfig: {volume_gain_db: 0}
+       });
+       await fixture.whenStable();
+       fixture.detectChanges();
+       const errorMessage = fixture.nativeElement.querySelector(
+                                '.error-message') as HTMLDivElement;
+       expect(errorMessage.innerText).toEqual('TTS error: no access token');
+     });
+
+  for (const [errorObject, expectedErrorText] of [
+           [{error: {error_message: 'foo error'}}, 'TTS error: foo error'],
+           [{statusText: 'bar error'}, 'TTS error: bar error']] as
+       Array<[any, string]>) {
+    it(`synthesizeSpeech call error shows error message: ${expectedErrorText}`,
+       async () => {
+         const audioElement =
+             fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+         spyOn(component.textToSpeechService, 'synthesizeSpeech')
+             .and.callFake(() => {
+               return throwError(errorObject);
+             });
+         textEntryEndSubject.next({
+           text: 'hi, there',
+           timestampMillis: new Date().getTime(),
+           isFinal: true,
+           inAppTextToSpeechAudioConfig: {
+             volume_gain_db: 0,
+           }
+         });
+         await fixture.whenStable();
+         fixture.detectChanges();
+         expect(audioElement.src).toEqual('');
+         const errorMessage = fixture.nativeElement.querySelector(
+                                  '.error-message') as HTMLDivElement;
+         expect(errorMessage.innerText).toEqual(expectedErrorText);
+       });
+  }
+});

--- a/webui/src/app/text-to-speech/text-to-speech.component.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.ts
@@ -1,6 +1,6 @@
 /** Component for in-app text-to-speech audio output. */
 import {HttpErrorResponse} from '@angular/common/http';
-import {Component, ElementRef, Input, OnInit, QueryList, ViewChildren} from '@angular/core';
+import {ChangeDetectorRef, Component, ElementRef, Input, OnInit, QueryList, ViewChildren} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {TextToSpeechErrorResponse, TextToSpeechService} from '../text-to-speech-service';
@@ -24,7 +24,9 @@ export class TextToSpeechComponent implements OnInit {
   errorMessage?: string|null = null;
   audioPlaying: boolean = false;
 
-  constructor(public textToSpeechService: TextToSpeechService) {}
+  constructor(
+      public textToSpeechService: TextToSpeechService,
+      private cdr: ChangeDetectorRef) {}
 
   ngOnInit() {
     this.textEntryEndSubject.subscribe(event => {
@@ -75,6 +77,7 @@ export class TextToSpeechComponent implements OnInit {
               ttsAudioElement.src =
                   'data:audio/wav;base64,' + data.audio_content;
               ttsAudioElement.play();
+              this.cdr.detectChanges();
             },
             (error: HttpErrorResponse) => {
               if (error.error &&
@@ -84,6 +87,7 @@ export class TextToSpeechComponent implements OnInit {
               } else {
                 this.errorMessage = `${error.statusText}`;
               }
+              this.cdr.detectChanges();
             });
   }
 }

--- a/webui/src/app/text-to-speech/text-to-speech.component.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.ts
@@ -1,0 +1,89 @@
+/** Component for in-app text-to-speech audio output. */
+import {HttpErrorResponse} from '@angular/common/http';
+import {Component, ElementRef, Input, OnInit, QueryList, ViewChildren} from '@angular/core';
+import {Subject} from 'rxjs';
+
+import {TextToSpeechErrorResponse, TextToSpeechService} from '../text-to-speech-service';
+import {TextEntryEndEvent} from '../types/text-entry';
+
+const DEFAULT_LANGUAGE_CODE = 'en-US';
+const DEFAULT_AUDIO_ENCODING = 'LINEAR16';
+
+@Component({
+  selector: 'app-text-to-speech-component',
+  templateUrl: './text-to-speech.component.html',
+  providers: [TextToSpeechService],
+})
+export class TextToSpeechComponent implements OnInit {
+  @Input() textEntryEndSubject!: Subject<TextEntryEndEvent>;
+  @Input() accessToken!: string;
+
+  @ViewChildren('ttsAudio')
+  ttsAudioElements!: QueryList<ElementRef<HTMLAudioElement>>;
+
+  errorMessage?: string|null = null;
+  audioPlaying: boolean = false;
+
+  constructor(public textToSpeechService: TextToSpeechService) {}
+
+  ngOnInit() {
+    this.textEntryEndSubject.subscribe(event => {
+      // TODO(cais): Add unit test.
+      if (!event.isFinal || event.inAppTextToSpeechAudioConfig === undefined) {
+        return;
+      }
+      const {volume_gain_db} = event.inAppTextToSpeechAudioConfig;
+      if (volume_gain_db !== undefined && volume_gain_db !== 0) {
+        // TODO(#49): Support volume control.
+        throw new Error('Volume gain adjustment is not implemented yet.');
+      }
+      this.sendTextToSpeechRequest(event.text);
+    });
+  }
+
+  sendTextToSpeechRequest(text: string) {
+    if (this.accessToken.length === 0) {
+      this.errorMessage = 'no access token';
+      return;
+    }
+    this.textToSpeechService
+        .synthesizeSpeech({
+          text,
+          language: DEFAULT_LANGUAGE_CODE,
+          audio_config: {
+            audio_encoding: DEFAULT_AUDIO_ENCODING,
+            speaking_rate: 1.0,
+          },
+          access_token: this.accessToken,
+        })
+        .subscribe(
+            data => {
+              this.errorMessage = null;
+              const ttsAudioElement = this.ttsAudioElements.first.nativeElement;
+              if (!ttsAudioElement.onplay) {
+                ttsAudioElement.onplay = () => {
+                  this.audioPlaying = true;
+                };
+                ttsAudioElement.onended = () => {
+                  this.audioPlaying = false;
+                };
+              }
+              if (!data.audio_content) {
+                this.errorMessage = 'audio is empty';
+                return;
+              }
+              ttsAudioElement.src =
+                  'data:audio/wav;base64,' + data.audio_content;
+              ttsAudioElement.play();
+            },
+            (error: HttpErrorResponse) => {
+              if (error.error &&
+                  (error.error as TextToSpeechErrorResponse).error_message) {
+                this.errorMessage =
+                    (error.error as TextToSpeechErrorResponse).error_message;
+              } else {
+                this.errorMessage = `${error.statusText}`;
+              }
+            });
+  }
+}

--- a/webui/src/app/text-to-speech/text-to-speech.module.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+
+import {TextToSpeechComponent} from './text-to-speech.component';
+
+@NgModule({
+  declarations: [TextToSpeechComponent],
+  imports: [
+    BrowserModule,
+  ],
+  exports: [TextToSpeechComponent],
+})
+export class TextToSpeechModule {
+}

--- a/webui/src/app/types/text-entry.ts
+++ b/webui/src/app/types/text-entry.ts
@@ -1,5 +1,7 @@
 /** Types related to text entry events. */
 
+import {TextToSpeechAudioConfig} from './text-to-speech';
+
 /**
  * An event that signifies the beginning of a text entry, i.e., when the
  * users starts typing to compose a message.
@@ -37,4 +39,9 @@ export interface TextEntryEndEvent {
 
   // Sequence of automatically injected keys;
   injectedKeys?: string[];
+
+  // If specified, will trigger in-app text-to-speech, i.e., text-to-speech
+  // output from this app per se, not text-to-speech output in another app like
+  // the text editor tethereed to this app.
+  inAppTextToSpeechAudioConfig?: TextToSpeechAudioConfig;
 }

--- a/webui/src/app/types/text-to-speech.ts
+++ b/webui/src/app/types/text-to-speech.ts
@@ -2,6 +2,7 @@
 
 export interface TextToSpeechAudioConfig {
   // Volume gain in dB. 0 or undefined corresponds to the original volume (no
-  // gain).
+  // gain). A positive value means a louder than original; a negative value
+  // means softer than original.
   volume_gain_db?: number;
 }

--- a/webui/src/app/types/text-to-speech.ts
+++ b/webui/src/app/types/text-to-speech.ts
@@ -1,0 +1,7 @@
+/** Types related to text-to-speech audio output. */
+
+export interface TextToSpeechAudioConfig {
+  // Volume gain in dB. 0 or undefined corresponds to the original volume (no
+  // gain).
+  volume_gain_db?: number;
+}


### PR DESCRIPTION
- Implements the "speak" button
- Clicking the button triggers a call to the /tts route to retrieve the
  audio waveform
  - This supports custom voices and flexible volume control
- The base64-encoded audio waveform is then attached to the src
  attribute of a hidden HTML audio element to enable audio playback
- Error messages are displayed on the top-right corner of the UI
  when error occur