### PR TITLE
[WebUI] Add LexiconComponent

### DIFF
--- a/webui/src/app/lexicon/lexicon.component.spec.ts
+++ b/webui/src/app/lexicon/lexicon.component.spec.ts
@@ -1,0 +1,158 @@
+/** Unit tests for LexiconComponent. */
+import {HttpClientModule} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Observable, of, Subject} from 'rxjs';
+
+import {GetLexiconRequest, GetLexiconResponse, SpeakFasterService, TextPredictionRequest, TextPredictionResponse} from '../speakfaster-service';
+
+import {canonicalizeName, chooseStringRandomly, LexiconComponent, LoadLexiconRequest} from './lexicon.component';
+import {LexiconModule} from './lexicon.module';
+
+@Injectable()
+class SpeakFasterServiceForTest {
+  getLexicon(request: GetLexiconRequest): Observable<GetLexiconResponse> {
+    if (request.subset === 'LEXICON_SUBSET_GIVEN_NAMES') {
+      return of({
+        words: ['Alice', 'Bob', 'Carol', 'David'],
+      });
+    } else if (request.prefix === 'e') {
+      return of({
+        words: ['example', 'excellent'],
+      });
+    } else {
+      return of({
+        words: [],
+      });
+    }
+  }
+
+  textPrediction(textPredictionRequest: TextPredictionRequest):
+      Observable<TextPredictionResponse> {
+    if (textPredictionRequest.userId == 'testuser' &&
+        textPredictionRequest.allowedTags!.length === 1 &&
+        textPredictionRequest.allowedTags![0] === 'partner-name') {
+      return of({
+        contextualPhrases: [
+          {
+            phraseId: 'a1',
+            text: 'Alex',
+          },
+          {
+            phraseId: 'a2',
+            text: 'Ben',
+          },
+          {
+            phraseId: 'a3',
+            text: 'Celine',
+          },
+          {
+            phraseId: 'a4',
+            text: 'Danielle',
+          },
+        ]
+      })
+    } else {
+      return of({});
+    }
+  }
+}
+
+describe('LexiconComponent', () => {
+  let fixture: ComponentFixture<LexiconComponent>;
+  let speakFasterServiceForTest: SpeakFasterServiceForTest;
+  let loadPrefixedLexiconRequestSubject: Subject<LoadLexiconRequest>;
+  let getLexiconSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    (LexiconComponent as any).GIVEN_NAMES = null;
+    loadPrefixedLexiconRequestSubject = new Subject();
+    speakFasterServiceForTest = new SpeakFasterServiceForTest();
+    getLexiconSpy =
+        spyOn(speakFasterServiceForTest, 'getLexicon').and.callThrough();
+    await TestBed
+        .configureTestingModule({
+          imports: [LexiconModule, HttpClientModule],
+          declarations: [LexiconComponent],
+          providers: [
+            {
+              provide: SpeakFasterService,
+              useValue: speakFasterServiceForTest,
+            },
+          ],
+        })
+        .compileComponents();
+    fixture = TestBed.createComponent(LexiconComponent);
+    fixture.componentInstance.userId = 'testuser';
+    fixture.componentInstance.loadPrefixedLexiconRequestSubject =
+        loadPrefixedLexiconRequestSubject;
+    fixture.detectChanges();
+  });
+
+  describe('canonicalizeName', () => {
+    it('returns canonicalized names', () => {
+      expect(canonicalizeName('jerry')).toEqual('Jerry');
+      expect(canonicalizeName('jerry\n')).toEqual('Jerry');
+      expect(canonicalizeName(' Jerry')).toEqual('Jerry');
+    });
+  });
+
+  describe('chooseStringRandomly', () => {
+    it('chooses random string', () => {
+      const chosen = chooseStringRandomly(['foo', 'bar', 'qux']);
+      expect(['foo', 'bar', 'qux'].indexOf(chosen)).not.toEqual(-1);
+    });
+
+    it('throws error for empty list input', () => {
+      expect(() => chooseStringRandomly([])).toThrowError();
+    });
+  });
+
+  it('calls getLexicon with give name subset on init', () => {
+    expect(getLexiconSpy).toHaveBeenCalledOnceWith({
+      languageCode: undefined,
+      subset: 'LEXICON_SUBSET_GIVEN_NAMES',
+    });
+    expect((LexiconComponent as any).GIVEN_NAMES).toEqual([
+      'Alice', 'Bob', 'Carol', 'David'
+    ]);
+  });
+
+  it('calls getLexicon with language code on request event', () => {
+    loadPrefixedLexiconRequestSubject.next({
+      prefix: 'e',
+    });
+
+    expect(getLexiconSpy).toHaveBeenCalledTimes(2);
+    expect(getLexiconSpy).toHaveBeenCalledWith({
+      languageCode: undefined,
+      prefix: 'e',
+    });
+    expect(LexiconComponent.isValidWord('example')).toBeTrue();
+    expect(LexiconComponent.isValidWord('Example')).toBeTrue();
+    expect(LexiconComponent.isValidWord('EXAMPLE')).toBeTrue();
+    expect(LexiconComponent.isValidWord('Excellent')).toBeTrue();
+    expect(LexiconComponent.isValidWord('Earnest')).toBeFalse();
+  });
+
+  it('Replaces names with user specific ones', () => {
+    expect(LexiconComponent.replacePersonNamesWithKnownValues(
+               'Hi, how are you, Alice'))
+        .toEqual('Hi, how are you, Alex');
+    expect(LexiconComponent.replacePersonNamesWithKnownValues(
+               'Hi, how are you, bob'))
+        .toEqual('Hi, how are you, Ben');
+    expect(LexiconComponent.replacePersonNamesWithKnownValues(
+               'Carol, you have a minute?'))
+        .toEqual('Celine, you have a minute?');
+  });
+
+  it('Does not replace names without matches', () => {
+    expect(LexiconComponent.replacePersonNamesWithKnownValues(
+               'Hi, how are you, Frank'))
+        .toEqual('Hi, how are you, Frank');
+    expect(
+        LexiconComponent.replacePersonNamesWithKnownValues('Hi, how are you'))
+        .toEqual('Hi, how are you');
+  })
+});

