### PR TITLE
[WebUI] Add resizeWindow() API for window resizing; Fix docs

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -60,10 +60,10 @@ environment (e.g., a container web app).
 ### 1. Keystroke listening API
 
 The WebUI provides a function attached to the global `window` object, namely
-`window.registerExternalKeypress()`, which has the following signature:
+`window.externalKeypressHook()`, which has the following signature:
 
 ```typescript
-function registerExternalKeypress(virualKeyCode: number): void;
+function externalKeypressHook(virualKeyCode: number): void;
 ```
 
 wherein the `virtualKeyCode` argument obeys the
@@ -73,31 +73,52 @@ This allows the WebUI to be informed of all alphanumeric and functional keypress
 The function `getVirtualkeyCode()` in `external-events-component.ts` can
 translate strings into virtual key code values.
 
-### 2. Keystroke injection API
+### 2. Bound listner for WebUI-to-host information flow
 
-The WebUI assumes that the global object `window.boundListener` exists and has
-the following interface:
+The WebUI looks for the global `window.boundListener` object and expects
+it to have the following interface.
 
 ```typescript
 interface BoundObject {
-   function injectKey(virtualKeys: number[]): void;
+  function injectKey(virtualKeys: number[]): void;
+
+  function resizeWindow(height: number, width: number);
+
+  function updateButtonBoxes(componentName: string,
+                             boxes: Array<[number, number, number, number]>);
+
+
 }
 ```
+
+The three interface methods, `injectKey()`, `updateButtonBoxes()`, and
+`resizeWindow()` allow the WebUI to send different types of information to the
+host. Below we describe their use respectively.
+
+#### 2.1. Keystroke injection API
 
 The contract of the `injectKeys()` function is it will issue the keys in `virtualKeys`
 programmatically in the specified order.
 
-### 3. Registeration of gaze-clickable areas
+#### 2.2. Window resizing
+
+The contract of the `resizedWindow()` function is that it will request the host
+app to resize the window that contains the WebView to the specified height and
+width.
+
+### 2.3. Registeration of gaze-clickable areas
 
 The WebUI is meant to be used with an eye tracker. The hosting app provides
 two methods in the `window.boundListener` object to allow the WebUI to register
 and update its clickable regions such as buttons.
 
-The `updateButtonBoxes()` method has the following signature:
+As mentioed above, the `updateButtonBoxes()` method has the following signature:
 
 ```typescript
-function updateButtonBoxes(componentName: string,
-                           boxes: Array<[number, number, number, number]>);
+function updateButtonBoxes(
+  componentName: string,
+  boxes: Array<[number, number, number, number]>
+);
 ```
 
 The argument `componentName` specifies the (Agnular) component that the
@@ -110,9 +131,3 @@ new clickable regions that have appeared since the last call.
 Calling `updateButtonBoxes()` n times with n different `componentName`s will
 cause n sets of clickable regions to be registered.
 
