### PR TITLE
[WebUI] Accept access_token route parameter

### DIFF
--- a/webui/src/app/auth/auth.component.spec.ts
+++ b/webui/src/app/auth/auth.component.spec.ts
@@ -185,4 +185,18 @@ describe('AuthComponent', () => {
       }, refreshTokenInterval * 1e3);
     }, interval * 1e3);
   });
+
+  it('including access_token parameter in route fires newAccessToken', () => {
+    const seenAccessTokens: string[] = [];
+    component.newAccessToken.subscribe(accessToken => {
+      seenAccessTokens.push(accessToken);
+      component.stopRefreshTokenForTest();
+    });
+    mockActivatedRoute.testParams = {
+      access_token: 'foo-access-token'
+    };
+    fixture.detectChanges();
+
+    expect(seenAccessTokens).toEqual(['foo-access-token']);
+  });
 });

--- a/webui/src/app/auth/auth.component.ts
+++ b/webui/src/app/auth/auth.component.ts
@@ -35,6 +35,10 @@ export class AuthComponent implements OnInit {
 
   ngOnInit() {
     this.route.queryParams.subscribe(params => {
+      if (params['access_token']) {
+        this.newAccessToken.emit(params['access_token']);
+        return;
+      }
       if (params['client_secret'] && this.clientSecret === '') {
         this.clientSecret = params['client_secret'];
       }


### PR DESCRIPTION
Fixes #164

This allows the host app, which *can* persist refresh tokens, to
pass the access token directly into the WebUI. This gets rid of the
need to do limited-input OAuth. 

The host C# app performs the usual OAuth workflow as shown in the example:
https://github.com/googlesamples/oauth-apps-for-windows

and stores the refresh token, which can be used to acquire new access tokens
in the future (after app or system restart).