### PR TITLE
[WebUI] Refactor TextToSpeechComponent to support local TTS

### DIFF
--- a/webui/src/app/text-to-speech-service.ts
+++ b/webui/src/app/text-to-speech-service.ts
@@ -5,10 +5,20 @@ import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 
+/** Audio configuration for text-to-speech. */
 export interface AudioConfig {
   audio_encoding: 'LINEAR16';
 
+  // Speaking rate. 1.0 corresponds to baseline.
+  // values <1.0 and >0.0 means slower than baseline.
+  // Values >1.0 means faster than baseline.
   speaking_rate: number;
+
+  // Volume (sound intensity) of the requested audio, in decibels
+  // (dB). 0 means no additional gain relative to baseline.
+  // Values <0 means intensity lower (quieter) than baseline.
+  // Values >0 means intensity higher (louder) than baseline.
+  volume_gain_db: number;
 
   // TODO(cais): Add prosody parameters such as pitch.
 }
@@ -56,6 +66,7 @@ export class TextToSpeechService implements TextToSpeechServiceStub {
         language: request.language,
         audio_encoding: request.audio_config.audio_encoding,
         speaking_rate: request.audio_config.speaking_rate,
+        volume_gain_db: request.audio_config.volume_gain_db,
         access_token: request.access_token,
       },
     });

--- a/webui/src/app/text-to-speech/text-to-speech.component.html
+++ b/webui/src/app/text-to-speech/text-to-speech.component.html
@@ -7,15 +7,3 @@
 
 <audio #ttsAudio></audio>
 
-<div
-    *ngIf="audioPlaying"
-    class="audio-playing">
-  🔊
-</div>
-
-<div
-    *ngIf="errorMessage !== null"
-    class="error-message">
-  <span>TTS error:</span>
-  {{errorMessage}}
-</div>

--- a/webui/src/app/text-to-speech/text-to-speech.component.spec.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.spec.ts
@@ -1,11 +1,11 @@
 /** Unit tests for TextToSpeechComponent. */
 import {HttpClientModule} from '@angular/common/http';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {of, Subject, throwError} from 'rxjs';
 
 import {TextEntryEndEvent} from '../types/text-entry';
 
