### PR TITLE
[WebUI] Add InputBarComponent; Fix a few issues

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -73,6 +73,10 @@ Under the AAC user mode, the following URL parameters must be provided:
 3. `endpoint`: This is the URL to the API endpoint that serves features such as
    abbreviation expansion and text prediction.
 
+Optional URL parameters include:
+- `showMetrics`: Controls whether text-entry metrics such as words-per minute
+  (WPM) and keystroke-saving rate (KSR) are visible in the UI. Default: false.
+
 ### 2. Partner (companion) mode
 
 The partner mode can be activated with the URL parameter:

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -119,7 +119,7 @@ app-text-to-speech-component {
   </div>
 
   <app-metrics-component
-      *ngIf="hasAccessToken() && appState !== 'MINIBAR'"
+      *ngIf="showMetrics && hasAccessToken() && appState !== 'MINIBAR'"
       [textEntryBeginSubject]="textEntryBeginSubject"
       [textEntryEndSubject]="textEntryEndSubject">
   </app-metrics-component>

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -150,33 +150,32 @@ app-text-to-speech-component {
     </div>
 
     <div
-        class="main-right-pane mode-quick-pharses"
-        *ngIf="hasAccessToken() && isQuickPhrasesAppState()">
+        class="main-right-pane mode-quick-pharses">
       <app-quick-phrases-component
+          *ngIf="hasAccessToken() && isQuickPhrasesAppState()"
           [allowedTags]="getQuickPhrasesAllowedTags()"
           [color]="getQuickPhrasesColor()"
           [textEntryBeginSubject]="textEntryBeginSubject"
           [textEntryEndSubject]="textEntryEndSubject"
       ></app-quick-phrases-component>
-    </div>
-
-    <div
-        class="main-right-pane mode-abbreviation-expansion"
-        *ngIf="hasAccessToken() && appState === 'ABBREVIATION_EXPANSION'">
 
       <app-context-component
+        *ngIf="hasAccessToken() && appState === 'ABBREVIATION_EXPANSION'"
         [textEntryEndSubject]="textEntryEndSubject"
       ></app-context-component>
 
-      <app-text-prediction-component
-      ></app-text-prediction-component>
-
       <app-abbreviation-component
+        *ngIf="hasAccessToken() && appState === 'ABBREVIATION_EXPANSION'"
         [contextStrings]="contextStrings"
         [abbreviationExpansionTriggers]="abbreviationExpansionTriggers"
         [textEntryEndSubject]="textEntryEndSubject"
       ></app-abbreviation-component>
 
+      <div class="bottom-area">
+        <app-input-bar-component
+            [textEntryEndSubject]="textEntryEndSubject"
+        ></app-input-bar-component>
+      </div>
     </div>
 
   </div>

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -41,6 +41,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
   private previousNonMinimizedAppState: AppState = this.appState;
 
   private _isPartner = false;
+  private _showMetrics = false;
   // Set this to `false` to skip using access token (e.g., developing with
   // an automatically authorized browser context.)
   private useAccessToken = true;
@@ -72,6 +73,9 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
       }
       if (params['endpoint'] && this.endpoint === '') {
         this._endpoint = params['endpoint'];
+      }
+      if (params['show_metrics']) {
+        this._showMetrics = this.stringValueMeansTrue(params['show_metrics']);
       }
       const useOauth = params['use_oauth'];
       if (typeof useOauth === 'string' &&
@@ -145,6 +149,10 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   getUserRole(): UserRole {
     return this._isPartner ? UserRole.PARTNER : UserRole.AAC_USER;
+  }
+
+  get showMetrics(): boolean {
+    return this._showMetrics;
   }
 
   onNewAccessToken(accessToken: string) {

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -96,6 +96,11 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
+  private stringValueMeansTrue(str: string): boolean {
+    str = str.trim().toLocaleLowerCase();
+    return str === 'true' || str === '1' || str === 't';
+  }
+
   ngAfterViewInit() {
     registerExternalKeypressHook(
         this.externalEventsComponent.externalKeypressHook.bind(

--- a/webui/src/app/app.module.ts
+++ b/webui/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
+import {InputBarModule} from './input-bar/input-bar.module';
 import {AbbreviationModule} from './abbreviation/abbreviation.module';
 import {AppRoutingModule} from './app-routing.module';
 import {AppComponent} from './app.component';
@@ -17,6 +18,7 @@ import {TextToSpeechModule} from './text-to-speech/text-to-speech.module';
 @NgModule({
   declarations: [AppComponent],
   imports: [
+    InputBarModule,
     AbbreviationModule,
     AppRoutingModule,
     AuthModule,

--- a/webui/src/app/conversation-turn/conversation-turn.component.ts
+++ b/webui/src/app/conversation-turn/conversation-turn.component.ts
@@ -1,7 +1,8 @@
-import {AfterViewInit, Component, ElementRef, Input, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, Input, OnDestroy, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {createUuid} from 'src/utils/uuid';
 
-import {updateButtonBoxesForElements} from '../../utils/cefsharp';
+import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from '../../utils/cefsharp';
+import {getAgoString} from '../../utils/datetime-utils';
 import {limitStringLength} from '../../utils/text-utils';
 import {ConversationTurn} from '../types/conversation';
 
@@ -10,7 +11,7 @@ import {ConversationTurn} from '../types/conversation';
   templateUrl: './conversation-turn.component.html',
   providers: [],
 })
-export class ConversationTurnComponent implements AfterViewInit {
+export class ConversationTurnComponent implements AfterViewInit, OnDestroy {
   private static readonly _NAME = 'ConversationTurnComponent';
   private readonly instanceId =
       ConversationTurnComponent._NAME + '_' + createUuid();
@@ -20,8 +21,14 @@ export class ConversationTurnComponent implements AfterViewInit {
   private static readonly FONT_SCALING_LENGTH_THRESHOLD = 36;
 
   @Input() turn!: ConversationTurn;
+  @Input() isFocus: boolean = false;
+  @Input() showTimestamp: boolean = false;
   @ViewChildren('button') buttons!: QueryList<ElementRef<HTMLButtonElement>>;
   @ViewChild('turnContent') turnContentElement!: ElementRef;
+
+  get agoString(): string {
+    return getAgoString(new Date(this.turn.startTimestamp!), new Date());
+  }
 
   get contentString(): string {
     const length = this.turn.speechContent.length;
@@ -47,7 +54,10 @@ export class ConversationTurnComponent implements AfterViewInit {
           0.45);
     }
     contentElement.style.fontSize = `${fontSizePx.toFixed(1)}px`;
-    updateButtonBoxesForElements(
-        ConversationTurnComponent._NAME + this.instanceId, this.buttons);
+    updateButtonBoxesForElements(this.instanceId, this.buttons);
+  }
+
+  ngOnDestroy() {
+    updateButtonBoxesToEmpty(this.instanceId);
   }
 }

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -1,0 +1,94 @@
+<style>
+
+:host {
+    box-sizing: border-box;
+    color: #EEE;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 32px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+input[type="text"]:disabled{
+  background: #272626;
+  color: white;
+  font-size: 30px;
+  height: 48px;
+}
+
+.button-image {
+  max-width: 50%;
+  max-height: 50%;
+}
+
+.input-box {
+  border: none;
+  border-radius: 8px;
+  flex: 1;
+  margin: 0 8px;
+  min-width: 100%;
+  width: 100%;
+}
+
+.button-shortcut-key {
+  font-size: 18px;
+  color: #888;
+}
+
+.container {
+  display: flex;
+  flex-direction: row;
+  line-height: 45px;
+  padding: 0 0 5px;
+  vertical-align: middle;
+  width: 800px;
+}
+
+.hidden {
+  display: none;
+}
+
+.action-button {
+  background: #27AE60;
+  border: none;
+  border-radius: 8px;
+  color: #eee;
+  flex: 1;
+  font-size: 20px;
+  height: 50px;
+  margin: 0 10px;
+  min-width: 100px;
+  padding: 0;
+  vertical-align: middle;
+  width: 100px;
+}
+
+.favorite-button {
+  background: #473261;
+}
+
+</style>
+
+<div class="container">
+
+  <input
+      class="input-box"
+      type="text"
+      disabled="true"
+      value="{{inputString}}" />
+
+  <button
+      #clickableButton
+      class="action-button speak-button"
+      (click)="onSpeakAsIsButtonClicked($event)">
+      <img class="button-image" src="/assets/images/speak.png" alt="speak phrase as is" />
+  </button>
+
+  <button
+      #clickableButton
+      class="action-button favorite-button"
+      (click)="onFavoriteButtonClicked($event)">
+      <img class="button-image" src="/assets/images/favorite.png" alt="add phrase to favorite" />
+  </button>
+
+</div>

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1,0 +1,114 @@
+/** Unit tests for InputBarComponent. */
+import {ElementRef} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
+
+import {TextEntryEndEvent} from '../types/text-entry';
+
+import {InputBarComponent} from './input-bar.component';
+import {InputBarModule} from './input-bar.module';
+
+describe('InputBarComponent', () => {
+  let textEntryEndSubject: Subject<TextEntryEndEvent>;
+  let fixture: ComponentFixture<InputBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed
+        .configureTestingModule({
+          imports: [InputBarModule],
+          declarations: [InputBarComponent],
+        })
+        .compileComponents();
+    textEntryEndSubject = new Subject();
+    fixture = TestBed.createComponent(InputBarComponent);
+    fixture.componentInstance.textEntryEndSubject = textEntryEndSubject;
+    fixture.detectChanges();
+  });
+
+  it('input box is initially empty', () => {
+    const input = fixture.debugElement.query(By.css('.input-box')) as
+        ElementRef<HTMLInputElement>;
+
+    expect(input.nativeElement.value).toEqual('');
+  });
+
+  it('non-final text entry event updates input box value', () => {
+    textEntryEndSubject.next({
+      text: 'foo ',
+      timestampMillis: new Date().getTime(),
+      isFinal: false,
+    });
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('.input-box')) as
+        ElementRef<HTMLInputElement>;
+    expect(input.nativeElement.value).toEqual('foo ');
+  });
+
+  for (const isAborted of [false, true]) {
+    it(`final text entry event updates input box: isAborted=${isAborted}`,
+       () => {
+         textEntryEndSubject.next({
+           text: 'it is',
+           timestampMillis: new Date().getTime(),
+           isFinal: false,
+         });
+         textEntryEndSubject.next({
+           text: 'it is done',
+           timestampMillis: new Date().getTime(),
+           isFinal: true,
+           isAborted,
+         });
+         fixture.detectChanges();
+
+         const input = fixture.debugElement.query(By.css('.input-box')) as
+             ElementRef<HTMLInputElement>;
+         expect(input.nativeElement.value).toEqual('');
+       });
+  }
+
+  it('listening to keypress updates input box value', () => {
+    fixture.componentInstance.listenToKeypress(['h', 'e'], 'he');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('.input-box')) as
+        ElementRef<HTMLInputElement>;
+    expect(input.nativeElement.value).toEqual('he');
+  });
+
+  it('clicking speak button with non-empty text triggers TTS', () => {
+    fixture.componentInstance.listenToKeypress(['h', 'i'], 'hi');
+    fixture.detectChanges();
+    const events: TextEntryEndEvent[] = [];
+    textEntryEndSubject.subscribe(event => {
+      events.push(event);
+    });
+    const speakButton = fixture.debugElement.query(By.css('.speak-button'));
+    speakButton.nativeElement.click();
+
+    expect(events.length).toEqual(1);
+    expect(events[0].text).toEqual('hi');
+    expect(events[0].isFinal).toEqual(true);
+    expect(events[0].isAborted).toBeUndefined();
+    expect(events[0].inAppTextToSpeechAudioConfig).toEqual({volume_gain_db: 0});
+  });
+
+  for (const textValue of ['', ' ', '\t']) {
+    it(`'clicking speak button with empty text has no effect: ` +
+           `value=${JSON.stringify(textValue)}`,
+       () => {
+         fixture.componentInstance.inputString = textValue;
+         fixture.detectChanges();
+         const events: TextEntryEndEvent[] = [];
+         textEntryEndSubject.subscribe(event => {
+           events.push(event);
+         });
+         const speakButton =
+             fixture.debugElement.query(By.css('.speak-button'));
+         speakButton.nativeElement.click();
+
+         expect(events).toEqual([]);
+       });
+  }
+});

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -1,0 +1,75 @@
+/** An input bar, with related functional buttons. */
+import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnInit, Output, QueryList, ViewChildren} from '@angular/core';
+import {Subject} from 'rxjs';
+import {updateButtonBoxesForElements} from 'src/utils/cefsharp';
+import {createUuid} from 'src/utils/uuid';
+
+import {ExternalEventsComponent} from '../external/external-events.component';
+import {TextEntryEndEvent} from '../types/text-entry';
+
+@Component({
+  selector: 'app-input-bar-component',
+  templateUrl: './input-bar.component.html',
+})
+export class InputBarComponent implements OnInit, AfterViewInit {
+  private static readonly _NAME = 'InputBarComponent';
+  private readonly instanceId = InputBarComponent._NAME + '_' + createUuid();
+
+  @Input() textEntryEndSubject!: Subject<TextEntryEndEvent>;
+
+  @ViewChildren('clickableButton')
+  buttons!: QueryList<ElementRef<HTMLButtonElement>>;
+
+  inputString: string = '';
+
+  ngOnInit() {
+    this.textEntryEndSubject.subscribe((textInjection: TextEntryEndEvent) => {
+      if (textInjection.isFinal) {
+        this.resetState();
+      } else {
+        this.inputString = textInjection.text;
+      }
+    });
+    ExternalEventsComponent.registerKeypressListener(
+        this.listenToKeypress.bind(this));
+  }
+
+  ngAfterViewInit() {
+    updateButtonBoxesForElements(this.instanceId, this.buttons);
+    this.buttons.changes.subscribe(
+        (queryList: QueryList<ElementRef<HTMLButtonElement>>) => {
+          updateButtonBoxesForElements(this.instanceId, queryList);
+        });
+  }
+
+  public listenToKeypress(keySequence: string[], reconstructedText: string):
+      void {
+    this.inputString = reconstructedText;
+  }
+
+  onSpeakAsIsButtonClicked(event: Event) {
+    if (!this.inputString.trim()) {
+      return;
+    }
+    const text = this.inputString.trim();
+    this.textEntryEndSubject.next({
+      text,
+      timestampMillis: Date.now(),
+      isFinal: true,
+      inAppTextToSpeechAudioConfig: {
+        volume_gain_db: 0,
+      }
+    });
+  }
+
+  onFavoriteButtonClicked(event: Event) {
+    if (!this.inputString.trim()) {
+      return;
+    }
+    // TODO(cais): Implement favoriting phrases.
+  }
+
+  private resetState() {
+    this.inputString = '';
+  }
+}

--- a/webui/src/app/input-bar/input-bar.module.ts
+++ b/webui/src/app/input-bar/input-bar.module.ts
@@ -1,0 +1,17 @@
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+
+import {SpellModule} from '../spell/spell.module';
+
+import {InputBarComponent} from './input-bar.component';
+
+@NgModule({
+  declarations: [InputBarComponent],
+  imports: [
+    BrowserModule,
+    SpellModule,
+  ],
+  exports: [InputBarComponent],
+})
+export class InputBarModule {
+}

--- a/webui/src/app/quick-phrases/quick-phrases.component.html
+++ b/webui/src/app/quick-phrases/quick-phrases.component.html
@@ -36,7 +36,7 @@ mat-progress-spinner {
 }
 
 .quick-phrases-container {
-  height: 365px;
+  height: 300px;
   max-height: 365px;
   overflow-y: hidden;
 }

--- a/webui/src/app/spell/spell.component.html
+++ b/webui/src/app/spell/spell.component.html
@@ -10,6 +10,11 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+input[type="text"]:disabled{
+  background: #272626;
+  color: white;
+}
+
 .abbreviated-token {
   background: #333;
   border: 2px solid #888;
@@ -18,7 +23,7 @@
   display: inline-block;
   font-size: 24px;
   line-height: 24px;
-  margin: 10px 0 10px 10px;
+  margin: 5px 0 5px 10px;
   min-width: 75px;
   padding: 15px;
   vertical-align: middle;;
@@ -31,7 +36,7 @@
 }
 
 .done-button {
-  background: #333;
+  background: darkgreen;
   border: 2px solid #888;
   border-radius: 5px;
   color: #eee;
@@ -84,8 +89,9 @@
   <input
       *ngIf="spellIndex !== null && i === spellIndex"
       class="spell-input"
+      type="text"
+      disabled="true"
       [value]="tokenSpellingInput" />
-
 </div>
 
 <button

--- a/webui/src/app/spell/spell.component.spec.ts
+++ b/webui/src/app/spell/spell.component.spec.ts
@@ -1,6 +1,6 @@
 /** Unit tests for the SpellComponent. */
 import {HttpClientModule} from '@angular/common/http';
-import {SimpleChange} from '@angular/core';
+import {ElementRef, SimpleChange} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
@@ -86,6 +86,22 @@ describe('SpellComponent', () => {
     const spellInputs = fixture.debugElement.queryAll(By.css('.spell-input'));
     expect(spellInputs.length).toEqual(1);
     expect(spellInputs[0].nativeElement.value).toEqual('b');
+  });
+
+  it('input box is disabled and has type text during spelling', () => {
+    fixture.componentInstance.originalAbbreviationSpec =
+        getAbbreviationSpecForTest(['a', 'b', 'c']);
+    fixture.componentInstance.spellIndex = 1;
+    fixture.detectChanges();
+    fixture.componentInstance.listenToKeypress(
+        ['a', 'b', 'c', ' ', ' ', 'b'], 'abc  b');
+    fixture.detectChanges();
+
+    const spellInputs = fixture.debugElement.queryAll(By.css('.spell-input'));
+    expect(spellInputs.length).toEqual(1);
+    expect(spellInputs[0].nativeElement.getAttribute('type')).toEqual('text');
+    expect(spellInputs[0].nativeElement.getAttribute('disabled'))
+        .toEqual('true');
   });
 
   it('typing letters for spelled word populates spell input', () => {

--- a/webui/src/app/spell/spell.component.ts
+++ b/webui/src/app/spell/spell.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
+import {ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
 import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {isAlphanumericChar} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
@@ -58,6 +58,7 @@ export class SpellComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnDestroy() {
     // TODO(cais): Add unit test.
+    updateButtonBoxesToEmpty(this.instanceId);
     ExternalEventsComponent.unregisterKeypressListener(this.keypressListener);
   }
 

--- a/webui/src/app/types/abbreviation.ts
+++ b/webui/src/app/types/abbreviation.ts
@@ -64,8 +64,3 @@ export interface InputAbbreviationChangedEvent {
   readonly requestExpansion: boolean;
 }
 
-/** An event that signifies the starting of spelling out of an abbreviation. */
-export interface StartSpellingEvent {
-  readonly originalAbbreviationChars: string[];
-  readonly isNewSpellingTask: boolean;
-}

--- a/webui/src/utils/datetime-utils.spec.ts
+++ b/webui/src/utils/datetime-utils.spec.ts
@@ -1,0 +1,23 @@
+import {getAgoString} from './datetime-utils';
+
+describe('Datetime utils', () => {
+  describe('getAgoString', () => {
+    it('returns correct seconds string', () => {
+      const t0 = new Date();
+      expect(getAgoString(t0, t0)).toEqual('0s');
+      expect(getAgoString(t0, new Date(t0.getTime() + 10 * 1e3)))
+          .toEqual('10s');
+      expect(getAgoString(t0, new Date(t0.getTime() + 59 * 1e3)))
+          .toEqual('59s');
+    });
+
+    it('returns correct minute string', () => {
+      const t0 = new Date();
+      expect(getAgoString(t0, new Date(t0.getTime() + 60 * 1e3))).toEqual('1m');
+      expect(getAgoString(t0, new Date(t0.getTime() + 89 * 1e3))).toEqual('1m');
+      expect(getAgoString(t0, new Date(t0.getTime() + 90 * 1e3))).toEqual('2m');
+      expect(getAgoString(t0, new Date(t0.getTime() + 119 * 1e3)))
+          .toEqual('2m');
+    });
+  });
+});

--- a/webui/src/utils/datetime-utils.ts
+++ b/webui/src/utils/datetime-utils.ts
@@ -1,0 +1,17 @@
+/** Utilities related to date and time. */
+
+export function secondsBeforeNow(seconds: number): Date {
+  const now = new Date().getTime();
+  return new Date(now - seconds * 1e3);
+}
+
+export function getAgoString(
+    referenceTimestamp: Date, timestamp: Date): string {
+  const diffSeconds = Math.round(
+      Math.max(0, timestamp.getTime() - referenceTimestamp.getTime()) / 1e3);
+  if (diffSeconds >= 60) {
+    return `${Math.round(diffSeconds / 60)}m`;
+  } else {
+    return `${diffSeconds}s`;
+  }
+}


### PR DESCRIPTION
- See screenshot of the newly-added `InputBarComponent`, where the 2nd (favorite) button is not yet functional.
  - ![image](https://user-images.githubusercontent.com/16824702/153298235-a9e458fa-c5f2-4161-bb09-9f62dae48ca9.png)
- Fixes #184: Remove timestamp from `ConversationTurnComponent` by default
- Fixes #188: Make input elements in `SpellComponent` not focusable in order to prevent double processing of keypresses
- Hide `MetricsComponent` under URL parameter `showMetrics`