### PR TITLE
[WebUI] Refactor keyboard listening logic; Add keyword-based AE

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -23,9 +23,9 @@
   color: #eee;
   display: flex;
   font-size: 22px;
-  height: 65px;
+  height: 63px;
   line-height: 32px;
-  margin: 5px;
+  margin: 4px 5px;
   min-width: 300px;
   padding-left: 5px;
   white-space: nowrap;
@@ -99,7 +99,7 @@
   color: #111;
   display: inline;
   float: right;
-  height: 67px;
+  height: 64px;
   font-size: 20px;
   margin-left: 5px;
   width: 80px;

--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -146,3 +146,10 @@
     </div>
   </div>
 </div>
+
+<app-spell-component
+    *ngIf="abbreviation !== null && (state === 'SPELLING' || state === 'CHOOSING_EXPANSION')"
+    class="spell-component"
+    [originalAbbreviationSpec]="abbreviation!"
+    (newAbbreviationSpec)="onNewAbbreviationSpec($event)"
+></app-spell-component>

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -4,6 +4,7 @@ import {HttpClientModule} from '@angular/common/http';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {of, Subject} from 'rxjs';
+import {createUuid} from 'src/utils/uuid';
 
 import * as cefSharp from '../../utils/cefsharp';
 import {repeatVirtualKey, VIRTUAL_KEY} from '../external/external-events.component';
@@ -11,7 +12,7 @@ import {TestListener} from '../test-utils/test-cefsharp-listener';
 import {AbbreviationSpec, InputAbbreviationChangedEvent} from '../types/abbreviation';
 import {TextEntryEndEvent} from '../types/text-entry';
 
-import {AbbreviationComponent} from './abbreviation.component';
+import {AbbreviationComponent, State} from './abbreviation.component';
 import {AbbreviationModule} from './abbreviation.module';
 
 describe('AbbreviationComponent', () => {
@@ -85,6 +86,7 @@ describe('AbbreviationComponent', () => {
            ],
            readableString: 'ace',
            precedingText,
+           lineageId: createUuid(),
          };
          abbreviationExpansionTriggers.next({
            abbreviationSpec,
@@ -101,6 +103,7 @@ describe('AbbreviationComponent', () => {
   it('displays expansion options when available', () => {
     fixture.componentInstance.abbreviationOptions =
         ['what time is it', 'we took it in'];
+    fixture.componentInstance.state = State.CHOOSING_EXPANSION;
     fixture.detectChanges();
     const expansions =
         fixture.debugElement.queryAll(By.css('.abbreviation-expansion'));
@@ -117,6 +120,7 @@ describe('AbbreviationComponent', () => {
   it('calls updateButtonBoxes when expansion options become available',
      async () => {
        fixture.componentInstance.abbreviationOptions = ['what time is it'];
+       fixture.componentInstance.state = State.CHOOSING_EXPANSION;
        fixture.detectChanges();
        await fixture.whenStable();
        const calls = testListener.updateButtonBoxesCalls;
@@ -137,9 +141,11 @@ describe('AbbreviationComponent', () => {
                                             isKeyword: false,
                                           })),
          readableString: 'wtii',
-         triggerKeys: [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.SPACE]
+         triggerKeys: [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.SPACE],
+         lineageId: createUuid(),
        };
        fixture.componentInstance.abbreviationOptions = ['what time is it'];
+       fixture.componentInstance.state = State.CHOOSING_EXPANSION;
        fixture.detectChanges();
        const selectButtons =
            fixture.debugElement.queryAll(By.css('.select-button'));
@@ -160,8 +166,10 @@ describe('AbbreviationComponent', () => {
       readableString: 'wtii',
       triggerKeys: [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.SPACE],
       eraserSequence: repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 8),
+      lineageId: createUuid(),
     };
     fixture.componentInstance.abbreviationOptions = ['what time is it'];
+    fixture.componentInstance.state = State.CHOOSING_EXPANSION;
     fixture.detectChanges();
     const selectButtons =
         fixture.debugElement.queryAll(By.css('.select-button'));
@@ -187,10 +195,12 @@ describe('AbbreviationComponent', () => {
                                          isKeyword: false,
                                        })),
       readableString: 'wtii',
-      triggerKeys: [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.SPACE]
+      triggerKeys: [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.SPACE],
+      lineageId: createUuid(),
     };
     fixture.componentInstance.abbreviationOptions =
         ['what time is it', 'we took it in'];
+    fixture.componentInstance.state = State.CHOOSING_EXPANSION;
     fixture.detectChanges();
     const selectButtons =
         fixture.debugElement.queryAll(By.css('.select-button'));
@@ -199,6 +209,7 @@ describe('AbbreviationComponent', () => {
     expect(events[0].text).toEqual('we took it in');
     expect(events[0].isFinal).toBeTrue();
     expect(events[0].timestampMillis).toBeGreaterThan(0);
+    expect(events[0].inAppTextToSpeechAudioConfig).toBeUndefined();
     // "wtii" as a length 4; the trigger keys has a lenght 2; additionally,
     // there is the selection key at the end.
     const expectedNumKeypresses = 4 + 2 + 1;
@@ -241,10 +252,48 @@ describe('AbbreviationComponent', () => {
              precedingText,
              readableString: 'hay',
              eraserSequence: repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5),
+             lineageId: abbreviationChangeEvents[0].abbreviationSpec.lineageId,
            },
            requestExpansion: true,
          };
          expect(abbreviationChangeEvents).toEqual([expected]);
        });
   }
+
+  it('does not display SpellComponent initially', () => {
+    const spellComponents =
+        fixture.debugElement.queryAll(By.css('app-spell-component'));
+    expect(spellComponents).toEqual([]);
+  });
+
+  it('displays SpellComponent given abbreviaton and state', () => {
+    const abbreviationSpec: AbbreviationSpec = {
+      tokens: [
+        {
+          value: 'h',
+          isKeyword: false,
+        },
+        {
+          value: 'a',
+          isKeyword: false,
+        },
+        {
+          value: 'y',
+          isKeyword: false,
+        }
+      ],
+      readableString: 'hay',
+      lineageId: createUuid(),
+    };
+    abbreviationExpansionTriggers.next({
+      abbreviationSpec,
+      requestExpansion: true,
+    });
+    fixture.componentInstance.state = State.CHOOSING_EXPANSION;
+    fixture.detectChanges();
+
+    const spellComponents =
+        fixture.debugElement.queryAll(By.css('app-spell-component'));
+    expect(spellComponents.length).toEqual(1);
+  });
 });

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -19,6 +19,7 @@ describe('AbbreviationComponent', () => {
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
   let fixture: ComponentFixture<AbbreviationComponent>;
   let testListener: TestListener;
+  let abbreviationChangeEvents: InputAbbreviationChangedEvent[];
 
   beforeEach(async () => {
     testListener = new TestListener();
@@ -30,6 +31,9 @@ describe('AbbreviationComponent', () => {
         })
         .compileComponents();
     abbreviationExpansionTriggers = new Subject();
+    abbreviationChangeEvents = [];
+    abbreviationExpansionTriggers.subscribe(
+        (event) => abbreviationChangeEvents.push(event));
     textEntryEndSubject = new Subject();
     fixture = TestBed.createComponent(AbbreviationComponent);
     fixture.componentInstance.abbreviationExpansionTriggers =
@@ -39,7 +43,9 @@ describe('AbbreviationComponent', () => {
   });
 
   afterAll(async () => {
-    delete (window as any)[cefSharp.BOUND_LISTENER_NAME];
+    if (cefSharp.BOUND_LISTENER_NAME in (window as any)) {
+      delete (window as any)[cefSharp.BOUND_LISTENER_NAME];
+    }
   });
 
   it('initially displays no abbreviation options', () => {
@@ -78,13 +84,14 @@ describe('AbbreviationComponent', () => {
              }
            ],
            readableString: 'ace',
+           precedingText,
          };
          abbreviationExpansionTriggers.next({
            abbreviationSpec,
            requestExpansion: true,
          });
          expect(spy).toHaveBeenCalledOnceWith(
-             contextStrings.join('|'), abbreviationSpec, 128, undefined);
+             contextStrings.join('|'), abbreviationSpec, 128, precedingText);
          expect(fixture.componentInstance.abbreviationOptions).toEqual([
            'how are you', 'how about you'
          ]);
@@ -198,4 +205,46 @@ describe('AbbreviationComponent', () => {
     expect(events[0].numKeypresses).toEqual(expectedNumKeypresses);
     expect(events[0].numHumanKeypresses).toEqual(expectedNumKeypresses);
   });
+
+  for (const [keySequence, precedingText] of [
+           [['h', 'a', 'y', ' ', ' '], undefined],
+           [[' ', 'h', 'a', 'y', ' ', ' '], undefined],
+           [['a', ' ', 'h', 'a', 'y', ' ', ' '], 'a'],
+  ] as Array<[string[], string | undefined]>) {
+    it(`Double space triggers abbreviation expansion, key codes = ${
+           keySequence}`,
+       () => {
+         spyOn(
+             fixture.componentInstance.speakFasterService, 'expandAbbreviation')
+             .and.returnValue(of({
+               exactMatches: ['how are you', 'how about you'],
+             }));
+         fixture.componentInstance.contextStrings = ['hello'];
+         fixture.componentInstance.listenToKeypress(
+             keySequence, keySequence.join(''));
+         const expected: InputAbbreviationChangedEvent = {
+           abbreviationSpec: {
+             tokens: [
+               {
+                 value: 'h',
+                 isKeyword: false,
+               },
+               {
+                 value: 'a',
+                 isKeyword: false,
+               },
+               {
+                 value: 'y',
+                 isKeyword: false,
+               }
+             ],
+             precedingText,
+             readableString: 'hay',
+             eraserSequence: repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5),
+           },
+           requestExpansion: true,
+         };
+         expect(abbreviationChangeEvents).toEqual([expected]);
+       });
+  }
 });

--- a/webui/src/app/abbreviation/abbreviation.module.ts
+++ b/webui/src/app/abbreviation/abbreviation.module.ts
@@ -1,12 +1,15 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
+import {SpellModule} from '../spell/spell.module';
+
 import {AbbreviationComponent} from './abbreviation.component';
 
 @NgModule({
   declarations: [AbbreviationComponent],
   imports: [
     BrowserModule,
+    SpellModule,
   ],
   exports: [AbbreviationComponent],
 })

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -28,8 +28,7 @@ app-text-to-speech-component {
   <app-external-events-component
       #externalEvents
       [textEntryBeginSubject]="textEntryBeginSubject"
-      [textEntryEndSubject]="textEntryEndSubject"
-      [abbreviationExpansionTriggers]="abbreviationExpansionTriggers">
+      [textEntryEndSubject]="textEntryEndSubject">
   </app-external-events-component>
 
   <app-metrics-component

--- a/webui/src/app/context/context.component.ts
+++ b/webui/src/app/context/context.component.ts
@@ -49,7 +49,6 @@ export class ContextComponent implements OnInit {
             isTts: true,
             isHardcoded: false,
           }));
-      this.emitContextStringsSelected();
     });
   }
 

--- a/webui/src/app/context/context.component.ts
+++ b/webui/src/app/context/context.component.ts
@@ -49,6 +49,7 @@ export class ContextComponent implements OnInit {
             isTts: true,
             isHardcoded: false,
           }));