-import {TextToSpeechComponent} from './text-to-speech.component';
+import {getCloudTextToSpeechVolumeGainDb, getLocalTextToSpeechVolume, TextToSpeechComponent, TextToSpeechEvent, TextToSpeechListener} from './text-to-speech.component';
 import {TextToSpeechModule} from './text-to-speech.module';
 
 describe('TextToSpeechCmponent', () => {
@@ -15,7 +15,7 @@ describe('TextToSpeechCmponent', () => {
 
   beforeEach(async () => {
     textEntryEndSubject = new Subject();
-    // textToSpeechServiceForTest = new TextToSpeechServiceForTest();
+    TextToSpeechComponent.clearTextToSpeechListener();
     await TestBed
         .configureTestingModule({
           imports: [TextToSpeechModule, HttpClientModule],
@@ -27,125 +27,144 @@ describe('TextToSpeechCmponent', () => {
     component.textEntryEndSubject = textEntryEndSubject;
     fixture.detectChanges();
     component.accessToken = 'test_token';
+    component.disableAudioElementPlayForTest();
     jasmine.getEnv().allowRespy(true);
   });
 
-  it('Initially shows no error message', () => {
-    const errorMessage = fixture.nativeElement.querySelector('.error-message');
-    expect(errorMessage).toBeNull();
-  });
-
-  it('Initially audio element src is empty string', () => {
-    const audioElement =
-        fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
-    expect(audioElement.src).toEqual('');
-  });
-
-  it('On textEntryEndEvent with TTS audio config, sets audio element src',
-     async () => {
-       const audioElement =
-           fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+  it('registerTextToSpeechListener registers listeners and gets TTS events',
+     fakeAsync(() => {
        spyOn(component.textToSpeechService, 'synthesizeSpeech')
            .and.returnValue(of({
              audio_content: '0123abcd',
              audio_config: {
                audio_encoding: 'LINEAR16',
                speaking_rate: 1.0,
+               volume_gain_db: 0.0,
              }
            }));
+       const recordedEvents: TextToSpeechEvent[] = [];
+       const listener: TextToSpeechListener = (event: TextToSpeechEvent) => {
+         recordedEvents.push(event);
+       };
+       TextToSpeechComponent.registerTextToSpeechListener(listener);
        textEntryEndSubject.next({
-         text: 'hi, there',
+         text: 'Hi there',
          timestampMillis: new Date().getTime(),
          isFinal: true,
-         inAppTextToSpeechAudioConfig: {
-           volume_gain_db: 0,
-         }
+         inAppTextToSpeechAudioConfig: {}
        });
-       await fixture.whenStable();
-       expect(audioElement.src).toEqual('data:audio/wav;base64,0123abcd');
-     });
+       tick();
 
-  it('Empty audio content: shows error message', async () => {
-    const audioElement =
-        fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
-    spyOn(component.textToSpeechService, 'synthesizeSpeech')
-        .and.returnValue(of({
-          audio_content: '',
-          audio_config: {
-            audio_encoding: 'LINEAR16',
-            speaking_rate: 1.0,
-          }
-        }));
-    textEntryEndSubject.next({
-      text: 'hi, there',
-      timestampMillis: new Date().getTime(),
-      isFinal: true,
-      inAppTextToSpeechAudioConfig: {
-        volume_gain_db: 0,
-      }
-    });
-    await fixture.whenStable();
-    fixture.detectChanges();
-    const errorMessage =
-        fixture.nativeElement.querySelector('.error-message') as HTMLDivElement;
-    expect(errorMessage.innerText).toEqual('TTS error: audio is empty');
-  });
+       expect(recordedEvents.length).toEqual(1);
+       expect(recordedEvents[0])
+           .toEqual({state: 'REQUESTING', errorMessage: undefined});
+       expect(component.audioPlayCallCount).toEqual(1);
+       expect(component.ttsAudioElements.first.nativeElement.src)
+           .toEqual('data:audio/wav;base64,0123abcd');
+     }));
 
-  it('textEntryEndEvent without audio config does not set audio element',
-     async () => {
-       const audioElement =
-           fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+  it('unregisterTextToSpeechListener unregisters listener', fakeAsync(() => {
+       spyOn(component.textToSpeechService, 'synthesizeSpeech')
+           .and.returnValue(of({
+             audio_content: '0123abcd',
+             audio_config: {
+               audio_encoding: 'LINEAR16',
+               speaking_rate: 1.0,
+               volume_gain_db: 0.0,
+             }
+           }));
+       const recordedEvents: TextToSpeechEvent[] = [];
+       const listener: TextToSpeechListener = (event: TextToSpeechEvent) => {
+         recordedEvents.push(event);
+       };
+       TextToSpeechComponent.registerTextToSpeechListener(listener);
+       TextToSpeechComponent.unregisterTextToSpeechListener(listener);
        textEntryEndSubject.next({
-         text: 'hi, there',
+         text: 'Hi there',
          timestampMillis: new Date().getTime(),
          isFinal: true,
+         inAppTextToSpeechAudioConfig: {}
        });
-       await fixture.whenStable();
-       expect(audioElement.src).toEqual('');
-     });
+       tick();
 
-  it('textEntryEndEvent with audio config without access token sets error message',
-     async () => {
-       component.accessToken = '';
+       expect(recordedEvents.length).toEqual(0);
+     }));
+
+  it('listener is notified of audio data empty error', fakeAsync(() => {
+       spyOn(component.textToSpeechService, 'synthesizeSpeech')
+           .and.returnValue(of({
+             audio_content: '',
+             audio_config: {
+               audio_encoding: 'LINEAR16',
+               speaking_rate: 1.0,
+               volume_gain_db: 0.0,
+             }
+           }));
+       const recordedEvents: TextToSpeechEvent[] = [];
+       const listener: TextToSpeechListener = (event: TextToSpeechEvent) => {
+         recordedEvents.push(event);
+       };
+       TextToSpeechComponent.registerTextToSpeechListener(listener);
        textEntryEndSubject.next({
-         text: 'hi, there',
+         text: 'Hi there',
          timestampMillis: new Date().getTime(),
          isFinal: true,
-         inAppTextToSpeechAudioConfig: {volume_gain_db: 0}
+         inAppTextToSpeechAudioConfig: {}
        });
-       await fixture.whenStable();
-       fixture.detectChanges();
-       const errorMessage = fixture.nativeElement.querySelector(
-                                '.error-message') as HTMLDivElement;
-       expect(errorMessage.innerText).toEqual('TTS error: no access token');
-     });
+       tick();
 
-  for (const [errorObject, expectedErrorText] of [
-           [{error: {error_message: 'foo error'}}, 'TTS error: foo error'],
-           [{statusText: 'bar error'}, 'TTS error: bar error']] as
-       Array<[any, string]>) {
-    it(`synthesizeSpeech call error shows error message: ${expectedErrorText}`,
-       async () => {
-         const audioElement =
-             fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
-         spyOn(component.textToSpeechService, 'synthesizeSpeech')
-             .and.callFake(() => {
-               return throwError(errorObject);
-             });
-         textEntryEndSubject.next({
-           text: 'hi, there',
-           timestampMillis: new Date().getTime(),
-           isFinal: true,
-           inAppTextToSpeechAudioConfig: {
-             volume_gain_db: 0,
-           }
-         });
-         await fixture.whenStable();
-         fixture.detectChanges();
-         expect(audioElement.src).toEqual('');
-         const errorMessage = fixture.nativeElement.querySelector(
-                                  '.error-message') as HTMLDivElement;
-         expect(errorMessage.innerText).toEqual(expectedErrorText);
+       expect(recordedEvents.length).toEqual(2);
+       expect(recordedEvents[0])
+           .toEqual({state: 'REQUESTING', errorMessage: undefined});
+       expect(recordedEvents[1])
+           .toEqual({state: 'ERROR', errorMessage: 'Audio is empty'});
+     }));
+
+  it('listener is notified of error from service', fakeAsync(() => {
+       spyOn(component.textToSpeechService, 'synthesizeSpeech')
+           .and.returnValue(
+               throwError({error: {error_message: 'foo audio error'}}));
+       const recordedEvents: TextToSpeechEvent[] = [];
+       const listener: TextToSpeechListener = (event: TextToSpeechEvent) => {
+         recordedEvents.push(event);
+       };
+       TextToSpeechComponent.registerTextToSpeechListener(listener);
+       textEntryEndSubject.next({
+         text: 'Hi there',
+         timestampMillis: new Date().getTime(),
+         isFinal: true,
+         inAppTextToSpeechAudioConfig: {}
+       });
+       tick();
+
+       expect(recordedEvents.length).toEqual(2);
+       expect(recordedEvents[0])
+           .toEqual({state: 'REQUESTING', errorMessage: undefined});
+       expect(recordedEvents[1])
+           .toEqual({state: 'ERROR', errorMessage: 'foo audio error'});
+     }));
+
+  for (const [ttsVolume, expectedGainDb] of [
+           ['QUIET', -10], ['MEDIUM', 0], ['LOUD', 16]] as
+       Array<['QUIET' | 'MEDIUM' | 'LOUD', number]>) {
+    it('getCloudTextToSpeechVolumeGainDb returns correct values: ' + ttsVolume,
+       () => {
+         expect(getCloudTextToSpeechVolumeGainDb({
+           ttsVoiceType: 'PERSONALIZED',
+           ttsVolume: ttsVolume,
+         })).toEqual(expectedGainDb);
+       });
+  }
+
+  for (const [ttsVolume, expectedGainDb] of [
+           ['QUIET', 0.2], ['MEDIUM', 0.5], ['LOUD', 1.0]] as
+       Array<['QUIET' | 'MEDIUM' | 'LOUD', number]>) {
+    it('getLocalTextToSpeechVolume returns correct values: ' + ttsVolume,
+       () => {
+         expect(getLocalTextToSpeechVolume({
+           ttsVoiceType: 'GENERIC',
+           ttsVolume: ttsVolume,
+         })).toEqual(expectedGainDb);
        });
   }
 });

--- a/webui/src/app/text-to-speech/text-to-speech.component.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.ts
@@ -3,11 +3,48 @@ import {HttpErrorResponse} from '@angular/common/http';
 import {ChangeDetectorRef, Component, ElementRef, Input, OnInit, QueryList, ViewChildren} from '@angular/core';
 import {Subject} from 'rxjs';
 
+import {AppSettings, getAppSettings} from '../settings/settings';
 import {TextToSpeechErrorResponse, TextToSpeechService} from '../text-to-speech-service';
 import {TextEntryEndEvent} from '../types/text-entry';
 
 const DEFAULT_LANGUAGE_CODE = 'en-US';
 const DEFAULT_AUDIO_ENCODING = 'LINEAR16';
+
+export type TextToSpeechState = 'REQUESTING'|'PLAY'|'END'|'ERROR';
+
+export interface TextToSpeechEvent {
+  state: TextToSpeechState;
+
+  errorMessage?: string;
+}
+
+export type TextToSpeechListener = (event: TextToSpeechEvent) => void;
+
+export function getCloudTextToSpeechVolumeGainDb(appSettings: AppSettings):
+    number {
+  // Unit: dB. Default is 0.
+  const volume = appSettings.ttsVolume;
+  switch (volume) {
+    case 'QUIET':
+      return -10.0;
+    case 'MEDIUM':
+      return 0.0;
+    case 'LOUD':
+      return 16.0;
+  }
+}
+
+export function getLocalTextToSpeechVolume(appSettings: AppSettings): number {
+  const volume = appSettings.ttsVolume;
+  switch (volume) {
+    case 'QUIET':
+      return 0.2;
+    case 'MEDIUM':
+      return 0.5;
+    case 'LOUD':
+      return 1.0;
+  }
+}
 
 @Component({
   selector: 'app-text-to-speech-component',
@@ -15,39 +52,65 @@ const DEFAULT_AUDIO_ENCODING = 'LINEAR16';
   providers: [TextToSpeechService],
 })
 export class TextToSpeechComponent implements OnInit {
+  private static readonly listeners: TextToSpeechListener[] = [];
+
   @Input() textEntryEndSubject!: Subject<TextEntryEndEvent>;
   @Input() accessToken!: string;
 
   @ViewChildren('ttsAudio')
   ttsAudioElements!: QueryList<ElementRef<HTMLAudioElement>>;
-
-  errorMessage?: string|null = null;
-  audioPlaying: boolean = false;
+  private _audioPlayCallCount: number = 0;
+  private audioPlayDisabledForTest = false;
 
   constructor(
       public textToSpeechService: TextToSpeechService,
       private cdr: ChangeDetectorRef) {}
 
+  public static registerTextToSpeechListener(listener: TextToSpeechListener) {
+    if (TextToSpeechComponent.listeners.indexOf(listener) !== -1) {
+      return;
+    }
+    TextToSpeechComponent.listeners.push(listener);
+  }
+
+  public static unregisterTextToSpeechListener(listener: TextToSpeechListener) {
+    const index = TextToSpeechComponent.listeners.indexOf(listener);
+    if (index === -1) {
+      return;
+    }
+    TextToSpeechComponent.listeners.splice(index, 1);
+  }
+
+  public static clearTextToSpeechListener() {
+    TextToSpeechComponent.listeners.splice(0);
+  }
+
   ngOnInit() {
-    this.textEntryEndSubject.subscribe(event => {
-      // TODO(cais): Add unit test.
+    this.textEntryEndSubject.subscribe(async event => {
       if (!event.isFinal || event.inAppTextToSpeechAudioConfig === undefined) {
         return;
       }
-      const {volume_gain_db} = event.inAppTextToSpeechAudioConfig;
-      if (volume_gain_db !== undefined && volume_gain_db !== 0) {
-        // TODO(#49): Support volume control.
-        throw new Error('Volume gain adjustment is not implemented yet.');
+      const appSettings = await getAppSettings();
+      const ttsVoiceType = appSettings.ttsVoiceType;
+      if (ttsVoiceType === 'PERSONALIZED') {
+        this.doCloudTextToSpeech(event.text, appSettings);
+      } else {
+        this.doLocalTextToSpeech(event.text, appSettings);
       }
-      this.sendTextToSpeechRequest(event.text);
     });
   }
 
-  sendTextToSpeechRequest(text: string) {
+  /**
+   * Send Cloud call for speech synthesis and then play the synthesized audio.
+   */
+  private doCloudTextToSpeech(text: string, appSettings: AppSettings) {
     if (this.accessToken.length === 0) {
-      this.errorMessage = 'no access token';
+      TextToSpeechComponent.listeners.forEach(listener => {
+        listener({state: 'ERROR', errorMessage: 'No access token'});
+      });
       return;
     }
+    this.setListenersState('REQUESTING');
     this.textToSpeechService
         .synthesizeSpeech({
           text,
@@ -55,39 +118,78 @@ export class TextToSpeechComponent implements OnInit {
           audio_config: {
             audio_encoding: DEFAULT_AUDIO_ENCODING,
             speaking_rate: 1.0,
+            volume_gain_db: getCloudTextToSpeechVolumeGainDb(appSettings),
           },
           access_token: this.accessToken,
         })
         .subscribe(
             data => {
-              this.errorMessage = null;
-              const ttsAudioElement = this.ttsAudioElements.first.nativeElement;
+              const ttsAudioElement =
+                  this.ttsAudioElements.first.nativeElement as HTMLAudioElement;
               if (!ttsAudioElement.onplay) {
                 ttsAudioElement.onplay = () => {
-                  this.audioPlaying = true;
+                  this.setListenersState('PLAY');
                 };
                 ttsAudioElement.onended = () => {
-                  this.audioPlaying = false;
+                  this.setListenersState('END');
                 };
               }
               if (!data.audio_content) {
-                this.errorMessage = 'audio is empty';
+                TextToSpeechComponent.listeners.forEach(listener => {
+                  listener({state: 'ERROR', errorMessage: 'Audio is empty'});
+                });
+                ;
                 return;
               }
               ttsAudioElement.src =
                   'data:audio/wav;base64,' + data.audio_content;
-              ttsAudioElement.play();
+              if (!this.audioPlayDisabledForTest) {
+                ttsAudioElement.play();
+              }
+              this._audioPlayCallCount++;
               this.cdr.detectChanges();
             },
             (error: HttpErrorResponse) => {
+              let errorMessage = '';
               if (error.error &&
                   (error.error as TextToSpeechErrorResponse).error_message) {
-                this.errorMessage =
+                errorMessage =
                     (error.error as TextToSpeechErrorResponse).error_message;
               } else {
-                this.errorMessage = `${error.statusText}`;
+                errorMessage = `${error.statusText}`;
               }
+              TextToSpeechComponent.listeners.forEach(listener => {
+                listener({state: 'ERROR', errorMessage});
+              });
               this.cdr.detectChanges();
             });
+  }
+
+  /** Use local WebSpeech API to perform text-to-speech output. */
+  private doLocalTextToSpeech(text: string, appSettings: AppSettings) {
+    const utterance = new SpeechSynthesisUtterance(text.trim());
+    this.setListenersState('REQUESTING');
+    utterance.onstart = () => {
+      this.setListenersState('PLAY');
+    };
+    utterance.onend = () => {
+      this.setListenersState('END');
+    };
+    utterance.volume = getLocalTextToSpeechVolume(appSettings);
+    window.speechSynthesis.speak(utterance);
+  }
+
+  private setListenersState(state: TextToSpeechState, errorMessage?: string) {
+    TextToSpeechComponent.listeners.forEach(listener => {
+      listener({state, errorMessage});
+    });
+  }
+
+  public disableAudioElementPlayForTest() {
+    this.audioPlayDisabledForTest = true;
+  }
+
+  get audioPlayCallCount(): number {
+    return this._audioPlayCallCount;
   }
 }


### PR DESCRIPTION
- Support both cloud TTS (ttsVoiceType === 'PERSONALIZED') and generic local TTS (ttsVoiceType === 'GENERIC')
- In TextToSpeechComponent, remove the constituent UI elements for status display (e.g., playing, error). Instead, delegate the status display to listeners.

Fixes #198 