### PR TITLE
[WebUI] Add expand and abort buttons for abbreviaton expansion

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -99,7 +99,7 @@ mat-progress-spinner {
 }
 
 .action-abort-button {
-  background-color: darkorange;
+  background-color: brown;
   display: inline-block;
   height: 66px;
   margin: 2px;

--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -82,6 +82,30 @@ mat-progress-spinner {
   grid-area: f;
 }
 
+.action-button {
+  background: darkgreen;
+  border: 2px solid #888;
+  border-radius: 5px;
+  color: #eee;
+  display: inline-block;
+  font-size: 28px;
+  height: 72px;
+  line-height: 32px;
+  margin: 10px;
+  min-width: 72px;
+  padding: 15px;
+  vertical-align: top;
+  width: fit-content;
+}
+
+.action-abort-button {
+  background-color: darkorange;
+  display: inline-block;
+  height: 66px;
+  margin: 2px;
+  width: 66px;
+}
+
 .expansions {
   display: inline-block;
   white-space: nowrap;
@@ -112,19 +136,6 @@ mat-progress-spinner {
   color: orange;
 }
 
-.action-button {
-  background-color: grey;
-  border-radius: 5px;
-  color: #111;
-  display: inline;
-  float: right;
-  height: 64px;
-  font-size: 20px;
-  margin-left: 5px;
-  width: 80px;
-  padding: 2px 5px;
-}
-
 .speak-button {
   width: 70px;
 }
@@ -146,7 +157,15 @@ mat-progress-spinner {
 
 <div class="upper-container">
 
-<div *ngIf="requestOngoing" class="info request-ongoing">
+<button
+    #clickableButton
+    *ngIf="state === 'PRE_CHOOSING_EXPANSION' && !isInputAbbreviationEmpty"
+    class="action-button expand-abbreviation-button"
+    (click)="onExpandAbbreviationButtonClicked($event)">
+  Expand abbreviation
+</button>
+
+<div *ngIf="state == 'REQUEST_ONGOING'" class="info request-ongoing">
   <mat-progress-spinner
       [mode]="'indeterminate'"
       [value]="50">
@@ -180,6 +199,12 @@ mat-progress-spinner {
           (speakButtonClicked)="onSpeakOptionButtonClicked($event)"
           (injectButtonClicked)="onExpansionOptionButtonClicked($event)">
       </app-phrase-component>
+      <button
+          #clickableButton
+          class="action-button action-abort-button"
+          (click)="onAbortButtonClicked($event)">
+          🗙
+      </button>
     </div>
   </div>
 </div>
@@ -187,7 +212,7 @@ mat-progress-spinner {
 </div>
 
 <app-spell-component
-    *ngIf="abbreviation !== null && (state === 'SPELLING' || state === 'CHOOSING_EXPANSION')"
+    *ngIf="abbreviation !== null && (state === 'SPELLING' || state === 'CHOOSING_EXPANSION' || state === 'REQUEST_ONGOING')"
     class="spell-component"
     [originalAbbreviationSpec]="abbreviation!"
     (newAbbreviationSpec)="onNewAbbreviationSpec($event)"

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -8,6 +8,7 @@ import {createUuid} from 'src/utils/uuid';
 
 import * as cefSharp from '../../utils/cefsharp';
 import {ExternalEventsComponent, repeatVirtualKey, VIRTUAL_KEY} from '../external/external-events.component';
+import {configureService} from '../speakfaster-service';
 import {TestListener} from '../test-utils/test-cefsharp-listener';
 import {AbbreviationSpec, InputAbbreviationChangedEvent} from '../types/abbreviation';
 import {TextEntryEndEvent} from '../types/text-entry';
@@ -41,6 +42,10 @@ describe('AbbreviationComponent', () => {
         abbreviationExpansionTriggers;
     fixture.componentInstance.textEntryEndSubject = textEntryEndSubject;
     fixture.detectChanges();
+    configureService({
+      endpoint: '',
+      accessToken: null,
+    });
   });
 
   afterAll(async () => {
@@ -53,6 +58,66 @@ describe('AbbreviationComponent', () => {
     const abbreviationOptions =
         fixture.debugElement.queryAll(By.css('.abbreviation-option'));
     expect(abbreviationOptions.length).toEqual(0);
+  });
+
+  it('initially displays no abort button', () => {
+    const abortButtons =
+        fixture.debugElement.queryAll(By.css('.action-abort-button'));
+    expect(abortButtons.length).toEqual(0);
+  });
+
+  it('initially displays no expand-abbreviation button', () => {
+    const expandButton =
+        fixture.debugElement.queryAll(By.css('.expand-abbreviation-button'));
+    expect(expandButton.length).toEqual(0);
+  });
+
+  it('displays expand-abbreviation button after text becomes non-empty', () => {
+    fixture.componentInstance.listenToKeypress(['a'], 'a');
+    fixture.detectChanges();
+
+    const expandButton =
+        fixture.debugElement.queryAll(By.css('.expand-abbreviation-button'));
+    expect(expandButton.length).toEqual(1);
+  });
+
+  it('Erases text to empty hides expand-abbreviation button', () => {
+    fixture.componentInstance.listenToKeypress(['a'], 'a');
+    fixture.componentInstance.listenToKeypress(
+        ['a', VIRTUAL_KEY.BACKSPACE], '');
+    fixture.detectChanges();
+
+    const expandButton =
+        fixture.debugElement.queryAll(By.css('.expand-abbreviation-button'));
+    expect(expandButton.length).toEqual(0);
+    expect(expandButton.length).toEqual(0);
+  });
+
+  it('clicking expand-abbreviation button sends trigger', () => {
+    const triggers: InputAbbreviationChangedEvent[] = [];
+    fixture.componentInstance.abbreviationExpansionTriggers.subscribe(
+        trigger => {
+          triggers.push(trigger);
+        });
+    fixture.componentInstance.listenToKeypress(['a'], 'a');
+    fixture.componentInstance.listenToKeypress(['a', 'b'], 'ab');
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', VIRTUAL_KEY.SPACE], 'ab ');
+    fixture.detectChanges();
+    const expandButton =
+        fixture.debugElement.query(By.css('.expand-abbreviation-button'));
+    expandButton.nativeElement.click();
+
+    expect(triggers.length).toEqual(1);
+    expect(triggers[0].abbreviationSpec.tokens).toEqual([
+      {
+        value: 'a',
+        isKeyword: false,
+      },
+      {value: 'b', isKeyword: false}
+    ]);
+    expect(triggers[0].abbreviationSpec.readableString).toEqual('ab');
+    expect(triggers[0].requestExpansion).toBeTrue();
   });
 
   for (const [contextStrings, precedingText] of [
@@ -144,6 +209,33 @@ describe('AbbreviationComponent', () => {
     ]);
   });
 
+  it('clicking abort button resets state', () => {
+    fixture.componentInstance.abbreviation = {
+      tokens: ['w', 't', 'i', 'i'].map(char => ({
+                                         value: char,
+                                         isKeyword: false,
+                                       })),
+      readableString: 'wtii',
+      triggerKeys: [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.SPACE],
+      eraserSequence: repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, 8),
+      lineageId: createUuid(),
+    };
+    fixture.componentInstance.abbreviationOptions = ['what time is it'];
+    fixture.componentInstance.state = State.CHOOSING_EXPANSION;
+    fixture.detectChanges();
+    const abortButtons =
+        fixture.debugElement.query(By.css('.action-abort-button'));
+    abortButtons.nativeElement.click();
+    fixture.detectChanges();
+
+    const {componentInstance} = fixture;
+    expect(componentInstance.state).toEqual(State.PRE_CHOOSING_EXPANSION);
+    expect(componentInstance.abbreviation).toBeNull();
+    expect(componentInstance.responseError).toBeNull();
+    expect(componentInstance.abbreviationOptions).toEqual([]);
+    expect(componentInstance.reconstructedText).toEqual('');
+  });
+
   it('clicking inject-button publishes to textEntryEndSubject', () => {
     const events: TextEntryEndEvent[] = [];
     textEntryEndSubject.subscribe(event => {
@@ -178,21 +270,21 @@ describe('AbbreviationComponent', () => {
   });
 
   it('shows request ongoing spinner and message during server call',
-      async () => {
-        fixture.componentInstance.contextStrings = ['hello'];
-        fixture.componentInstance.listenToKeypress(
-            ['h', 'a', 'y', ' ', ' '], 'hay  ');
-        fixture.detectChanges();
+     async () => {
+       fixture.componentInstance.contextStrings = ['hello'];
+       fixture.componentInstance.listenToKeypress(
+           ['h', 'a', 'y', ' ', ' '], 'hay  ');
+       fixture.detectChanges();
 
-        const requestOngoingMessages =
-            fixture.debugElement.queryAll(By.css('.request-ongoing-message'));
-        expect(requestOngoingMessages.length).toEqual(1);
-        expect(requestOngoingMessages[0].nativeElement.innerText)
-            .toEqual('Getting abbrevaition expansions...');
-        const spinners =
-            fixture.debugElement.queryAll(By.css('mat-progress-spinner'));
-        expect(spinners.length).toEqual(1);
-      });
+       const requestOngoingMessages =
+           fixture.debugElement.queryAll(By.css('.request-ongoing-message'));
+       expect(requestOngoingMessages.length).toEqual(1);
+       expect(requestOngoingMessages[0].nativeElement.innerText)
+           .toEqual('Getting abbrevaition expansions...');
+       const spinners =
+           fixture.debugElement.queryAll(By.css('mat-progress-spinner'));
+       expect(spinners.length).toEqual(1);
+     });
 
   for (const [keySequence, precedingText] of [
            [['h', 'a', 'y', ' ', ' '], undefined],

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -209,7 +209,12 @@ describe('AbbreviationComponent', () => {
     ]);
   });
 
-  it('clicking abort button resets state', () => {
+  it('clicking abort button resets state and send end event', () => {
+    const textEntryEndEvents: TextEntryEndEvent[] = [];
+    textEntryEndSubject.subscribe(event => {
+      textEntryEndEvents.push(event);
+    });
+    fixture.componentInstance.reconstructedText = 'wtii  ';
     fixture.componentInstance.abbreviation = {
       tokens: ['w', 't', 'i', 'i'].map(char => ({
                                          value: char,
@@ -234,6 +239,11 @@ describe('AbbreviationComponent', () => {
     expect(componentInstance.responseError).toBeNull();
     expect(componentInstance.abbreviationOptions).toEqual([]);
     expect(componentInstance.reconstructedText).toEqual('');
+    expect(textEntryEndEvents.length).toEqual(1);
+    expect(textEntryEndEvents[0].text).toEqual('');
+    expect(textEntryEndEvents[0].timestampMillis).toBeGreaterThan(0);
+    expect(textEntryEndEvents[0].isFinal).toBeTrue();
+    expect(textEntryEndEvents[0].isAborted).toBeTrue();
   });
 
   it('clicking inject-button publishes to textEntryEndSubject', () => {

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -147,6 +147,14 @@ export class AbbreviationComponent implements OnDestroy, OnInit, AfterViewInit {
   }
 
   onAbortButtonClicked(event: Event) {
+    if (this.reconstructedText) {
+      this.textEntryEndSubject.next({
+        text: '',
+        timestampMillis: new Date().getTime(),
+        isFinal: true,
+        isAborted: true,
+      });
+    }
     this.resetState();
   }
 

--- a/webui/src/app/context/context.component.ts
+++ b/webui/src/app/context/context.component.ts
@@ -36,7 +36,7 @@ export class ContextComponent implements OnInit {
   ngOnInit() {
     this.focusContextIds.splice(0);
     this.textEntryEndSubject.subscribe((textInjection: TextEntryEndEvent) => {
-      if (!textInjection.isFinal) {
+      if (!textInjection.isFinal || textInjection.isAborted) {
         return;
       }
       const timestamp = new Date(textInjection.timestampMillis);

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -100,6 +100,19 @@ describe('ExternalEventsComponent', () => {
     expect(component.text).toEqual('a');
   });
 
+  it('aborted event resets state', () => {
+    component.externalKeypressHook(65);  // 'a'
+    component.externalKeypressHook(32);  // Space
+    component.externalKeypressHook(32);  // Space
+    textEntryEndSubject.next({
+      text: '',
+      timestampMillis: Date.now(),
+      isFinal: true,
+      isAborted: true,
+    });
+    expect(component.text).toEqual('');
+  });
+
   it('Registering keypress listener causes listener to be called', () => {
     const keySequences: string[][] = [];
     const reconstructedTexts: string[] = [];

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -228,7 +228,7 @@ export class ExternalEventsComponent implements OnInit {
   ngOnInit() {
     this.textEntryEndSubject.subscribe(event => {
       // TODO(cais): Add unit test.
-      if (!event.isFinal || event.isAborted) {
+      if (!event.isFinal) {
         return;
       }
       this.reset();

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -228,7 +228,7 @@ export class ExternalEventsComponent implements OnInit {
   ngOnInit() {
     this.textEntryEndSubject.subscribe(event => {
       // TODO(cais): Add unit test.
-      if (!event.isFinal) {
+      if (!event.isFinal || event.isAborted) {
         return;
       }
       this.reset();

--- a/webui/src/app/metrics/metrics.component.ts
+++ b/webui/src/app/metrics/metrics.component.ts
@@ -27,7 +27,7 @@ export class MetricsComponent implements OnInit {
       console.log(`Text entry begin at ${event.timestampMillis}`);
     });
     this.textEntryEndSubject.subscribe((event: TextEntryEndEvent) => {
-      if (!event.isFinal) {
+      if (!event.isFinal || event.isAborted) {
         return;
       }
       if (this.currentStartTimeMillis === null) {

--- a/webui/src/app/metrics/metrics.spec.ts
+++ b/webui/src/app/metrics/metrics.spec.ts
@@ -163,4 +163,20 @@ describe('MetricsComponent', () => {
              .toEqual('(latest:0.80)');
        });
   }
+
+  it('ignores aborted event', () => {
+    textEntryBeginSubject.next({
+      timestampMillis: 1000,
+    });
+    textEntryEndSubject.next({
+      timestampMillis: 2000,
+      text: '',
+      isFinal: true,
+      isAborted: true,
+    });
+    const wpmContainer = fixture.debugElement.query(By.css('.wpm'));
+    expect(wpmContainer).toBeNull();
+    const ksrContainer = fixture.debugElement.query(By.css('.ksr'));
+    expect(ksrContainer).toBeNull();
+  });
 });

--- a/webui/src/app/types/text-entry.ts
+++ b/webui/src/app/types/text-entry.ts
@@ -44,4 +44,7 @@ export interface TextEntryEndEvent {
   // output from this app per se, not text-to-speech output in another app like
   // the text editor tethereed to this app.
   inAppTextToSpeechAudioConfig?: TextToSpeechAudioConfig;
+
+  // Whether this is an aborted text entry event.
+  isAborted?: boolean;
 }


### PR DESCRIPTION
Fixes #172
Fixes #177 

- Move the "Expand abbreviation" button away from the edge. Make it big and easier to gaze-click:
  - ![image](https://user-images.githubusercontent.com/16824702/152386378-871a3e10-d10e-4960-acbe-9c6137a23572.png)
- Add "Abort" (X) button at the end of the available options
  - ![image](https://user-images.githubusercontent.com/16824702/152386846-bfb580e2-1fef-4b81-a6e9-59a0c9a657f8.png)
- Clean ups:
  - In `AbbreviationComponent`, remove the private member `requestOngoing` and fold the state logic into `state` (new enum value: `REQUEST_ONGOING`) 