+      this.emitContextStringsSelected();
     });
   }
 

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -18,6 +18,7 @@
 
 import {Component, Input, OnInit} from '@angular/core';
 import {Subject} from 'rxjs';
+import {keySequenceEndsWith} from 'src/utils/text-utils';
 
 import {AbbreviationSpec, InputAbbreviationChangedEvent} from '../types/abbreviation';
 import {TextEntryBeginEvent, TextEntryEndEvent} from '../types/text-entry';
@@ -97,13 +98,6 @@ export const PUNCTUATION: VIRTUAL_KEY[] = [
 ];
 
 export const TTS_TRIGGER_COMBO_KEY: string[] = [VIRTUAL_KEY.LCTRL, 'q'];
-// Abbreviation expansion can be triggered by entering the abbreviation followed
-// by typing two consecutive spaces in the external app.
-// TODO(#49): This can be generalized and made configurable.
-// TODO(#49): Explore continuous AE without explicit trigger, perhaps
-// added by heuristics for detecting abbreviations vs. words.
-export const ABBRVIATION_EXPANSION_TRIGGER_COMBO_KEY: string[] =
-    [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.SPACE];
 
 function getKeyFromVirtualKeyCode(vkCode: number): string|null {
   if (vkCode >= 48 && vkCode <= 57) {
@@ -198,22 +192,14 @@ export function getNumOrPunctuationLiteral(
   }
 }
 
-function allItemsEqual(array1: string[], array2: string[]): boolean {
-  if (array1.length !== array2.length) {
-    return false;
-  }
-  for (let i = 0; i < array1.length; ++i) {
-    if (array1[i] !== array2[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 /** Repeat a virtual key a given number of times. */
 export function repeatVirtualKey(key: VIRTUAL_KEY, num: number): VIRTUAL_KEY[] {
   return Array(num).fill(key);
 }
+
+
+export type KeypressListener =
+    (keySequence: string[], reconstructedText: string) => void;
 
 @Component({
   selector: 'app-external-events-component',
@@ -222,8 +208,8 @@ export function repeatVirtualKey(key: VIRTUAL_KEY, num: number): VIRTUAL_KEY[] {
 export class ExternalEventsComponent implements OnInit {
   @Input() textEntryBeginSubject!: Subject<TextEntryBeginEvent>;
   @Input() textEntryEndSubject!: Subject<TextEntryEndEvent>;
-  @Input()
-  abbreviationExpansionTriggers!: Subject<InputAbbreviationChangedEvent>;
+
+  private static keypressListeners: KeypressListener[] = [];
 
   private previousKeypressTimeMillis: number|null = null;
   // Number of keypresses effected through eye gaze (as determiend by
@@ -249,6 +235,24 @@ export class ExternalEventsComponent implements OnInit {
     });
   }
 
+  /**
+   * Register a listener for keypresses.
+   * Repeated registrations of the same listener function are ignored.
+   * @param listener
+   */
+  public static registerKeypressListener(listener: KeypressListener) {
+    if (ExternalEventsComponent.keypressListeners.indexOf(listener) !== -1) {
+      // Ignore repeated registration.
+      return;
+    }
+    ExternalEventsComponent.keypressListeners.push(listener);
+  }
+
+  /** Clear all registered keypress listeners. */
+  public static clearKeypressListeners() {
+    ExternalEventsComponent.keypressListeners.splice(0);
+  }
+
   public externalKeypressHook(vkCode: number) {
     const virtualKey = getKeyFromVirtualKeyCode(vkCode);
     if (virtualKey === null) {
@@ -262,7 +266,7 @@ export class ExternalEventsComponent implements OnInit {
       this.numGazeKeypresses++;
     }
     this.previousKeypressTimeMillis = nowMillis;
-    if (this.keySequenceEndsWith(TTS_TRIGGER_COMBO_KEY)) {
+    if (keySequenceEndsWith(this.keySequence, TTS_TRIGGER_COMBO_KEY)) {
       // A TTS action has been triggered.
       console.log(`TTS event: "${this._text}"`);
       this.textEntryEndSubject.next({
@@ -324,41 +328,8 @@ export class ExternalEventsComponent implements OnInit {
       this.textEntryBeginSubject.next({timestampMillis: Date.now()});
     }
 
-    if (this.keySequenceEndsWith(ABBRVIATION_EXPANSION_TRIGGER_COMBO_KEY) &&
-        this._text.trim().length > 0) {
-      let spaceIndex = this._text.length - 1;
-      while (this._text[spaceIndex] === ' ' && spaceIndex >= 0) {
-        spaceIndex--;
-      }
-      while (this._text[spaceIndex] !== ' ' && spaceIndex >= 0) {
-        spaceIndex--;
-      }
-      let text = this._text.slice(spaceIndex + 1);
-      let precedingText: string|undefined =
-          spaceIndex > 0 ? this._text.slice(0, spaceIndex).trim() : undefined;
-      if (precedingText === '') {
-        precedingText = undefined;
-      }
-      const eraserLength = text.length;
-      text = text.trim();
-      if (text.length > 0) {
-        // An abbreviation expansion has been triggered.
-        // TODO(#49): Support keywords in abbreviation (e.g.,
-        // "this event is going very well" --> "this e igvw")
-        const abbreviationSpec: AbbreviationSpec = {
-          tokens: text.split('').map(char => ({
-                                       value: char,
-                                       isKeyword: false,
-                                     })),
-          readableString: text,
-          eraserSequence: repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, eraserLength),
-          precedingText,
-        };
-        console.log('Abbreviation expansion triggered:', abbreviationSpec);
-        this.abbreviationExpansionTriggers.next(
-            {abbreviationSpec, requestExpansion: true});
-        return;
-      }
+    for (const listener of ExternalEventsComponent.keypressListeners) {
+      listener(this.keySequence, this._text);
     }
 
     // TODO(cais): Take care of the up and down arrow keys.
@@ -368,13 +339,6 @@ export class ExternalEventsComponent implements OnInit {
     console.log(
         `externalKeypressHook(): virtualKey=${virtualKey}; ` +
         `text="${this._text}"; cursorPos=${this.cursorPos}`);
-  }
-
-  private keySequenceEndsWith(suffix: string[]): boolean {
-    return this.keySequence.length > suffix.length &&
-        allItemsEqual(
-               this.keySequence.slice(this.keySequence.length - suffix.length),
-               suffix);
   }
 
   private insertCharAsCursorPos(char: string) {

--- a/webui/src/app/spell/spell.component.html
+++ b/webui/src/app/spell/spell.component.html
@@ -94,5 +94,4 @@
     class="done-button"
     (click)="onDoneButtonClicked($event)">
   Done
-  <span>(Ctrl+s)</span>
 </button>

--- a/webui/src/app/spell/spell.component.html
+++ b/webui/src/app/spell/spell.component.html
@@ -1,0 +1,98 @@
+<style>
+
+:host {
+  box-sizing: border-box;
+  color: #EEE;
+  display: block;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 24px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.abbreviated-token {
+  background: #333;
+  border: 2px solid #888;
+  border-radius: 5px;
+  color: #eee;
+  display: inline-block;
+  font-size: 24px;
+  line-height: 24px;
+  margin: 10px 0 10px 10px;
+  min-width: 75px;
+  padding: 15px;
+  vertical-align: middle;;
+  width: fit-content;
+}
+
+.button-shortcut-key {
+  font-size: 18px;
+  color: #888;
+}
+
+.done-button {
+  background: #333;
+  border: 2px solid #888;
+  border-radius: 5px;
+  color: #eee;
+  display: inline-block;
+  font-size: 24px;
+  line-height: 24px;
+  margin: 10px;
+  min-width: 75px;
+  padding: 15px;
+  vertical-align: middle;;
+  width: fit-content;
+}
+
+.spell-input {
+  border: 2px solid #888;
+  border-radius: 3px;
+  font-size: 32px;
+  height: 46px;
+  margin: 6px 8px;
+  padding: 0 4px 8px 4px;
+  text-overflow: fade;
+  width: 120px;  /* TODO(cais): Make width adaptive. */
+}
+
+.spell-item-container {
+  display: inline-block;
+}
+
+.spell-label {
+  display: inline-block;
+  margin-left: 8px;
+  width: 78px;
+}
+
+</style>
+
+<div class=spell-label>Spell:</div>
+
+<div
+    *ngFor="let abbreviationChar of originalAbbreviationChars; let i = index"
+    class="spell-item-container">
+  <button
+      *ngIf="!(spellIndex !== null && i === spellIndex)"
+      #clickableButton
+      class="abbreviated-token"
+      (click)="onTokenButtonClicked($event, i)">
+    <div class="abbreviated-token-text">{{stringAtIndex(i)}}</div>
+  </button>
+
+  <input
+      *ngIf="spellIndex !== null && i === spellIndex"
+      class="spell-input"
+      [value]="tokenSpellingInput" />
+
+</div>
+
+<button
+    *ngIf="spellIndex !== null"
+    #clickableButton
+    class="done-button"
+    (click)="onDoneButtonClicked($event)">
+  Done
+  <span>(Ctrl+s)</span>
+</button>

--- a/webui/src/app/spell/spell.component.spec.ts
+++ b/webui/src/app/spell/spell.component.spec.ts
@@ -1,0 +1,366 @@
+/** Unit tests for the SpellComponent. */
+import {HttpClientModule} from '@angular/common/http';
+import {SimpleChange} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
+import {createUuid} from 'src/utils/uuid';
+
+import * as cefSharp from '../../utils/cefsharp';
+import {getVirtualkeyCode, repeatVirtualKey, VIRTUAL_KEY} from '../external/external-events.component';
+import {TestListener} from '../test-utils/test-cefsharp-listener';
+import {AbbreviationSpec, AbbreviationToken, InputAbbreviationChangedEvent} from '../types/abbreviation';
+
+import {SpellComponent, SpellingState} from './spell.component';
+import {SpellModule} from './spell.module';
+
+describe('SpellComponent', () => {
+  let abbreviationExpansionTriggers: Subject<InputAbbreviationChangedEvent>;
+  let fixture: ComponentFixture<SpellComponent>;
+  let testListener: TestListener;
+  let abbreviationChangeEvents: InputAbbreviationChangedEvent[];
+
+  beforeEach(async () => {
+    testListener = new TestListener();
+    (window as any)[cefSharp.BOUND_LISTENER_NAME] = testListener;
+    await TestBed
+        .configureTestingModule({
+          imports: [SpellModule, HttpClientModule],
+          declarations: [SpellComponent],
+        })
+        .compileComponents();
+    abbreviationExpansionTriggers = new Subject();
+    abbreviationChangeEvents = [];
+    abbreviationExpansionTriggers.subscribe(
+        (event) => abbreviationChangeEvents.push(event));
+    fixture = TestBed.createComponent(SpellComponent);
+  });
+
+  afterEach(() => {
+    if ((window as any).externalKeypressHook !== undefined) {
+      delete (window as any).externalKeypressHook;
+    }
+  });
+
+  function getAbbreviationSpecForTest(initialLetters: string[]):
+      AbbreviationSpec {
+    const tokens: AbbreviationToken[] = [];
+    for (const letter of initialLetters) {
+      tokens.push({
+        value: letter,
+        isKeyword: false,
+      });
+    }
+    return {
+      tokens,
+      readableString: initialLetters.join(''),
+      eraserSequence:
+          repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, initialLetters.length + 2),
+      lineageId: createUuid(),
+    };
+  }
+
+  it('initial state is CHOOSING_TOKEN', () => {
+    expect(fixture.componentInstance.state)
+        .toEqual(SpellingState.CHOOSING_TOKEN);
+  });
+
+  it('displays initial letters given original abbreviaton spec', () => {
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.state)
+        .toEqual(SpellingState.SPELLING_TOKEN);
+    const tokenButtons =
+        fixture.debugElement.queryAll(By.css('.abbreviated-token'));
+    // Spelling has started on 'b' (the 2nd letter). There should be buttons
+    // for the two remaining letters ('a' and 'c').
+    expect(tokenButtons.length).toEqual(2);
+    expect(tokenButtons[0].nativeElement.innerText).toEqual('a');
+    expect(tokenButtons[1].nativeElement.innerText).toEqual('c');
+    const spellInputs = fixture.debugElement.queryAll(By.css('.spell-input'));
+    expect(spellInputs.length).toEqual(1);
+    expect(spellInputs[0].nativeElement.value).toEqual('b');
+  });
+
+  it('typing letters for spelled word populates spell input', () => {
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i'], 'abc  bi');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't'], 'abc  bit');
+    fixture.detectChanges();
+
+    const spellInput = fixture.debugElement.query(By.css('.spell-input'));
+    expect(spellInput.nativeElement.value).toEqual('bit');
+  });
+
+  it('typing with Backspace for spelled word populates spell input', () => {
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i'], 'abc  bi');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', VIRTUAL_KEY.BACKSPACE], 'abc  b');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', VIRTUAL_KEY.BACKSPACE, 'y'],
+        'abc  by');
+    fixture.detectChanges();
+
+    const spellInput = fixture.debugElement.query(By.css('.spell-input'));
+    expect(spellInput.nativeElement.value).toEqual('by');
+  });
+
+  for (const triggerKey of [' ', VIRTUAL_KEY.ENTER]) {
+    it(`typing followed by space triggers new abbreviation ` +
+           `expansion: trigger key = ${triggerKey}`,
+       () => {
+         const emittedAbbreviationSpecs: AbbreviationSpec[] = [];
+         fixture.componentInstance.newAbbreviationSpec.subscribe(
+             spec => emittedAbbreviationSpecs.push(spec));
+         fixture.componentInstance.originalAbbreviationSpec =
+             getAbbreviationSpecForTest(['a', 'b', 'c']);
+         fixture.componentInstance.spellIndex = 1;
+         fixture.detectChanges();
+         fixture.componentInstance.listenToKeypress(
+             ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+         fixture.componentInstance.listenToKeypress(
+             ['a', 'b', 'c', ' ', ' ', 'b', 'i'], 'abc  bi');
+         fixture.componentInstance.listenToKeypress(
+             ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't'], 'abc  bit');
+         const finalText =
+             'abc  bit' + (triggerKey === VIRTUAL_KEY.ENTER ? '\n' : ' ');
+         fixture.componentInstance.listenToKeypress(
+             ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't', triggerKey], finalText);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.state).toEqual(SpellingState.DONE);
+         expect(fixture.componentInstance.spelledWords).toEqual([
+           null, 'bit', null
+         ]);
+         expect(emittedAbbreviationSpecs.length).toEqual(1);
+         expect(emittedAbbreviationSpecs[0].tokens.length).toEqual(3);
+         expect(emittedAbbreviationSpecs[0].tokens[0]).toEqual({
+           value: 'a',
+           isKeyword: false,
+         });
+         expect(emittedAbbreviationSpecs[0].tokens[1]).toEqual({
+           value: 'bit',
+           isKeyword: true,
+         });
+         expect(emittedAbbreviationSpecs[0].tokens[2]).toEqual({
+           value: 'c',
+           isKeyword: false,
+         });
+         expect(emittedAbbreviationSpecs[0].readableString).toEqual('a bit c');
+         expect(emittedAbbreviationSpecs[0].eraserSequence)
+             .toEqual(repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5 + 4));
+         const tokenButtons =
+             fixture.debugElement.queryAll(By.css('.abbreviated-token'));
+         expect(tokenButtons.length).toEqual(3);
+         expect(tokenButtons[0].nativeElement.innerText).toEqual('a');
+         expect(tokenButtons[1].nativeElement.innerText).toEqual('bit');
+         expect(tokenButtons[2].nativeElement.innerText).toEqual('c');
+       });
+  }
+
+  it('Clicking done button triggers AE', () => {
+    const emittedAbbreviationSpecs: AbbreviationSpec[] = [];
+    fixture.componentInstance.newAbbreviationSpec.subscribe(
+        spec => emittedAbbreviationSpecs.push(spec));
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i'], 'abc  bi');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't'], 'abc  bit');
+    const doneButton = fixture.debugElement.query(By.css('.done-button'));
+    (doneButton.nativeElement as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.state).toEqual(SpellingState.DONE);
+    expect(fixture.componentInstance.spelledWords).toEqual([null, 'bit', null]);
+    expect(emittedAbbreviationSpecs.length).toEqual(1);
+    expect(emittedAbbreviationSpecs[0].tokens.length).toEqual(3);
+    expect(emittedAbbreviationSpecs[0].tokens[0]).toEqual({
+      value: 'a',
+      isKeyword: false,
+    });
+    expect(emittedAbbreviationSpecs[0].tokens[1]).toEqual({
+      value: 'bit',
+      isKeyword: true,
+    });
+    expect(emittedAbbreviationSpecs[0].tokens[2]).toEqual({
+      value: 'c',
+      isKeyword: false,
+    });
+    expect(emittedAbbreviationSpecs[0].readableString).toEqual('a bit c');
+    expect(emittedAbbreviationSpecs[0].eraserSequence)
+        .toEqual(repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5 + 4));
+  });
+
+  it(`supports spelling 2nd word after spelling the first`, () => {
+    const emittedAbbreviationSpecs: AbbreviationSpec[] = [];
+    fixture.componentInstance.newAbbreviationSpec.subscribe(
+        spec => emittedAbbreviationSpecs.push(spec));
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i'], 'abc  bi');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't'], 'abc  bit');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't', ' '], 'abc  bit ');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't', ' ', 'c'], 'abc  bit c');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't', ' ', 'c', 'o'], 'abc  bit co');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't', ' ', 'c', 'o', 'l'],
+        'abc  bit col');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't', ' ', 'c', 'o', 'l', 'd'],
+        'abc  bit cold');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't', ' ', 'c', 'o', 'l', 'd', ' '],
+        'abc  bit cold ');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.state).toEqual(SpellingState.DONE);
+    expect(fixture.componentInstance.spelledWords).toEqual([
+      null, 'bit', 'cold'
+    ]);
+    expect(emittedAbbreviationSpecs.length).toEqual(2);
+    expect(emittedAbbreviationSpecs[1].tokens.length).toEqual(3);
+    expect(emittedAbbreviationSpecs[1].tokens[0]).toEqual({
+      value: 'a',
+      isKeyword: false,
+    });
+    expect(emittedAbbreviationSpecs[1].tokens[1]).toEqual({
+      value: 'bit',
+      isKeyword: true,
+    });
+    expect(emittedAbbreviationSpecs[1].tokens[2]).toEqual({
+      value: 'cold',
+      isKeyword: true,
+    });
+    expect(emittedAbbreviationSpecs[1].readableString).toEqual('a bit cold');
+    expect(emittedAbbreviationSpecs[1].eraserSequence)
+        .toEqual(repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5 + 4 + 5));
+    const tokenButtons =
+        fixture.debugElement.queryAll(By.css('.abbreviated-token'));
+    expect(tokenButtons.length).toEqual(3);
+    expect(tokenButtons[0].nativeElement.innerText).toEqual('a');
+    expect(tokenButtons[1].nativeElement.innerText).toEqual('bit');
+    expect(tokenButtons[2].nativeElement.innerText).toEqual('cold');
+    // console.log('=== TEST ENDS');  // DEBUG
+  });
+
+  it('supports 2nd spelling after 1st one', () => {
+    console.log('=== BEGIN');  // DEBUG
+    const emittedAbbreviationSpecs: AbbreviationSpec[] = [];
+
+    fixture.componentInstance.newAbbreviationSpec.subscribe(
+        spec => emittedAbbreviationSpecs.push(spec));
+    const oldAbbreviationSpec = getAbbreviationSpecForTest(['a', 'b'])
+    fixture.componentInstance.originalAbbreviationSpec = oldAbbreviationSpec;
+    fixture.componentInstance.spellIndex = 0;
+    fixture.componentInstance.ngOnInit();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'a'], 'abc  a');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'a', 'l'], 'abc  al');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'a', 'l', 'l'], 'abc  all');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'a', 'l', 'l', ' '], 'abc  all ');
+    fixture.detectChanges();
+    // Set up the second AE spelling.
+    const newAbbreviationSpec = getAbbreviationSpecForTest(['s', 'c'])
+    fixture.componentInstance.originalAbbreviationSpec = newAbbreviationSpec;
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.ngOnChanges({
+      originalAbbreviationSpec: new SimpleChange(
+          oldAbbreviationSpec, newAbbreviationSpec, /* firstChange= */ true),
+    });
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'a', 'l', 'l', ' ', 's', 'c', ' ', ' '],
+        'abc  all sc  ');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'a', 'l', 'l', ' ', 's', 'c', ' ', ' ', 'c'],
+        'abc  all sc  c');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.state)
+        .toEqual(SpellingState.SPELLING_TOKEN);
+    const tokenButtons =
+        fixture.debugElement.queryAll(By.css('.abbreviated-token'));
+    // Spelling has started on 'c' (the 2nd letter). There should be one button
+    // for the 1st letter ('s').
+    expect(tokenButtons.length).toEqual(1);
+    expect(tokenButtons[0].nativeElement.innerText).toEqual('s');
+    const spellInputs = fixture.debugElement.queryAll(By.css('.spell-input'));
+    expect(spellInputs.length).toEqual(1);
+    expect(spellInputs[0].nativeElement.value).toEqual('c');
+  });
+
+  it('registers buttons on spelling', async () => {
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(testListener.updateButtonBoxesCalls.length)
+        .toBeGreaterThanOrEqual(1);
+    const lastCall =
+        testListener
+            .updateButtonBoxesCalls[testListener.updateButtonBoxesCalls.length - 1];
+    expect(lastCall[0].indexOf('SpellComponent_')).toEqual(0);
+    expect(lastCall[1].length).toEqual(3);
+  });
+
+  it('Clicking token button starts spelling', () => {
+    //   console.log('==== TEST BEGINS');  // DEUBG
+    const keyCodeValues: number[][] = [];
+    (window as any).externalKeypressHook = (keyCode: number[]) => {
+      keyCodeValues.push(keyCode);
+    };
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.state = SpellingState.SPELLING_TOKEN;
+    fixture.detectChanges();
+
+    const tokenButtons =
+        fixture.debugElement.queryAll(By.css('.abbreviated-token'));
+    (tokenButtons[1].nativeElement as HTMLButtonElement).click();
+    console.log('keyCodeValues:', keyCodeValues);  // DEBUG
+    expect(keyCodeValues).toEqual([getVirtualkeyCode('b')]);
+  });
+});