--- a/webui/src/app/lexicon/lexicon.component.ts
+++ b/webui/src/app/lexicon/lexicon.component.ts
@@ -1,0 +1,181 @@
+/** Component processing personal names in text. */
+import {Component, Input, OnInit} from '@angular/core';
+import {Subject} from 'rxjs';
+
+import {GetLexiconResponse, SpeakFasterService, TextPredictionResponse} from '../speakfaster-service';
+
+export interface LoadLexiconRequest {
+  prefix: string;
+}
+
+export function canonicalizeName(name: string): string {
+  name = name.trim();
+  return name.slice(0, 1).toLocaleUpperCase() +
+      name.slice(1).toLocaleLowerCase();
+}
+
+export function chooseStringRandomly(strings: string[]): string {
+  if (strings.length === 0) {
+    throw new Error('Cannot choose at random: array is empty.')
+  }
+  const n = strings.length;
+  const i = Math.min(Math.floor(Math.random() * n), n - 1);
+  return strings[i];
+}
+
+@Component({
+  selector: 'app-lexicon-component',
+  templateUrl: './lexicon.component.html',
+})
+export class LexiconComponent implements OnInit {
+  private static readonly PERSONAL_NAMES_TAG = 'partner-name';
+  private static GIVEN_NAMES: string[]|null = null;
+  private static readonly REGISTERED_NAMES: string[] = [];
+  private static readonly FULL_LEXICON_BY_PREFIX:
+      {[prefix: string]: string[]} = {};
+  private static readonly VALID_WORD_REGEX = /[A-Za-z]+[,;\-\.\?\!]/;
+
+  /**
+   * Replace personal names in input string with registered, user-specific
+   * personal names.
+   */
+  public static replacePersonNamesWithKnownValues(inputString: string): string {
+    if (LexiconComponent.GIVEN_NAMES === null ||
+        LexiconComponent.GIVEN_NAMES.length === 0) {
+      return inputString;
+    }
+    const words = inputString.split(' ').filter(word => word.length > 0);
+    for (let i = 0; i < words.length; ++i) {
+      let canonicalWord = canonicalizeName(words[i]);
+      let punctuation = '';
+      if (canonicalWord.match(LexiconComponent.VALID_WORD_REGEX)) {
+        punctuation = canonicalWord.slice(canonicalWord.length - 1);
+        canonicalWord = canonicalWord.slice(0, canonicalWord.length - 1);
+      }
+      if (LexiconComponent.GIVEN_NAMES.indexOf(canonicalWord) !== -1 &&
+          LexiconComponent.REGISTERED_NAMES.length > 0) {
+        // This is given name.
+        const initialLetter = canonicalWord.slice(0, 1).toLocaleLowerCase();
+        const matchingRegisteredNames =
+            LexiconComponent.REGISTERED_NAMES.filter(name => {
+              return name.toLocaleLowerCase().startsWith(initialLetter);
+            });
+        if (matchingRegisteredNames.length > 0) {
+          words[i] =
+              chooseStringRandomly(matchingRegisteredNames) + punctuation;
+        }
+      }
+    }
+    return words.join(' ');
+  }
+
+  /**
+   * Determines if input string is a valid word in the lexicon.
+   * If lexicon is not loaded, return false. If lexicon is loaded, returns true
+   * if and only if `inputString` matches any of the words in the lexicon in a
+   * case-insensitive way.
+   */
+  public static isValidWord(inputString: string): boolean {
+    if (inputString.length === 0) {
+      return false;
+    }
+    inputString = inputString.toLocaleLowerCase();
+    const firstLetter = inputString[0];
+    if (LexiconComponent.FULL_LEXICON_BY_PREFIX[firstLetter] === undefined) {
+      return false;
+    }
+    return LexiconComponent.FULL_LEXICON_BY_PREFIX[firstLetter].indexOf(
+               inputString) !== -1;
+  }
+
+
+  @Input() userId!: string;
+  @Input() languageCode!: string;
+  @Input() loadPrefixedLexiconRequestSubject!: Subject<LoadLexiconRequest>;
+
+  errorMessage?: string|null = null;
+
+  constructor(public speakFasterService: SpeakFasterService) {}
+
+  ngOnInit() {
+    this.loadPrefixedLexiconRequestSubject.subscribe(
+        (request: LoadLexiconRequest) => {
+          this.loadPrefixedLexicon(request.prefix);
+        });
+
+    if (LexiconComponent.GIVEN_NAMES === null) {
+      this.speakFasterService
+          .getLexicon({
+            languageCode: this.languageCode,
+            subset: 'LEXICON_SUBSET_GIVEN_NAMES',
+          })
+          .subscribe((response: GetLexiconResponse) => {
+            if (LexiconComponent.GIVEN_NAMES !== null) {
+              return;
+            }
+            LexiconComponent.GIVEN_NAMES = response.words.slice();
+          });
+    }
+
+    this.speakFasterService
+        .textPrediction({
+          userId: this.userId,
+          contextTurns: [],
+          textPrefix: '',
+          timestamp: new Date().toISOString(),
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          allowedTags: [LexiconComponent.PERSONAL_NAMES_TAG],
+        })
+        .subscribe((data: TextPredictionResponse) => {
+          data.contextualPhrases?.forEach(phrase => {
+            LexiconComponent.registerName(phrase.text);
+          });
+          console.log(
+              'Registered personal names:',
+              JSON.stringify(LexiconComponent.REGISTERED_NAMES));
+        });
+  }
+
+  private static registerName(name: string): void {
+    name = canonicalizeName(name);
+    if (LexiconComponent.REGISTERED_NAMES.indexOf(name) !== -1) {
+      return;
+    }
+    LexiconComponent.REGISTERED_NAMES.push(name);
+  }
+
+  private static unregisterName(name: string): void {
+    name = canonicalizeName(name);
+    const index = LexiconComponent.REGISTERED_NAMES.indexOf(name);
+    if (index === -1) {
+      return;
+    }
+    LexiconComponent.REGISTERED_NAMES.splice(index, 1);
+  }
+
+  /** Loads the full (non-subset) lexicon for given prefix. */
+  private loadPrefixedLexicon(prefix: string) {
+    if (prefix.length === 0) {
+      throw new Error('Prefix cannot be empty');
+    }
+    if (prefix.length !== 1) {
+      throw new Error(`Prefix string must have length 1; got ${prefix.length}`);
+    }
+    if (LexiconComponent.FULL_LEXICON_BY_PREFIX[prefix] !== undefined) {
+      // Already loaded.
+      return;
+    }
+    this.speakFasterService
+        .getLexicon({
+          languageCode: this.languageCode,
+          prefix,
+        })
+        .subscribe((response: GetLexiconResponse) => {
+          if (LexiconComponent.FULL_LEXICON_BY_PREFIX[prefix] !== undefined) {
+            return;
+          }
+          LexiconComponent.FULL_LEXICON_BY_PREFIX[prefix] =
+              response.words.map(word => word.toLocaleLowerCase());
+        });
+  }
+}