-The `updateButtonBoxesToEmpty()` is a convenient method that erases the latest
-registered clickable regions of the specified component:
-
-```typescript
-function updateButtonBoxesToEmpty(componentName: string);
-```

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -20,43 +20,47 @@ app-text-to-speech-component {
 
 </style>
 
-<div class="content" role="main">
-  <div *ngIf="!hasAccessToken()" class="auth-area">
-    <app-auth-component (newAccessToken)="onNewAccessToken($event)"></app-auth-component>
+<div #contentWrapper class="content" role="main">
+
+  <div class="content" role="main">
+    <div *ngIf="!hasAccessToken()" class="auth-area">
+      <app-auth-component (newAccessToken)="onNewAccessToken($event)"></app-auth-component>
+    </div>
+
+    <app-external-events-component
+        #externalEvents
+        [textEntryBeginSubject]="textEntryBeginSubject"
+        [textEntryEndSubject]="textEntryEndSubject">
+    </app-external-events-component>
+
+    <app-metrics-component
+        [textEntryBeginSubject]="textEntryBeginSubject"
+        [textEntryEndSubject]="textEntryEndSubject">
+    </app-metrics-component>
+
+    <app-text-to-speech-component
+        [textEntryEndSubject]="textEntryEndSubject"
+        [accessToken]="accessToken">
+    </app-text-to-speech-component>
+
+    <div *ngIf="hasAccessToken()">
+
+      <app-context-component
+        [textEntryEndSubject]="textEntryEndSubject"
+      ></app-context-component>
+
+      <app-text-prediction-component
+      ></app-text-prediction-component>
+
+      <app-abbreviation-component
+        [contextStrings]="contextStrings"
+        [abbreviationExpansionTriggers]="abbreviationExpansionTriggers"
+        [textEntryEndSubject]="textEntryEndSubject"
+      ></app-abbreviation-component>
+
+    </div>
   </div>
 
-  <app-external-events-component
-      #externalEvents
-      [textEntryBeginSubject]="textEntryBeginSubject"
-      [textEntryEndSubject]="textEntryEndSubject">
-  </app-external-events-component>
-
-  <app-metrics-component
-      [textEntryBeginSubject]="textEntryBeginSubject"
-      [textEntryEndSubject]="textEntryEndSubject">
-  </app-metrics-component>
-
-  <app-text-to-speech-component
-      [textEntryEndSubject]="textEntryEndSubject"
-      [accessToken]="accessToken">
-  </app-text-to-speech-component>
-
-  <div *ngIf="hasAccessToken()">
-
-    <app-context-component
-      [textEntryEndSubject]="textEntryEndSubject"
-    ></app-context-component>
-
-    <app-text-prediction-component
-    ></app-text-prediction-component>
-
-    <app-abbreviation-component
-      [contextStrings]="contextStrings"
-      [abbreviationExpansionTriggers]="abbreviationExpansionTriggers"
-      [textEntryEndSubject]="textEntryEndSubject"
-    ></app-abbreviation-component>
-
-  </div>
 </div>
 
 <router-outlet></router-outlet>

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {AppComponent} from './app.component';
@@ -7,6 +7,8 @@ import {ExternalEventsModule} from './external/external-events.module';
 import {MetricsModule} from './metrics/metrics.module';
 
 describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+
   beforeEach(async () => {
     await TestBed
         .configureTestingModule({
@@ -19,24 +21,28 @@ describe('AppComponent', () => {
           declarations: [AppComponent],
         })
         .compileComponents();
+    fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    AppComponent.clearAppResizeCallback();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
   it(`should have as title 'SpeakFasterApp'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app.title).toEqual('SpeakFasterApp');
   });
 
   it('should render app-auth-component initially', () => {
-    const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('app-auth-component')).toBeTruthy();
+  });
+
+  it('finds content wrapper ElementRef', () => {
+    expect(fixture.componentInstance.contentWrapper).not.toBeUndefined();
   });
 });

--- a/webui/src/app/spell/spell.component.ts
+++ b/webui/src/app/spell/spell.component.ts
@@ -3,6 +3,7 @@ import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/
 import {isAlphanumericChar} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
+import {AppComponent} from '../app.component';
 import {ExternalEventsComponent, getVirtualkeyCode, repeatVirtualKey, VIRTUAL_KEY} from '../external/external-events.component';
 import {AbbreviationSpec, AbbreviationToken} from '../types/abbreviation';
 
@@ -52,6 +53,7 @@ export class SpellComponent implements OnInit, OnChanges {
     if (this.eraserSequence.length === 0) {
       this.resetState();
     }
+    AppComponent.registerAppResizeCallback(this.appResizeCallback.bind(this));
   }
 
   ngAfterViewInit() {
@@ -71,6 +73,12 @@ export class SpellComponent implements OnInit, OnChanges {
         changes.originalAbbreviationSpec.previousValue.lineageId !==
             changes.originalAbbreviationSpec.currentValue.lineageId) {
       this.resetState();
+    }
+  }
+
+  private appResizeCallback() {
+    if (this.clickableButtons.length > 0) {
+      updateButtonBoxesForElements(this.instanceId, this.clickableButtons);
     }
   }
 

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -82,6 +82,20 @@ export function injectKeys(virtualKeys: Array<string|VIRTUAL_KEY>) {
   ((window as any)[BOUND_LISTENER_NAME] as any).injectKeys(virtualKeyCodes);
 }
 
+/**
+ * Request hosting app to resize the window that contains the web view.
+ * @param height new window height
+ * @param width new window width
+ */
+export function resizeWindow(height: number, width: number): void {
+  if ((window as any)[BOUND_LISTENER_NAME] == null) {
+    console.warn(`Cannot call resizeWindow(${height}, ${
+        width}), because object ${BOUND_LISTENER_NAME} is not found`);
+    return;
+  }
+  ((window as any)[BOUND_LISTENER_NAME] as any).resizeWindow(height, width);
+}
+
 export type ExternalKeypressHook = (vkCode: number) => void;
 
 export function registerExternalKeypressHook(callback: ExternalKeypressHook) {


### PR DESCRIPTION
Fixes #158

- Add the interface method for the `boundListener`: `reiszeWindow()` that allows the WebUI conten
  to request resizing of the host window.
- In `AppComponent`, use a `ResizeObserver` on a content-wrapper div to observe the change in
  the size of the entire app.
- From `AppComponent`, provide a callback registration mechanism (`registerAppResizeCallback()`)
  through which other components can listen to app size change and perform necessary downstream
  actions such as updating the button boxes.
- Unit tests are updated accordingly.
- In README.md
  - Document the new `resizeWindow()` API
  - Fix the incorrect documentation about the keypress API: `registerExternelKeypress()` --> `externalKeypressHook()`.