--- a/webui/src/app/spell/spell.component.spec.ts
+++ b/webui/src/app/spell/spell.component.spec.ts
@@ -410,7 +410,7 @@ describe('SpellComponent', () => {
     expect(keyCodeValues).toEqual([]);
   });
 
-  it('clicking token button starts spelling: no duplicate letters', () => {
+  it('clicking token button starts spelling: has duplicate letters', () => {
     const keyCodeValues: number[][] = [];
     (window as any).externalKeypressHook = (keyCode: number[]) => {
       keyCodeValues.push(keyCode);

--- a/webui/src/app/spell/spell.component.spec.ts
+++ b/webui/src/app/spell/spell.component.spec.ts
@@ -187,34 +187,35 @@ describe('SpellComponent', () => {
     fixture.componentInstance.spellIndex = 1;
     fixture.detectChanges();
     fixture.componentInstance.listenToKeypress(
-        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+        ['a', 'b', 'c', ' ', ' ', 'c'], 'abc  c');
     fixture.componentInstance.listenToKeypress(
-        ['a', 'b', 'c', ' ', ' ', 'b', 'i'], 'abc  bi');
+        ['a', 'b', 'c', ' ', ' ', 'c', 'o'], 'abc  co');
     fixture.componentInstance.listenToKeypress(
-        ['a', 'b', 'c', ' ', ' ', 'b', 'i', 't'], 'abc  bit');
+        ['a', 'b', 'c', ' ', ' ', 'c', 'o', 'l'], 'abc  col');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'c', 'o', 'l', 'd'], 'abc  cold');
     const doneButton = fixture.debugElement.query(By.css('.done-button'));
     (doneButton.nativeElement as HTMLButtonElement).click();
     fixture.detectChanges();
 
     expect(fixture.componentInstance.state).toEqual(SpellingState.DONE);
-    expect(fixture.componentInstance.spelledWords).toEqual([null, 'bit', null]);
+    expect(fixture.componentInstance.spelledWords).toEqual([
+      null, null, 'cold'
+    ]);
     expect(emittedAbbreviationSpecs.length).toEqual(1);
-    expect(emittedAbbreviationSpecs[0].tokens.length).toEqual(3);
-    expect(emittedAbbreviationSpecs[0].tokens[0]).toEqual({
-      value: 'a',
-      isKeyword: false,
-    });
-    expect(emittedAbbreviationSpecs[0].tokens[1]).toEqual({
-      value: 'bit',
-      isKeyword: true,
-    });
-    expect(emittedAbbreviationSpecs[0].tokens[2]).toEqual({
-      value: 'c',
-      isKeyword: false,
-    });
-    expect(emittedAbbreviationSpecs[0].readableString).toEqual('a bit c');
+    expect(emittedAbbreviationSpecs[0].tokens).toEqual([
+      {
+        value: 'ab',
+        isKeyword: false,
+      },
+      {
+        value: 'cold',
+        isKeyword: true,
+      }
+    ]);
+    expect(emittedAbbreviationSpecs[0].readableString).toEqual('ab cold');
     expect(emittedAbbreviationSpecs[0].eraserSequence)
-        .toEqual(repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5 + 3));
+        .toEqual(repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5 + 4));
   });
 
   it(`supports spelling 2nd word after spelling the first`, () => {
@@ -253,19 +254,20 @@ describe('SpellComponent', () => {
       null, 'bit', 'cold'
     ]);
     expect(emittedAbbreviationSpecs.length).toEqual(2);
-    expect(emittedAbbreviationSpecs[1].tokens.length).toEqual(3);
-    expect(emittedAbbreviationSpecs[1].tokens[0]).toEqual({
-      value: 'a',
-      isKeyword: false,
-    });
-    expect(emittedAbbreviationSpecs[1].tokens[1]).toEqual({
-      value: 'bit',
-      isKeyword: true,
-    });
-    expect(emittedAbbreviationSpecs[1].tokens[2]).toEqual({
-      value: 'cold',
-      isKeyword: true,
-    });
+    expect(emittedAbbreviationSpecs[1].tokens).toEqual([
+      {
+        value: 'a',
+        isKeyword: false,
+      },
+      {
+        value: 'bit',
+        isKeyword: true,
+      },
+      {
+        value: 'cold',
+        isKeyword: true,
+      }
+    ]);
     expect(emittedAbbreviationSpecs[1].readableString).toEqual('a bit cold');
     expect(emittedAbbreviationSpecs[1].eraserSequence)
         .toEqual(repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 5 + 4 + 5));
@@ -358,15 +360,16 @@ describe('SpellComponent', () => {
       null,
     ]);
     expect(emittedAbbreviationSpecs.length).toEqual(2);
-    expect(emittedAbbreviationSpecs[1].tokens.length).toEqual(2);
-    expect(emittedAbbreviationSpecs[1].tokens[0]).toEqual({
-      value: 'at',
-      isKeyword: true,
-    });
-    expect(emittedAbbreviationSpecs[1].tokens[1]).toEqual({
-      value: 'b',
-      isKeyword: false,
-    });
+    expect(emittedAbbreviationSpecs[1].tokens).toEqual([
+      {
+        value: 'at',
+        isKeyword: true,
+      },
+      {
+        value: 'b',
+        isKeyword: false,
+      }
+    ]);
     expect(emittedAbbreviationSpecs[1].readableString).toEqual('at b');
     expect(emittedAbbreviationSpecs[1].eraserSequence)
         .toEqual(repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 11));

