### PR TITLE
[WebUI] Inject string in addition to keypresses; Handle shift keys

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -130,7 +130,7 @@ it to have the following interface.
 
 ```typescript
 interface BoundObject {
-  function injectKey(virtualKeys: number[]): void;
+  function injectKeys(virtualKeys: number[], text: string): void;
 
   function requestSoftkeyboardRest(): number;
 
@@ -150,7 +150,7 @@ interface BoundObject {
 }
 ```
 
-The three interface methods, `injectKey()`, `updateButtonBoxes()`, and
+The three interface methods, `injectKeys()`, `updateButtonBoxes()`, and
 `resizeWindow()` allow the WebUI to send different types of information to the
 host. Below we describe their use respectively.
 

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -196,6 +196,7 @@ describe('AbbreviationComponent', () => {
     // 8]. Includes the leading eraser keys and the trailing space.
     expect(calls[0]).toEqual(
         [87, 72, 65, 84, 32, 84, 73, 77, 69, 32, 73, 83, 32, 73, 84, 190, 32]);
+    expect(testListener.injectedTextCalls).toEqual(['what time is it']);
   });
 
   it('clicking inject-button publishes to textEntryEndSubject', () => {

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -298,7 +298,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
         injectedKeys.push(VIRTUAL_KEY.PERIOD);
       }
       injectedKeys.push(VIRTUAL_KEY.SPACE);  // Append a space at the end.
-      injectKeys(injectedKeys);
+      injectKeys(injectedKeys, text);
     }
     this.textEntryEndSubject.next({
       text,

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -353,6 +353,17 @@ describe('ExternalEventsComponent', () => {
     });
   }
 
+  it('LShift key enters upper case letter', () => {
+    const vkCodes = [160, 65, 66, 67, 160, 68, 162, END_KEY_CODE];
+    for (const vkCode of vkCodes) {
+      ExternalEventsComponent.externalKeypressHook(vkCode);
+    }
+    expect(beginEvents.length).toEqual(1);
+    expect(endEvents.length).toEqual(1);
+    expect(endEvents[0].text).toEqual('AbcD');
+    expect(endEvents[0].isFinal).toBeTrue();
+  });
+
   for (const keyCodes
            of [[65, 162, 8],
                [65, 162, 8, 162, 8],
@@ -688,16 +699,14 @@ describe('ExternalEventsComponent', () => {
 
   it('appendText updates recon state correctly', () => {
     ExternalEventsComponent.externalKeypressHook(65, /* isExternal= */ false);
-    ExternalEventsComponent.appendString(
-        'hi there', /* isExternal= */ false);
+    ExternalEventsComponent.appendString('hi there', /* isExternal= */ false);
 
     expect(ExternalEventsComponent.internalText).toEqual('a hi there ');
   });
 
   it('appendText followed by backspaces works', () => {
     ExternalEventsComponent.externalKeypressHook(65, /* isExternal= */ false);
-    ExternalEventsComponent.appendString(
-        'hi there', /* isExternal= */ false);
+    ExternalEventsComponent.appendString('hi there', /* isExternal= */ false);
     ExternalEventsComponent.externalKeypressHook(8, /* isExternal= */ false);
     ExternalEventsComponent.externalKeypressHook(8, /* isExternal= */ false);
 
@@ -706,8 +715,7 @@ describe('ExternalEventsComponent', () => {
 
   it('appendText followed by word backspace works', () => {
     ExternalEventsComponent.externalKeypressHook(65, /* isExternal= */ false);
-    ExternalEventsComponent.appendString(
-        'hi there', /* isExternal= */ false);
+    ExternalEventsComponent.appendString('hi there', /* isExternal= */ false);
     ExternalEventsComponent.externalKeypressHook(162, /* isExternal= */ false);
     ExternalEventsComponent.externalKeypressHook(160, /* isExternal= */ false);
     ExternalEventsComponent.externalKeypressHook(37, /* isExternal= */ false);

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -147,11 +147,14 @@ function getKeyFromVirtualKeyCode(vkCode: number): string|null {
 }
 
 function insertCharAsCursorPos(char: string, reconState: TextReconState) {
+  const casedChar =
+      reconState.isShiftOn ? char.toLocaleUpperCase() : char.toLocaleLowerCase()
   if (reconState.cursorPos === reconState.text.length) {
-    reconState.text += char;
-  } else {
-    reconState.text = reconState.text.slice(0, reconState.cursorPos) + char +
-        reconState.text.slice(reconState.cursorPos);
+    reconState.text += casedChar;
+  }
+  else {
+    reconState.text = reconState.text.slice(0, reconState.cursorPos) +
+        casedChar + reconState.text.slice(reconState.cursorPos);
   }
   reconState.cursorPos += 1;
 }

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -188,6 +188,11 @@ describe('InputBarComponent', () => {
                ],
                 [['x', 'y', VIRTUAL_KEY.ENTER], 'xy\n', 'xy', 3],
                 [
+                  // Casing in abbreviation should be ignored.
+                  [VIRTUAL_KEY.LSHIFT, 'x', 'y', VIRTUAL_KEY.ENTER], 'Xy\n',
+                  'xy', 3
+                ],
+                [
                   ['x', 'y', VIRTUAL_KEY.SPACE, VIRTUAL_KEY.ENTER], 'xy \n',
                   'xy', 4
                 ],
@@ -517,8 +522,9 @@ describe('InputBarComponent', () => {
     const spellButton = fixture.debugElement.query(By.css('.spell-button'));
     spellButton.nativeElement.click();
     fixture.detectChanges();
-    const spellSequence = ['b', 'i', 't'];
-    const spellReconstructedText = spellSequence.join('') + reconstructedText;
+    // Letter casing should be ignored.
+    const spellSequence = [VIRTUAL_KEY.LSHIFT, 'b', 'i', 't'];
+    const spellReconstructedText = 'Bit';
     enterKeysIntoComponent(spellSequence, spellReconstructedText);
     const expandButton = fixture.debugElement.query(By.css('.expand-button'));
     expandButton.nativeElement.click();
@@ -931,6 +937,7 @@ describe('InputBarComponent', () => {
        const calls = testListener.injectedKeysCalls;
        expect(calls.length).toEqual(1);
        expect(calls[0]).toEqual([65, 76, 76, 32, 71, 79, 79, 68, 190, 32]);
+       expect(testListener.injectedTextCalls).toEqual(['all good. ']);
      });
 
   it('clicking inject text button injects keypresses without added final period',

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -302,7 +302,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
             this._chips.length, matchingChipIndices[0]);
         this.state = State.FOCUSED_ON_LETTER_CHIP;
         // Signal to soft keyboard a word boundary. TODO(cais): Decide.
-        injectKeys([VIRTUAL_KEY.SPACE]);
+        injectKeys([VIRTUAL_KEY.SPACE], null);
         this.baseReconstructedText = this.latestReconstructedString.slice(
             0, this.latestReconstructedString.length - 1);
         this._focusChipIndex = matchingChipIndices[0];
@@ -404,7 +404,9 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
             pendingChars = '';
           }
           tokens.push({
-            value: removePunctuation(this._chipTypedText![i]!).trim(),
+            value: removePunctuation(this._chipTypedText![i]!)
+                       .trim()
+                       .toLocaleLowerCase(),
             isKeyword: true,
           });
         } else {
@@ -420,8 +422,9 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
       }
       abbreviationSpec = {
         tokens,
-        readableString:
-            tokens.map(token => removePunctuation(token.value)).join(' '),
+        readableString: tokens.map(token => removePunctuation(token.value))
+                            .join(' ')
+                            .toLocaleLowerCase(),
         precedingText,
         eraserSequence: repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, eraserLength),
         lineageId: createUuid(),
@@ -459,11 +462,12 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     });
     readableString += abbrevText;
     tokens.push({
-      value: abbrevText,
+      value: abbrevText.toLocaleLowerCase(),
       isKeyword: false,
-    })
+    });
     return {
-      tokens, readableString, precedingText: '',
+      tokens, readableString: readableString.toLocaleLowerCase(),
+          precedingText: '',
           eraserSequence: repeatVirtualKey(VIRTUAL_KEY.BACKSPACE, eraserLength),
           lineageId: createUuid(),
     }
@@ -629,7 +633,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     this.eventLogger.logInputBarInjectButtonClick(getPhraseStats(text));
     const injectedKeys: Array<string|VIRTUAL_KEY> = [];
     injectedKeys.push(...text.split(''));
-    injectKeys(injectedKeys);
+    injectKeys(injectedKeys, text);
     this.textEntryEndSubject.next({
       text,
       timestampMillis: Date.now(),

--- a/webui/src/app/quick-phrases/quick-phrases.component.spec.ts
+++ b/webui/src/app/quick-phrases/quick-phrases.component.spec.ts
@@ -214,6 +214,7 @@ describe('QuickPhrasesComponent', () => {
     expect(endEvents[0].isFinal).toEqual(true);
     expect(endEvents[0].inAppTextToSpeechAudioConfig).toEqual({});
     expect(testListener.injectedKeysCalls.length).toEqual(0);
+    expect(testListener.injectedTextCalls.length).toEqual(0);
   });
 
   it('phrase inject button triggers input bar text append event', async () => {

--- a/webui/src/app/quick-phrases/quick-phrases.component.ts
+++ b/webui/src/app/quick-phrases/quick-phrases.component.ts
@@ -2,7 +2,6 @@
 import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, QueryList, SimpleChanges, ViewChild, ViewChildren} from '@angular/core';
 import {Subject} from 'rxjs';
 import {injectKeys, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
-import {allItemsEqual} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
 import {AppComponent} from '../app.component';
@@ -294,7 +293,7 @@ export class QuickPhrasesComponent implements AfterViewInit, OnInit, OnChanges,
       // TODO(cais): Properly handle punctuation (if any).
       injectedKeys.push(...phrase.split(''));
       injectedKeys.push(VIRTUAL_KEY.SPACE);  // Append a space at the end.
-      injectKeys(injectedKeys);
+      injectKeys(injectedKeys, phrase);
     }
     this.eventLogger.logContextualPhraseSelection(
         getContextualPhraseStats(this.phrases[index]),

--- a/webui/src/app/test-utils/test-cefsharp-listener.ts
+++ b/webui/src/app/test-utils/test-cefsharp-listener.ts
@@ -5,6 +5,7 @@ import {AppSettings, getDefaultAppSettings, ShowGazeTracker, tryLoadSettings} fr
 export class TestListener {
   private readonly buttonBoxesCalls: Array<[string, number[][]]> = [];
   private readonly injectedKeys: Array<number[]> = [];
+  private readonly injectedTexts: string[] = [];
   private _numRequestSoftKeyboardResetCalls = 0;
   private readonly resizeWindowValues: Array<[number, number]> = [];
   private readonly _setEyeGazeOptionsCalls: Array<[boolean, number, number]> =
@@ -18,8 +19,9 @@ export class TestListener {
     return this.buttonBoxesCalls;
   }
 
-  public injectKeys(virtualKeys: number[]) {
+  public injectKeys(virtualKeys: number[], text: string) {
     this.injectedKeys.push(virtualKeys);
+    this.injectedTexts.push(text);
   }
 
   public requestSoftKeyboardReset() {
@@ -28,6 +30,10 @@ export class TestListener {
 
   get injectedKeysCalls(): Array<number[]> {
     return this.injectedKeys.slice();
+  }
+
+  get injectedTextCalls(): string[] {
+    return this.injectedTexts.slice();
   }
 
   get numRequestSoftkeyboardResetCalls(): number {

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -116,8 +116,13 @@ function updateButtonBoxes(
  *   order. A special key (Backspace or Enter) must use the VIRTUAL_KEY enum.
  *   Non-special keys (e.g., letters, numbers, and punctuation) should be in
  *   their literal form.
+ * @param text (optional) the text to be injected. This doesn't include
+ *   non-text parts of `virtualKeys` such as the Backspaces for erasure. This
+ *   argument may be used for setting the system clipboard (for copy-pasting) on
+ *   the host side.
  */
-export function injectKeys(virtualKeys: Array<string|VIRTUAL_KEY>): number {
+export function injectKeys(
+    virtualKeys: Array<string|VIRTUAL_KEY>, text: string|null): number {
   if ((window as any)[BOUND_LISTENER_NAME] == null) {
     console.warn(`Cannot call injectKeys(), because object ${
         BOUND_LISTENER_NAME} is not found`)
@@ -128,7 +133,7 @@ export function injectKeys(virtualKeys: Array<string|VIRTUAL_KEY>): number {
     virtualKeyCodes.push(...getVirtualkeyCode(virtualKey));
   }
   return ((window as any)[BOUND_LISTENER_NAME] as any)
-             .injectKeys(virtualKeyCodes) as number;
+             .injectKeys(virtualKeyCodes, text) as number;
 }
 
 /** Request host app to reset the state of the attached soft keyboard. */


### PR DESCRIPTION
This PR includes two loosely-related changes:
1. When injecting text, not only issue keypresses, but also send
   the text string as an argument, so that the host can optionally
   add it to the system clipboard to support text pasting into other
   apps.
   Towards: https://github.com/TeamGleason/SpeakFaster/issues/239
2. Handle the shift key properly in the `InputBarComponent`, so that
   the letter casing can be reflected in the typed text. Previously
   all entered text showed up as lowercase regardless of shift-key
   states.