### PR TITLE
[WebUI] Call service to get quick phrases; remove hardcoding

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -8,7 +8,6 @@ import {createUuid} from 'src/utils/uuid';
 
 import * as cefSharp from '../../utils/cefsharp';
 import {ExternalEventsComponent, repeatVirtualKey, VIRTUAL_KEY} from '../external/external-events.component';
-import {configureService} from '../speakfaster-service';
 import {TestListener} from '../test-utils/test-cefsharp-listener';
 import {AbbreviationSpec, InputAbbreviationChangedEvent} from '../types/abbreviation';
 import {TextEntryEndEvent} from '../types/text-entry';
@@ -42,10 +41,6 @@ describe('AbbreviationComponent', () => {
         abbreviationExpansionTriggers;
     fixture.componentInstance.textEntryEndSubject = textEntryEndSubject;
     fixture.detectChanges();
-    configureService({
-      endpoint: '',
-      accessToken: null,
-    });
   });
 
   afterAll(async () => {

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -153,7 +153,7 @@ app-text-to-speech-component {
         class="main-right-pane mode-quick-pharses"
         *ngIf="hasAccessToken() && isQuickPhrasesAppState()">
       <app-quick-phrases-component
-          [phrases]="getQuickPhrases()"
+          [allowedTags]="getQuickPhrasesAllowedTags()"
           [color]="getQuickPhrasesColor()"
           [textEntryBeginSubject]="textEntryBeginSubject"
           [textEntryEndSubject]="textEntryEndSubject"

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -9,7 +9,6 @@ import {AuthModule} from './auth/auth.module';
 import {ExternalEventsModule} from './external/external-events.module';
 import {MetricsModule} from './metrics/metrics.module';
 import {MiniBarModule} from './mini-bar/mini-bar.module';
-import {QuickPhrasesModule} from './quick-phrases/quick-phrases.module';
 import {TestListener} from './test-utils/test-cefsharp-listener';
 import {AppState} from './types/app-state';
 
@@ -27,7 +26,6 @@ describe('AppComponent', () => {
             ExternalEventsModule,
             MetricsModule,
             MiniBarModule,
-            QuickPhrasesModule,
             RouterTestingModule,
           ],
           declarations: [AppComponent],

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -167,28 +167,6 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     return this._accessToken;
   }
 
-  onQuickPhrasesCareButtonClicked(event: Event, appState: string) {
-    switch (appState) {
-      case 'QUICK_PHRASES_FAVORITE':
-        this.changeAppState(AppState.QUICK_PHRASES_FAVORITE);
-        break;
-      case 'QUICK_PHRASES_TEMPORAL':
-        this.changeAppState(AppState.QUICK_PHRASES_TEMPORAL);
-        break;
-      case 'QUICK_PHRASES_PARTNERS':
-        this.changeAppState(AppState.QUICK_PHRASES_PARTNERS);
-        break;
-      case 'QUICK_PHRASES_CARE':
-        this.changeAppState(AppState.QUICK_PHRASES_CARE);
-        break;
-      case 'ABBREVIATION_EXPANSION':
-        this.changeAppState(AppState.ABBREVIATION_EXPANSION);
-        break;
-      default:
-        break;
-    }
-  }
-
   onMinimizeButtonClicked(event: Event) {
     this.changeAppState(AppState.MINIBAR);
   }
@@ -211,6 +189,28 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
   /** Clear all reigstered app-resize callbacks. */
   public static clearAppResizeCallback() {
     AppComponent.appResizeCallbacks.splice(0);
+  }
+
+  onQuickPhrasesCareButtonClicked(event: Event, appState: string) {
+    switch (appState) {
+      case 'QUICK_PHRASES_FAVORITE':
+        this.changeAppState(AppState.QUICK_PHRASES_FAVORITE);
+        break;
+      case 'QUICK_PHRASES_TEMPORAL':
+        this.changeAppState(AppState.QUICK_PHRASES_TEMPORAL);
+        break;
+      case 'QUICK_PHRASES_PARTNERS':
+        this.changeAppState(AppState.QUICK_PHRASES_PARTNERS);
+        break;
+      case 'QUICK_PHRASES_CARE':
+        this.changeAppState(AppState.QUICK_PHRASES_CARE);
+        break;
+      case 'ABBREVIATION_EXPANSION':
+        this.changeAppState(AppState.ABBREVIATION_EXPANSION);
+        break;
+      default:
+        break;
+    }
   }
 
   isQuickPhrasesAppState() {
@@ -246,34 +246,20 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  // TODO(cais): Do not hardcode. Query these from the SpeakFasterService
-  // instead.
-  getQuickPhrases(): string[] {
+  getQuickPhrasesAllowedTags(): string[] {
     switch (this.appState) {
       case AppState.QUICK_PHRASES_FAVORITE:
-        return [];
+        return ['favorite'];
       case AppState.QUICK_PHRASES_TEMPORAL:
-        return [
-          'Good morning',
-          'Have a wonderful Tuesday',
-        ];
+        return ['temporal'];
       case AppState.QUICK_PHRASES_PARTNERS:
-        return [
-          'Alice', 'Bob', 'Charlie', 'Danielle', 'Elly', 'Frank', 'George',
-          'Heather', 'Irine', 'John', 'Kevin', 'Lana', 'Mike', 'Nick', 'Oscar',
-          'Peter', 'Quentin', 'Rene', 'Sherry', 'Tom', 'Ulysses', 'Vivian',
-          'William', 'Xavier', 'Yasmin', 'Zachary'
-        ];
+        return ['partner'];
       case AppState.QUICK_PHRASES_CARE:
-        return [
-          'Thank you very much',
-          'I need to think about that',
-          'Let\'s go for a walk',
-        ];
+        return ['care'];
       default:
         throw new Error(`Invalid app state: ${this.appState}`);
     }
-  }
+  };
 
   getQuickPhrasesColor(): string {
     switch (this.appState) {

--- a/webui/src/app/quick-phrases/quick-phrases.component.html
+++ b/webui/src/app/quick-phrases/quick-phrases.component.html
@@ -10,9 +10,22 @@ app-phrase-component {
   margin: 3px 5px;
 }
 
+mat-progress-spinner {
+  display: inline-block;
+  stroke: #ddd;
+  zoom: 0.3;
+}
+
 .container {
   display: flex;
   flex-direction: row;
+}
+
+.error {
+  color: red;
+  font-size: 22px;
+  margin: 8px;
+  text-align: center;
 }
 
 .no-quick-phrases {
@@ -26,6 +39,13 @@ app-phrase-component {
   height: 365px;
   max-height: 365px;
   overflow-y: hidden;
+}
+
+.retrieving-quick-phrases {
+  color: #aaa;
+  font-size: 22px;
+  margin: 8px;
+  text-align: center;
 }
 
 .scroll-button {
@@ -73,10 +93,27 @@ app-phrase-component {
     </app-phrase-component>
 
     <div
-        *ngIf="phrases.length === 0"
+        *ngIf="state === 'RETRIEVING_PHRASES'"
+        class="retrieving-quick-phrases">
+      <mat-progress-spinner
+          [mode]="'indeterminate'"
+          [value]="50">
+      </mat-progress-spinner>
+      Retrieving phrases...
+    </div>
+
+    <div
+        *ngIf="state === 'RETRIEVED_PHRASES' && phrases.length === 0"
         class="no-quick-phrases">
         No quick phrases found
     </div>
+
+    <div
+        *ngIf="state === 'ERROR'"
+        class="error">
+      {{errorMessage}}
+    </div>
+
   </div>
 
   <div

--- a/webui/src/app/quick-phrases/quick-phrases.component.spec.ts
+++ b/webui/src/app/quick-phrases/quick-phrases.component.spec.ts
@@ -1,22 +1,94 @@
 /** Unit tests for QuickPhrasesComponent. */
+import {Injectable, SimpleChange} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {Subject} from 'rxjs';
+import {Observable, of, Subject, throwError} from 'rxjs';
+import {createUuid} from 'src/utils/uuid';
 
 import * as cefSharp from '../../utils/cefsharp';
+import {SpeakFasterService, TextPredictionRequest, TextPredictionResponse} from '../speakfaster-service';
 import {TestListener} from '../test-utils/test-cefsharp-listener';
+import {ContextualPhrase} from '../types/contextual_phrase';
 import {TextEntryBeginEvent, TextEntryEndEvent} from '../types/text-entry';
 
 import {QuickPhrasesComponent} from './quick-phrases.component';
 import {QuickPhrasesModule} from './quick-phrases.module';
+
+type TestMode = 'normal'|'error';
+
+@Injectable()
+class SpeakFasterServiceForTest {
+  readonly contextualPhrases: ContextualPhrase[] = [];
+  private mode: TestMode = 'normal';
+
+  constructor() {
+    this.contextualPhrases.push(
+        ...[{
+          phraseId: createUuid(),
+          text: 'Hello',
+          tags: ['favorite'],
+        },
+            {
+              phraseId: createUuid(),
+              text: 'Thank you',
+              tags: ['favorite'],
+            },
+            {
+              phraseId: createUuid(),
+              text: 'To living room',
+              tags: ['care'],
+            },
+            {
+              phraseId: createUuid(),
+              text: 'To bedroom',
+              tags: ['care'],
+            },
+    ]);
+    for (let i = 0; i < 30; ++i) {
+      this.contextualPhrases.push({
+        phraseId: createUuid(),
+        text: `Count %{i}`,
+        tags: ['counting'],
+      });
+    }
+  }
+
+  public setTestMode(mode: TestMode) {
+    this.mode = mode;
+  }
+
+  textPrediction(textPredictionRequest: TextPredictionRequest):
+      Observable<TextPredictionResponse> {
+    if (this.mode === 'error') {
+      return throwError('Error');
+    } else {
+      return of({
+        contextualPhrases: this.contextualPhrases.filter(phrase => {
+          if (phrase.tags === undefined) {
+            return false;
+          }
+          for (const tag of phrase.tags) {
+            if (!textPredictionRequest.allowedTags ||
+                textPredictionRequest.allowedTags.indexOf(tag) !== -1) {
+              return true;
+            }
+          }
+          return false;
+        }),
+      });
+    }
+  }
+}
 
 describe('QuickPhrasesComponent', () => {
   let fixture: ComponentFixture<QuickPhrasesComponent>;
   let testListener: TestListener;
   let textEntryBeginSubject: Subject<TextEntryBeginEvent>;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
+  let speakFasterServiceForTest: SpeakFasterServiceForTest;
 
   beforeEach(async () => {
+    speakFasterServiceForTest = new SpeakFasterServiceForTest();
     testListener = new TestListener();
     textEntryBeginSubject = new Subject();
     textEntryEndSubject = new Subject();
@@ -25,38 +97,66 @@ describe('QuickPhrasesComponent', () => {
         .configureTestingModule({
           imports: [QuickPhrasesModule],
           declarations: [QuickPhrasesComponent],
-          providers: [],
+          providers: [
+            {provide: SpeakFasterService, useValue: speakFasterServiceForTest}
+          ],
         })
         .compileComponents();
     fixture = TestBed.createComponent(QuickPhrasesComponent);
-    fixture.componentInstance.phrases = ['roses are red', 'violets are blue'];
     fixture.componentInstance.textEntryBeginSubject = textEntryBeginSubject;
     fixture.componentInstance.textEntryEndSubject = textEntryEndSubject;
     fixture.detectChanges();
   });
 
-  it('shows PhraseComponents when phrases are non-empty', () => {
+  it('shows PhraseComponents when phrases are non-empty', async () => {
+    fixture.componentInstance.allowedTags = ['favorite'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          undefined, fixture.componentInstance.allowedTags, true),
+    });
+    await fixture.whenStable();
     const phraseComponents =
         fixture.debugElement.queryAll(By.css('app-phrase-component'));
     const noQuickPhrases =
         fixture.debugElement.query(By.css('.no-quick-phrases'));
     const scrollButtons =
         fixture.debugElement.queryAll(By.css('.scroll-button'));
+    const error = fixture.debugElement.query(By.css('.error'));
 
     expect(phraseComponents.length).toEqual(2);
-    expect(phraseComponents[0].componentInstance.phraseText)
-        .toEqual('roses are red');
+    expect(phraseComponents[0].componentInstance.phraseText).toEqual('Hello');
     expect(phraseComponents[0].componentInstance.phraseIndex).toEqual(0);
     expect(phraseComponents[1].componentInstance.phraseText)
-        .toEqual('violets are blue');
+        .toEqual('Thank you');
     expect(phraseComponents[1].componentInstance.phraseIndex).toEqual(1);
     expect(noQuickPhrases).toBeNull();
     expect(scrollButtons).toEqual([]);
+    expect(error).toBeNull();
   });
 
-  it('shows no-quick-phrases label when phrases are empty', () => {
-    fixture.componentInstance.phrases = [];
-    fixture.detectChanges();
+  it('hides progress spinner after successful prhase retrieval', async () => {
+    fixture.componentInstance.allowedTags = ['favorite'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          undefined, fixture.componentInstance.allowedTags, true),
+    });
+    await fixture.whenStable();
+
+    const retrievingPhrases =
+        fixture.debugElement.query(By.css('.retrieving-quick-phrases'));
+    expect(retrievingPhrases).toBeNull();
+    const matProgressSpinner =
+        fixture.debugElement.query(By.css('mat-progress-spinner'));
+    expect(matProgressSpinner).toBeNull();
+  });
+
+  it('shows no-quick-phrases label when phrases are empty', async () => {
+    fixture.componentInstance.allowedTags = ['nonexistent_tag'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          ['favorite'], fixture.componentInstance.allowedTags, false),
+    });
+    await fixture.whenStable();
     const phraseComponents =
         fixture.debugElement.queryAll(By.css('app-phrase-component'));
     const noQuickPhrases =
@@ -66,7 +166,7 @@ describe('QuickPhrasesComponent', () => {
     expect(noQuickPhrases).not.toBeNull();
   });
 
-  it('phrase speak button triggers text entry begin-end events', () => {
+  it('phrase speak button triggers text entry begin-end events', async () => {
     let beginEvents: TextEntryBeginEvent[] = [];
     let endEvents: TextEntryEndEvent[] = [];
     textEntryBeginSubject.subscribe(event => {
@@ -75,15 +175,21 @@ describe('QuickPhrasesComponent', () => {
     textEntryEndSubject.subscribe(event => {
       endEvents.push(event);
     });
+    fixture.componentInstance.allowedTags = ['favorite'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          undefined, fixture.componentInstance.allowedTags, true),
+    });
+    await fixture.whenStable();
     const phraseComponents =
         fixture.debugElement.queryAll(By.css('app-phrase-component'));
     phraseComponents[0].componentInstance.speakButtonClicked.emit(
-        {phraseText: 'roses are red', phraseIndex: 0});
+        {phraseText: 'Hello', phraseIndex: 0});
 
     expect(beginEvents.length).toEqual(1);
     expect(beginEvents[0].timestampMillis).toBeGreaterThan(0);
     expect(endEvents.length).toEqual(1);
-    expect(endEvents[0].text).toEqual('roses are red');
+    expect(endEvents[0].text).toEqual('Hello');
     expect(endEvents[0].timestampMillis)
         .toBeGreaterThan(beginEvents[0].timestampMillis);
     expect(endEvents[0].injectedKeys).toBeUndefined();
@@ -94,7 +200,7 @@ describe('QuickPhrasesComponent', () => {
     expect(testListener.injectedKeysCalls.length).toEqual(0);
   });
 
-  it('phrase inject button triggers tex entry begin-end events', () => {
+  it('phrase inject button triggers tex entry begin-end events', async () => {
     let beginEvents: TextEntryBeginEvent[] = [];
     let endEvents: TextEntryEndEvent[] = [];
     textEntryBeginSubject.subscribe(event => {
@@ -103,29 +209,39 @@ describe('QuickPhrasesComponent', () => {
     textEntryEndSubject.subscribe(event => {
       endEvents.push(event);
     });
+    fixture.componentInstance.allowedTags = ['favorite'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          undefined, fixture.componentInstance.allowedTags, true),
+    });
+    await fixture.whenStable();
     const phraseComponents =
         fixture.debugElement.queryAll(By.css('app-phrase-component'));
     phraseComponents[1].componentInstance.injectButtonClicked.emit(
-        {phraseText: 'violets are blue', phraseIndex: 1});
+        {phraseText: 'Thank you', phraseIndex: 1});
 
     expect(beginEvents.length).toEqual(1);
     expect(beginEvents[0].timestampMillis).toBeGreaterThan(0);
     expect(endEvents.length).toEqual(1);
-    expect(endEvents[0].text).toEqual('violets are blue');
+    expect(endEvents[0].text).toEqual('Thank you');
     expect(endEvents[0].timestampMillis)
         .toBeGreaterThan(beginEvents[0].timestampMillis);
     expect(endEvents[0].isFinal).toEqual(true);
     expect(endEvents[0].inAppTextToSpeechAudioConfig).toBeUndefined();
     expect(testListener.injectedKeysCalls.length).toEqual(1);
     expect(testListener.injectedKeysCalls[0].length)
-        .toEqual('violets are blue'.length + 1);
+        .toEqual('Thank you'.length + 1);
   });
 
   it('when overflow happens, shows scroll buttons and registers buttons boxes',
      async () => {
-       // Assume that 30 phrases of 'lorem ipsum'. Same below.
-       fixture.componentInstance.phrases = Array(30).fill('lorem ipsum');
-       fixture.detectChanges();
+       // Assume that 30 phrases of 'Counting ...' is enough to cause overflow
+       // and therefore scrolling. Same below.
+       fixture.componentInstance.allowedTags = ['counting'];
+       fixture.componentInstance.ngOnChanges({
+         allowedTags: new SimpleChange(
+             undefined, fixture.componentInstance.allowedTags, true),
+       });
        await fixture.whenStable();
        const phrasesContainer =
            fixture.debugElement.query(By.css('.quick-phrases-container'));
@@ -143,8 +259,11 @@ describe('QuickPhrasesComponent', () => {
      });
 
   it('clicking scroll down button updates scrollTop', async () => {
-    fixture.componentInstance.phrases = Array(30).fill('lorem ipsum');
-    fixture.detectChanges();
+    fixture.componentInstance.allowedTags = ['counting'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          undefined, fixture.componentInstance.allowedTags, true),
+    });
     await fixture.whenStable();
     const phrasesContainer =
         fixture.debugElement.query(By.css('.quick-phrases-container'));
@@ -157,8 +276,11 @@ describe('QuickPhrasesComponent', () => {
   });
 
   it('clicking scroll down then scroll up updates scrollTop', async () => {
-    fixture.componentInstance.phrases = Array(30).fill('lorem ipsum');
-    fixture.detectChanges();
+    fixture.componentInstance.allowedTags = ['counting'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          undefined, fixture.componentInstance.allowedTags, true),
+    });
     await fixture.whenStable();
     const phrasesContainer =
         fixture.debugElement.query(By.css('.quick-phrases-container'));
@@ -170,5 +292,27 @@ describe('QuickPhrasesComponent', () => {
     scrollButtons[0].nativeElement.click();
     await fixture.whenStable();
     expect(phrasesContainer.nativeElement.scrollTop).toEqual(0);
+  });
+
+  it('shows progress spinner during request', () => {
+    const retrievingPhrases =
+        fixture.debugElement.queryAll(By.css('.retrieving-quick-phrases'));
+    expect(retrievingPhrases.length).toEqual(1);
+    const matProgressSpinner =
+        fixture.debugElement.queryAll(By.css('mat-progress-spinner'));
+    expect(matProgressSpinner.length).toEqual(1);
+  });
+
+  it('shows error message when error occurs', async () => {
+    speakFasterServiceForTest.setTestMode('error');
+    fixture.componentInstance.allowedTags = ['favorite'];
+    fixture.componentInstance.ngOnChanges({
+      allowedTags: new SimpleChange(
+          undefined, fixture.componentInstance.allowedTags, true),
+    });
+    await fixture.whenStable();
+
+    const errors = fixture.debugElement.queryAll(By.css('.error'));
+    expect(errors.length).toEqual(1);
   });
 });

--- a/webui/src/app/quick-phrases/quick-phrases.module.ts
+++ b/webui/src/app/quick-phrases/quick-phrases.module.ts
@@ -1,13 +1,16 @@
 import {NgModule} from '@angular/core';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {PhraseModule} from '../phrase/phrase.module';
+
 import {QuickPhrasesComponent} from './quick-phrases.component';
 
 @NgModule({
   declarations: [QuickPhrasesComponent],
   imports: [
     BrowserModule,
+    MatProgressSpinnerModule,
     PhraseModule,
   ],
   exports: [QuickPhrasesComponent],

--- a/webui/src/app/types/contextual_phrase.ts
+++ b/webui/src/app/types/contextual_phrase.ts
@@ -1,0 +1,44 @@
+/**
+ * Type definitions related to contextual phrase predictions ("quick phrases").
+ */
+
+export enum DayOfWeek {
+  DAY_OF_WEEK_UNKNOWN = 0,
+  DAY_OF_WEEK_MONDAY = 1,
+  DAY_OF_WEEK_TUESDAY = 2,
+  DAY_OF_WEEK_WEDNESDAY = 3,
+  DAY_OF_WEEK_THURSDAY = 4,
+  DAY_OF_WEEK_FRIDAY = 5,
+  DAY_OF_WEEK_SATURDAY = 6,
+  DAY_OF_WEEK_SUNDAY = 7,
+}
+
+// A temporal range. The fields of this proto are interpreted as having a
+// logical AND relation. For example, if `day_of_week` is [DAY_OF_WEEK_SUNDAY]
+// and (min_seconds_since_day_start, max_seconds_since_day_start) are (8 * 3600,
+// 9 * 3600), it is interpretedas meaning "every Sunday from 8 AM to 9 AM".
+export interface TemporalRange {
+  // Which day(s) of the week the temporal range applies to.
+  dayOfWeek?: DayOfWeek[];
+
+  // Minimum and maximum seconds since the start of the day. Together thse
+  // two fields specif the time-of-the day range. The absence of this field
+  // is interpreted as the TemporalRange applies to the entire day.
+  minSecondsSinceDayStart?: number;
+  maxSecondsSinceDayStart?: number;
+}
+
+export interface ContextualPhrase {
+  // A unique ID for the phrase.
+  phraseId: string;
+
+  // The text of the phrase.
+  text: string;
+
+  // Tags for the phrase, e.g., "care", "temporal".
+  tags?: string[];
+
+  // The presence of a conversation partner, as specified by the unique ID for
+  // the partner, as a contextual signal.
+  partnerId?: string;
+}


### PR DESCRIPTION
- Create new type definitions in `contextual_phrase.ts`. These are related to the contextual phrases (aka quick phrases) and their associated contexts.
- Refactor the existing interface method `SpeakFasterService.textPrediction()` to accommodate contextual phrase retrieval from backend.
- Remove the hardcoded phrases in `app.componnet.ts`. Replace them with the `allowsTags` argument values that are used by different tabs of quick phrases.
- Refactor `QuickPhrasesCompnent` to adapt to these chagne; update related unit tests.
- In `QuickPhrasesComponent`, add UI elements to show the request-pending and error states.