### PR TITLE
[WebUI] A few improvements and fixes for AbbreviationComponent

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -84,6 +84,7 @@ mat-progress-spinner {
 }
 
 .info {
+  font-size: 22px;
   margin-left: 10px;
 }
 
@@ -96,8 +97,11 @@ mat-progress-spinner {
 }
 
 .request-ongoing-message {
-  font-size: 22px;
   margin-left: 15px;
+}
+
+.response-empty {
+  color: orange;
 }
 
 .response-error {
@@ -121,6 +125,15 @@ mat-progress-spinner {
   width: 70px;
 }
 
+.try-again-button {
+  font-size: 18px;
+  height: fit-content;
+  line-height: 32px;
+  padding: 5px;
+  vertical-align: top;
+  width: 120px;
+}
+
 .upper-container {
   height: 150px;
 }
@@ -138,6 +151,15 @@ mat-progress-spinner {
 </div>
 <div *ngIf="responseError !== null" class="info response-error">
   Error: {{responseError}}
+</div>
+<div *ngIf="receivedEmptyOptions" class="empty-options-container">
+  <span class="info response-empty">Found no expansions</span>
+  <button
+      #clickableButton
+      class="option-button try-again-button"
+      (click)="onTryAgainButtonClicked($event)">
+    Try again
+  </button>
 </div>
 <div
     *ngIf="state === 'CHOOSING_EXPANSION' || state == 'SPELLING'"

--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -1,12 +1,12 @@
 <style>
 
 :host {
-    box-sizing: border-box;
-    color: #EEE;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    font-size: 32px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  box-sizing: border-box;
+  color: #EEE;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 32px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .abbreviation-expansion {
@@ -17,6 +17,12 @@
   vertical-align: middle;
 }
 
+mat-progress-spinner {
+  display: inline-block;
+  stroke: #ddd;
+  zoom: 0.3;
+}
+
 .abbreviation-option {
   background: #333;
   border-radius: 5px;
@@ -25,7 +31,7 @@
   font-size: 22px;
   height: 63px;
   line-height: 32px;
-  margin: 4px 5px;
+  margin: 3px 5px;
   min-width: 300px;
   padding-left: 5px;
   white-space: nowrap;
@@ -89,6 +95,11 @@
   color: yellow;
 }
 
+.request-ongoing-message {
+  font-size: 22px;
+  margin-left: 15px;
+}
+
 .response-error {
   color: orange;
 }
@@ -110,17 +121,26 @@
   width: 70px;
 }
 
+.upper-container {
+  height: 150px;
+}
+
 </style>
 
+<div class="upper-container">
+
 <div *ngIf="requestOngoing" class="info request-ongoing">
-  Getting abbrevaition expansions...
+  <mat-progress-spinner
+      [mode]="'indeterminate'"
+      [value]="50">
+  </mat-progress-spinner>
+  <span class="request-ongoing-message">Getting abbrevaition expansions...</span>
 </div>
 <div *ngIf="responseError !== null" class="info response-error">
   Error: {{responseError}}
 </div>
-
 <div
-    *ngIf="state === 'CHOOSING_EXPANSION'"
+    *ngIf="state === 'CHOOSING_EXPANSION' || state == 'SPELLING'"
     class="expansions">
   <div class="abbreviation-options-container">
     <div class="abbreviation-options-grid">
@@ -135,6 +155,8 @@
       </app-phrase-component>
     </div>
   </div>
+</div>
+
 </div>
 
 <app-spell-component

--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -54,6 +54,10 @@ mat-progress-spinner {
     "b b b b d d d d f f f f";
 }
 
+.item {
+  width: 355px;
+}
+
 .item1 {
   grid-area: a;
 }
@@ -169,9 +173,10 @@ mat-progress-spinner {
       <app-phrase-component
           *ngFor="let abbreviationOption of abbreviationOptions; let i = index"
           #abbreviationOption
-          class="item{{i + 1}}"
+          class="item item{{i + 1}}"
           [phraseText]="abbreviationOption"
           [phraseIndex]="i"
+          [scaleFontSize]="true"
           (speakButtonClicked)="onSpeakOptionButtonClicked($event)"
           (injectButtonClicked)="onExpansionOptionButtonClicked($event)">
       </app-phrase-component>

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -177,6 +177,23 @@ describe('AbbreviationComponent', () => {
     expect(events[0].numHumanKeypresses).toEqual(expectedNumKeypresses);
   });
 
+  it('shows request ongoing spinner and message during server call',
+      async () => {
+        fixture.componentInstance.contextStrings = ['hello'];
+        fixture.componentInstance.listenToKeypress(
+            ['h', 'a', 'y', ' ', ' '], 'hay  ');
+        fixture.detectChanges();
+
+        const requestOngoingMessages =
+            fixture.debugElement.queryAll(By.css('.request-ongoing-message'));
+        expect(requestOngoingMessages.length).toEqual(1);
+        expect(requestOngoingMessages[0].nativeElement.innerText)
+            .toEqual('Getting abbrevaition expansions...');
+        const spinners =
+            fixture.debugElement.queryAll(By.css('mat-progress-spinner'));
+        expect(spinners.length).toEqual(1);
+      });
+
   for (const [keySequence, precedingText] of [
            [['h', 'a', 'y', ' ', ' '], undefined],
            [[' ', 'h', 'a', 'y', ' ', ' '], undefined],

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -253,7 +253,7 @@ describe('AbbreviationComponent', () => {
     expect(tryAgainButtons.length).toEqual(1);
   });
 
-  it('Clicking try again button dismisses no-expnsion and try-again button',
+  it('Clicking try again button dismisses no-expansion and try-again button',
      async () => {
        const spy = spyOn(
                        fixture.componentInstance.speakFasterService,

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -237,6 +237,44 @@ describe('AbbreviationComponent', () => {
        });
   }
 
+  it('Shows no-option mesasage and try-again button if no option', () => {
+    spyOn(fixture.componentInstance.speakFasterService, 'expandAbbreviation')
+        .and.returnValue(of({}));
+    fixture.componentInstance.contextStrings = ['hello'];
+    fixture.componentInstance.listenToKeypress(
+        ['h', 'a', 'y', ' ', ' '], 'hay  ');
+    fixture.detectChanges();
+
+    const noExpansionSpans =
+        fixture.debugElement.queryAll(By.css('.response-empty'));
+    expect(noExpansionSpans.length).toEqual(1);
+    const tryAgainButtons =
+        fixture.debugElement.queryAll(By.css('.try-again-button'));
+    expect(tryAgainButtons.length).toEqual(1);
+  });
+
+  it('Clicking try again button dismisses no-expnsion and try-again button',
+     async () => {
+       const spy = spyOn(
+                       fixture.componentInstance.speakFasterService,
+                       'expandAbbreviation')
+                       .and.returnValue(of({}));
+       fixture.componentInstance.contextStrings = ['hello'];
+       fixture.componentInstance.listenToKeypress(
+           ['h', 'a', 'y', ' ', ' '], 'hay  ');
+       fixture.detectChanges();
+       const tryAgainButtons =
+           fixture.debugElement.query(By.css('.try-again-button'));
+       spy.and.callThrough();
+       tryAgainButtons.nativeElement.click();
+       fixture.detectChanges();
+       await fixture.whenStable();
+
+       expect(fixture.debugElement.query(By.css('.response-empty'))).toBeNull();
+       expect(fixture.debugElement.query(By.css('.try-again-button')))
+           .toBeNull();
+     });
+
   it('does not display SpellComponent initially', () => {
     const spellComponents =
         fixture.debugElement.queryAll(By.css('app-spell-component'));

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -258,6 +258,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, AfterViewInit {
               this.responseError = error.message;
               this.cdr.detectChanges();
             });
+    this.cdr.detectChanges();
   }
 
   /** Heuristics about the num_samples to use when requesting AE from server. */

--- a/webui/src/app/abbreviation/abbreviation.module.ts
+++ b/webui/src/app/abbreviation/abbreviation.module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 
 import {PhraseModule} from '../phrase/phrase.module';
 import {SpellModule} from '../spell/spell.module';
@@ -10,6 +11,7 @@ import {AbbreviationComponent} from './abbreviation.component';
   declarations: [AbbreviationComponent],
   imports: [
     BrowserModule,
+    MatProgressSpinnerModule,
     PhraseModule,
     SpellModule,
   ],

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -16,6 +16,7 @@ app-abbreviation-component {
 
 app-context-component {
   display: block;
+  height: 84px;
 }
 
 app-text-to-speech-component {

--- a/webui/src/app/conversation-turn/conversation-turn.component.html
+++ b/webui/src/app/conversation-turn/conversation-turn.component.html
@@ -18,6 +18,7 @@
   font-size: 26px;
   margin: 5px;
   min-width: 250px;
+  max-height: 80px;
   max-width: 420px;
   padding: 12px 5px;
   text-align: left;

--- a/webui/src/app/conversation-turn/conversation-turn.component.ts
+++ b/webui/src/app/conversation-turn/conversation-turn.component.ts
@@ -17,7 +17,7 @@ export class ConversationTurnComponent implements AfterViewInit {
 
   private static readonly CONTENT_STRING_MAX_LENGTH = 50;
   private static readonly BASE_FONT_SIZE_PX = 24;
-  private static readonly FONT_SCALING_LENGTH_THRESHOLD = 45;
+  private static readonly FONT_SCALING_LENGTH_THRESHOLD = 36;
 
   @Input() turn!: ConversationTurn;
   @ViewChildren('button') buttons!: QueryList<ElementRef<HTMLButtonElement>>;

--- a/webui/src/app/phrase/phrase.component.html
+++ b/webui/src/app/phrase/phrase.component.html
@@ -55,7 +55,7 @@
 <div class="phrase-container"
   style="background-color: {{color}}">
 
-  <div class="phrase">{{phraseText}}</div>
+  <div #phrase class="phrase">{{phraseText}}</div>
   <button
       #clickableButton
       class="action-button speak-button"

--- a/webui/src/app/phrase/phrase.component.ts
+++ b/webui/src/app/phrase/phrase.component.ts
@@ -1,5 +1,5 @@
 /** A phrase option for user selection. */
-import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnDestroy, Output, QueryList, ViewChildren} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnDestroy, Output, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {createUuid} from 'src/utils/uuid';
 
@@ -11,10 +11,13 @@ export class PhraseComponent implements AfterViewInit, OnDestroy {
   private static readonly _NAME = 'PhraseComponent';
 
   private readonly instanceId = PhraseComponent._NAME + '_' + createUuid();
+  private static readonly BASE_FONT_SIZE_PX = 22;
+  private static readonly FONT_SCALING_LENGTH_THRESHOLD = 32;
   @Input() color: string = '#093F3A';
   @Input() phraseText!: string;
   @Input() phraseIndex!: number;
   @Input() showFavoriteButton: boolean = false;
+  @Input() scaleFontSize = false;
   @Output()
   speakButtonClicked: EventEmitter<{phraseText: string, phraseIndex: number}> =
       new EventEmitter();
@@ -26,6 +29,8 @@ export class PhraseComponent implements AfterViewInit, OnDestroy {
       EventEmitter<{phraseText: string, phraseIndex: number}> =
           new EventEmitter();
 
+  @ViewChild('phrase') phraseElement!: ElementRef<HTMLDivElement>;
+
   public updateButtonBoxesWithContainerRect(containerRect: DOMRect) {
     updateButtonBoxesForElements(
         this.instanceId, this.clickableButtons, containerRect);
@@ -35,6 +40,20 @@ export class PhraseComponent implements AfterViewInit, OnDestroy {
   clickableButtons!: QueryList<ElementRef<HTMLElement>>;
 
   ngAfterViewInit() {
+    let fontSizePx = PhraseComponent.BASE_FONT_SIZE_PX;
+    if (this.scaleFontSize &&
+        this.phraseText.length >
+            PhraseComponent.FONT_SCALING_LENGTH_THRESHOLD) {
+      fontSizePx /= Math.pow(
+          (this.phraseText.length /
+           PhraseComponent.FONT_SCALING_LENGTH_THRESHOLD),
+          1.2);
+      this.phraseElement.nativeElement.style.fontSize =
+          `${fontSizePx.toFixed(1)}px`;
+      const lineHeightPx = fontSizePx + 2;
+      this.phraseElement.nativeElement.style.lineHeight =
+          `${lineHeightPx.toFixed(1)}px`;
+    }
     updateButtonBoxesForElements(this.instanceId, this.clickableButtons);
     this.clickableButtons.changes.subscribe(
         (queryList: QueryList<ElementRef>) => {


### PR DESCRIPTION
- Prevents the spell buttons from becoming not gaze-clickable during the spelling
- Make the options available even during spelling in case the users changes the mind and would like to give up spelling and just choose on of the existing options
- Add mat-spinner during server calls
- Prevent long `ContextTurnComponents` at the top from changing the position of AE options down below.
- Prevent text overflow in `PhraseComponent`s in `AbbreviationComponet`; prevent button cutoff
  - ![image](https://user-images.githubusercontent.com/16824702/152215349-5cec3133-d1f6-4660-af34-bc33bf207235.png)
- When no AE option is available: provide message and "try again" button:
  - ![image](https://user-images.githubusercontent.com/16824702/152198923-ab74c58f-1255-406d-b1ef-5de67147ff29.png)

Fixes #157 
Fixes #174