--- a/webui/src/app/spell/spell.component.spec.ts
+++ b/webui/src/app/spell/spell.component.spec.ts
@@ -275,11 +275,9 @@ describe('SpellComponent', () => {
     expect(tokenButtons[0].nativeElement.innerText).toEqual('a');
     expect(tokenButtons[1].nativeElement.innerText).toEqual('bit');
     expect(tokenButtons[2].nativeElement.innerText).toEqual('cold');
-    // console.log('=== TEST ENDS');  // DEBUG
   });
 
   it('supports 2nd spelling after 1st one', () => {
-    console.log('=== BEGIN');  // DEBUG
     const emittedAbbreviationSpecs: AbbreviationSpec[] = [];
 
     fixture.componentInstance.newAbbreviationSpec.subscribe(
@@ -347,7 +345,6 @@ describe('SpellComponent', () => {
   });
 
   it('Clicking token button starts spelling', () => {
-    //   console.log('==== TEST BEGINS');  // DEUBG
     const keyCodeValues: number[][] = [];
     (window as any).externalKeypressHook = (keyCode: number[]) => {
       keyCodeValues.push(keyCode);
@@ -360,7 +357,6 @@ describe('SpellComponent', () => {
     const tokenButtons =
         fixture.debugElement.queryAll(By.css('.abbreviated-token'));
     (tokenButtons[1].nativeElement as HTMLButtonElement).click();
-    console.log('keyCodeValues:', keyCodeValues);  // DEBUG
     expect(keyCodeValues).toEqual([getVirtualkeyCode('b')]);
   });
 });

--- a/webui/src/app/spell/spell.component.ts
+++ b/webui/src/app/spell/spell.component.ts
@@ -157,21 +157,32 @@ export class SpellComponent implements OnInit, OnChanges {
 
   private recreateAbbreviation(): AbbreviationSpec {
     this.spelledWords[this.spellIndex!] = this.tokenSpellingInput.trim();
+    let pendingChars = '';
     const tokens: AbbreviationToken[] = [];
     for (let i = 0; i < this.originalAbbreviationChars.length; ++i) {
-      if (this.spelledWords[i] !== null) {
+      if (this.spelledWords[i] === null) {
+        // Word not spelled out.
+        pendingChars += this.originalAbbreviationChars[i];
+      } else {
+        // The word has been spelled out.
+        if (pendingChars) {
+          tokens.push({
+            value: pendingChars,
+            isKeyword: false,
+          });
+          pendingChars = '';
+        }
         tokens.push({
-          value: this.spelledWords[i] as string,
+          value: this.spelledWords[i]!,
           isKeyword: true,
         });
-      } else {
-        const char = this.originalAbbreviationChars[i];
-        tokens.push({
-          value: char,
-          isKeyword: false,
-        });
       }
-      this.spelledWords
+    }
+    if (pendingChars) {
+      tokens.push({
+        value: pendingChars,
+        isKeyword: false,
+      });
     }
     let newAbbreviationSpec: AbbreviationSpec = {
       tokens,

--- a/webui/src/app/spell/spell.component.ts
+++ b/webui/src/app/spell/spell.component.ts
@@ -1,0 +1,181 @@
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
+import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
+import {createUuid} from 'src/utils/uuid';
+
+import {ExternalEventsComponent, getVirtualkeyCode, repeatVirtualKey, VIRTUAL_KEY} from '../external/external-events.component';
+import {AbbreviationSpec, AbbreviationToken} from '../types/abbreviation';
+
+// TODO(cais): Support workflow: enter initial-only abbreviation, get no
+// matching AE option, continue to type out any word of the phrase, and
+// hit enter to perform AE with keyword. Can enter more keywords if still has
+// no match.
+// TODO(cais): Support workflow, same as above, but before entering the
+// keyword, first click a button to indicate which word is being spelled out.
+export enum SpellingState {
+  CHOOSING_TOKEN = 'CHOOSING_TOKEN',
+  SPELLING_TOKEN = 'SPELLING_TOKEN',
+  DONE = 'DONE',
+}
+
+@Component({
+  selector: 'app-spell-component',
+  templateUrl: './spell.component.html',
+})
+export class SpellComponent implements OnInit, OnChanges {
+  private static readonly _NAME = 'SpellComponent';
+  private readonly instanceId = SpellComponent._NAME + '_' + createUuid();
+
+  @Input() originalAbbreviationSpec!: AbbreviationSpec;
+  @Output()
+  newAbbreviationSpec: EventEmitter<AbbreviationSpec> = new EventEmitter();
+
+  @ViewChildren('clickableButton')
+  clickableButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
+  originalAbbreviationChars: string[] = [];
+  // Which word in the abbreviated phrase is being spelled.
+  spellIndex: number|null = null;
+  state: SpellingState = SpellingState.CHOOSING_TOKEN;
+  tokenSpellingInput: string = '';
+  private originalReconText: string = '';
+
+  // Words that have already been spelled out so far. This supports
+  // incremental spelling out of multiple words in an abbreviation.
+  readonly spelledWords: Array<string|null> = [];
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit() {
+    ExternalEventsComponent.registerKeypressListener(
+        this.listenToKeypress.bind(this));
+    if (this.originalReconText === '') {
+      this.resetState();
+    }
+  }
+
+  ngAfterViewInit() {
+    if (this.clickableButtons === undefined) {
+      return;
+    }
+    updateButtonBoxesForElements(this.instanceId, this.clickableButtons);
+    this.clickableButtons.changes.subscribe(
+        (queryList: QueryList<ElementRef<HTMLButtonElement>>) => {
+          updateButtonBoxesForElements(this.instanceId, queryList);
+        });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.originalAbbreviationSpec &&
+        changes.originalAbbreviationSpec.previousValue &&
+        changes.originalAbbreviationSpec.previousValue.lineageId !==
+            changes.originalAbbreviationSpec.currentValue.lineageId) {
+      this.resetState();
+    }
+  }
+
+  private resetState() {
+    this.originalAbbreviationChars.splice(0);
+    this.spelledWords.splice(0);
+    this.originalAbbreviationSpec.tokens.forEach(token => {
+      this.originalAbbreviationChars.push(token.value);
+      this.spelledWords.push(null);
+    });
+  }
+
+  listenToKeypress(keySequence: string[], reconstructedText: string): void {
+    const lastKey = keySequence[keySequence.length - 1];
+    if (this.state === SpellingState.CHOOSING_TOKEN ||
+        this.state === SpellingState.DONE) {
+      const spellIndices: number[] = [];
+      this.originalAbbreviationSpec.tokens.forEach((abbreviationToken, i) => {
+        if (abbreviationToken.value.toLowerCase() === lastKey) {
+          spellIndices.push(i);
+        }
+      });
+      if (spellIndices.length === 1) {
+        // There is a unique matching token.
+        this.spellIndex = spellIndices[0];
+        this.state = SpellingState.SPELLING_TOKEN;
+        this.originalReconText =
+            reconstructedText.slice(0, reconstructedText.length - 1);
+        this.tokenSpellingInput =
+            reconstructedText.slice(this.originalReconText.length);
+        this.cdr.detectChanges();
+        // TODO(cais): Disallow punctuation?
+      }
+    } else if (this.state === SpellingState.SPELLING_TOKEN) {
+      if (lastKey === ' ' || lastKey == VIRTUAL_KEY.ENTER) {
+        // Space or Enter terminates the spelling and trigger a new AE call.
+        this.endSpelling();
+      } else {
+        this.tokenSpellingInput =
+            reconstructedText.slice(this.originalReconText.length);
+        this.cdr.detectChanges();
+      }
+    }
+  }
+
+  onTokenButtonClicked(event: Event, i: number) {
+    (window as any)
+        .externalKeypressHook(
+            getVirtualkeyCode(this.originalAbbreviationChars[i]));
+  }
+
+  onDoneButtonClicked(event: Event) {
+    this.endSpelling();
+  }
+
+  stringAtIndex(i: number): string {
+    if (this.spelledWords.length > 0 && this.spelledWords[i] !== null) {
+      return this.spelledWords[i] as string;
+    } else {
+      return this.originalAbbreviationChars[i];
+    }
+  }
+
+  private endSpelling() {
+    this.state = SpellingState.DONE;
+    const abbreviationSpec = this.recreateAbbreviation();
+    this.originalAbbreviationSpec = abbreviationSpec;
+    this.newAbbreviationSpec.emit(abbreviationSpec);
+    this.tokenSpellingInput = '';
+    this.spellIndex = null;
+    this.cdr.detectChanges();
+  }
+
+  private recreateAbbreviation(): AbbreviationSpec {
+    this.spelledWords[this.spellIndex!] = this.tokenSpellingInput.trim();
+    const tokens: AbbreviationToken[] = [];
+    for (let i = 0; i < this.originalAbbreviationChars.length; ++i) {
+      if (this.spelledWords[i] !== null) {
+        tokens.push({
+          value: this.spelledWords[i] as string,
+          isKeyword: true,
+        });
+      } else {
+        const char = this.originalAbbreviationChars[i];
+        tokens.push({
+          value: char,
+          isKeyword: false,
+        });
+      }
+      this.spelledWords
+    }
+    let newAbbreviationSpec: AbbreviationSpec = {
+      tokens,
+      readableString: tokens.map(token => token.value).join(' '),
+      lineageId: this.originalAbbreviationSpec.lineageId,
+    };
+    if (this.originalAbbreviationSpec.eraserSequence !== undefined) {
+      newAbbreviationSpec = {
+        ...newAbbreviationSpec,
+        eraserSequence: [
+          ...this.originalAbbreviationSpec.eraserSequence,
+          ...repeatVirtualKey(
+              VIRTUAL_KEY.BACKSPACE, this.tokenSpellingInput.length + 1),
+        ],
+      };
+    }
+    return newAbbreviationSpec;
+  }
+}

--- a/webui/src/app/spell/spell.component.ts
+++ b/webui/src/app/spell/spell.component.ts
@@ -88,8 +88,8 @@ export class SpellComponent implements OnInit, OnChanges {
     if (this.state === SpellingState.CHOOSING_TOKEN ||
         this.state === SpellingState.DONE) {
       const spellIndices: number[] = [];
-      this.originalAbbreviationSpec.tokens.forEach((abbreviationToken, i) => {
-        if (abbreviationToken.value.toLowerCase().slice(0, 1) === lastKey) {
+      this.originalAbbreviationChars.forEach((abbreviationChar, i) => {
+        if (abbreviationChar.toLowerCase().slice(0, 1) === lastKey) {
           spellIndices.push(i);
         }
       });

--- a/webui/src/app/spell/spell.module.ts
+++ b/webui/src/app/spell/spell.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+
+import {SpellComponent} from './spell.component';
+
+@NgModule({
+  declarations: [SpellComponent],
+  imports: [
+    BrowserModule,
+  ],
+  exports: [SpellComponent],
+})
+export class SpellModule {
+}

--- a/webui/src/app/types/abbreviation.ts
+++ b/webui/src/app/types/abbreviation.ts
@@ -43,8 +43,15 @@ export interface AbbreviationSpec {
   // injection later.
   readonly eraserSequence?: VIRTUAL_KEY[];
 
-  // Unique ID for the lineage of abbreviatoins.
+  // Unique ID for the lineage of abbreviations.
   // Derived abbreviations will share the same ID as the original one.
+  // A lineage of abbreviations is generated when the user incrementally
+  // spells words out in the intended phrase in order to overcome possible
+  // initial abbreviation expansion failure. E.g., the intended phrase is "I
+  // feel grumpy", which is initially abbreviated as "ifg". But suppose the
+  // initially expansion call fails to find the phrase, the user types out the
+  // word "grumpy", which leads to a second abbreviation in the lineage: "if
+  // grumpy".
   readonly lineageId: string;
 }
 
@@ -62,4 +69,3 @@ export interface StartSpellingEvent {
   readonly originalAbbreviationChars: string[];
   readonly isNewSpellingTask: boolean;
 }
-

--- a/webui/src/app/types/abbreviation.ts
+++ b/webui/src/app/types/abbreviation.ts
@@ -42,6 +42,10 @@ export interface AbbreviationSpec {
   // that resulted from the trigger keys, which can be used for key
   // injection later.
   readonly eraserSequence?: VIRTUAL_KEY[];
+
+  // Unique ID for the lineage of abbreviatoins.
+  // Derived abbreviations will share the same ID as the original one.
+  readonly lineageId: string;
 }
 
 /** An event that signifies the change in an input abbreviation */

--- a/webui/src/utils/text-utils.spec.ts
+++ b/webui/src/utils/text-utils.spec.ts
@@ -1,6 +1,6 @@
 /** Test utils for text-utils. */
 
-import {limitStringLength} from './text-utils';
+import {keySequenceEndsWith, limitStringLength} from './text-utils';
 
 describe('text-utils', () => {
   describe('limitStringLength', () => {
@@ -11,6 +11,16 @@ describe('text-utils', () => {
 
     it('head truncation for long input strings', () => {
       expect(limitStringLength('hello world', 6)).toEqual('world');
+    });
+  });
+
+  describe('keySequenceEndsWith', () => {
+    it('returns true for true suffix', () => {
+      expect(keySequenceEndsWith(['a', 'b', 'c'], ['b', 'c'])).toEqual(true);
+    });
+
+    it('returns false for non-suffix', () => {
+      expect(keySequenceEndsWith(['a', 'b', 'c'], ['b', 'a'])).toEqual(false);
     });
   });
 });

--- a/webui/src/utils/text-utils.ts
+++ b/webui/src/utils/text-utils.ts
@@ -44,3 +44,12 @@ function allItemsEqual(array1: string[], array2: string[]): boolean {
   }
   return true;
 }
+
+/** Determine whether a string is a single alphanumeric character. */
+export function isAlphanumericChar(str: string): boolean {
+  if (str.length !== 1) {
+    return false;
+  }
+  str = str.toLowerCase();
+  return str >= 'a' && str <= 'z' || str >= '0' && str <= '9';
+}

--- a/webui/src/utils/text-utils.ts
+++ b/webui/src/utils/text-utils.ts
@@ -24,3 +24,23 @@ export function limitStringLength(
   }
   return output;
 }
+
+/** Determines if an array of strings ends with the specified suffix. */
+export function keySequenceEndsWith(
+    keySequence: string[], suffix: string[]): boolean {
+  return keySequence.length > suffix.length &&
+      allItemsEqual(
+             keySequence.slice(keySequence.length - suffix.length), suffix);
+}
+
+function allItemsEqual(array1: string[], array2: string[]): boolean {
+  if (array1.length !== array2.length) {
+    return false;
+  }
+  for (let i = 0; i < array1.length; ++i) {
+    if (array1[i] !== array2[i]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
Towards fixing #49 

When initial abbreviation expansion fails:
![image](https://user-images.githubusercontent.com/16824702/150249552-9fa5265c-8bad-4cd8-bbf8-7637c78d933e.png)
Let's suppose you want to say "I feel a little groggy", but the option isn't provided (even though it is actually available in the example in the screenshot above!) You can click the letter that corresponds to the "g" or simply type "g" with the keyboard.

![image](https://user-images.githubusercontent.com/16824702/150250088-2b8b89e0-ab8a-4e51-bc3d-f8d0aacd2eb7.png)
The screenshot above shows when you have typed out the word "groggy". Then you can type Space or Enter to trigger AE again, this time with keyword.

![image](https://user-images.githubusercontent.com/16824702/150250442-25ef7ce6-a927-4628-b5b7-4c15874219b3.png)
This will narrow down the AE options and bring up the desired phrase, as shown in the example above.

Additional facts about the `SpellComponent`'s recovery-from-AE-failure feature (not shown in the above screenshots):
- More than one words can be spelled out
- When there are duplicate letters in an abbreviation (e.g., "i feel fine" --> "iff"), any of the duplicate letters can be spelled out. The user just needs to gaze-click the corresponding button at the bottom.
- A letter can be spelled out repeatedly, each time with a different word if so desired.

Also in this PR:
* Refactor logic for listening to external keypresses into `ExternalEventsComponent.registerKeypressListener()`. Other components, such as `AbbreviationComponent` call this method to register custom keypress-driven logic such as AE. This teases out component-specific logic out from `ExternalEventsComponent`.