--- a/webui/src/app/lexicon/lexicon.module.ts
+++ b/webui/src/app/lexicon/lexicon.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+
+import {LexiconComponent} from './lexicon.component';
+
+@NgModule({
+  declarations: [LexiconComponent],
+  imports: [
+    BrowserModule,
+  ],
+  exports: [LexiconComponent],
+})
+export class LexiconModule {
+}

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -46,6 +46,9 @@ export interface TextPredictionRequest {
   // Tags used to filter the responses. Used for the contextual phrases (quick
   // phrases). Undefined or empty array is interpreted as no filtering.
   allowedTags?: string[];
+
+  // ID of the user for which the text predictions are to be generated.
+  userId?: string;
 }
 
 export interface TextPredictionResponse {
@@ -62,6 +65,21 @@ export interface FillMaskResponse {
 
 export interface PartnerUsersResponse {
   user_ids: string[];
+}
+
+export interface GetLexiconRequest {
+  // Language code in ISO 639-1 format. E.g., 'en-us'.
+  languageCode: string;
+
+  // Subset name.
+  subset?: 'LEXICON_SUBSET_GIVEN_NAMES';
+
+  // Prefix string used to filter the words in the reponse.
+  prefix?: string;
+}
+
+export interface GetLexiconResponse {
+  words: string[];
 }
 
 /** Abstract interface for SpeakFaster service backend. */
@@ -118,6 +136,11 @@ export interface SpeakFasterServiceStub {
    * partner.
    */
   getPartnerUsers(partnerEmail: string): Observable<PartnerUsersResponse>;
+
+  /**
+   * Get a lexicon of given language. Supports subsets and filtering by prefix.
+   */
+  getLexicon(request: GetLexiconRequest): Observable<GetLexiconResponse>;
 }
 
 /** Configuration for remote service. */
@@ -273,7 +296,21 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       },
       withCredentials,
       headers,
-    })
+    });
+  }
+
+  getLexicon(request: GetLexiconRequest): Observable<GetLexiconResponse> {
+    const {endpoint, headers, withCredentials} = this.getServerCallParams();
+    return this.http.get<GetLexiconResponse>(endpoint, {
+      params: {
+        mode: 'get_lexicon',
+        languageCode: request.languageCode,
+        subset: request.subset || '',
+        prefix: request.prefix || '',
+      },
+      withCredentials,
+      headers,
+    });
   }
 
   private getServerCallParams(): {


### PR DESCRIPTION
- Manages request to get the lexicon and its subsets (by prefix)
- Manages request to get user-specific partner given names via
  the textPrediction() route.
- Provides public methods to replace lexicon given names with
  user specific ones.
- Provides public method to determine if a token is a valid word
  in the lexicon.
- Add unit tests.

Fixes #189 at main HEAD.