### PR TITLE
[Data Manager] Relax tEnd check in check_keypresses()

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/elan_process_curated.py
+++ b/Observer/SpeakFasterObserver Decoder/elan_process_curated.py
@@ -189,6 +189,8 @@ def load_rows(tsv_path, column_order, has_header=False):
 def check_keypresses(merged_tsv_path, curated_rows):
   """Check for any accidentally-deleated keypress TSV rows.
 
+  tEnd is ignored during checking. Only tBegin, tier and contents are checked.
+
   Args:
     merged_tsv_path: The path to the merged.tsv file that contains the raw
       keypress data, potentially along with other types of data such as
@@ -196,7 +198,7 @@ def check_keypresses(merged_tsv_path, curated_rows):
     curated_rows: TSV rows from after the curation, as a list of tuples or
       lists. Each tuple or list should contain elements (tBegin, tEnd, tier,
       content). The list may contain tuples that are of other types (e.g.,
-      SpeechTranscript).
+      SpeechTranscript). tEnd is ignored during checking.
 
   Raises:
     ValueError: if the set of keypresses in `curated_rows` does not
@@ -205,9 +207,9 @@ def check_keypresses(merged_tsv_path, curated_rows):
   column_order, has_header = infer_columns(merged_tsv_path)
   original_rows = load_rows(
       merged_tsv_path, column_order, has_header=has_header)
-  original_keypress_rows = [tuple(row) for row in original_rows if
+  original_keypress_rows = [(row[0], row[3]) for row in original_rows if
                             row[2] == tsv_data.KEYPRESS_TIER]
-  curated_keypress_rows = [tuple(row) for row in curated_rows if
+  curated_keypress_rows = [(row[0], row[3]) for row in curated_rows if
                            row[2] == tsv_data.KEYPRESS_TIER]
   missing_from_original = [row for row in curated_keypress_rows
                            if (row not in original_keypress_rows)]

--- a/Observer/SpeakFasterObserver Decoder/elan_process_curated_test.py
+++ b/Observer/SpeakFasterObserver Decoder/elan_process_curated_test.py
@@ -473,7 +473,7 @@ class CalculuateSpeechCurationStatsTest(tf.test.TestCase):
       elan_process_curated.calculate_speech_curation_stats(
           self.merged_tsv_path, curated_rows, self.realname_to_pseudonym)
 
-  def testCheckKeypresse_letsCorrectDataPass(self):
+  def testCheckKeypresses_letsCorrectDataPass(self):
     curated_rows = [
         [15.2, 16.0, "SpeechTranscript",
          "I have <RedactedSensitive time=\"00:00:01.500-00:00:04\">abc</RedactedSensitive> [SpeakerTTS:Sean]"],
@@ -487,7 +487,16 @@ class CalculuateSpeechCurationStatsTest(tf.test.TestCase):
         [32.0, 32.01, "Keypress", "c"]]
     elan_process_curated.check_keypresses(self.merged_tsv_path, curated_rows)
 
-  def testCheckKeypresse_detectsAddedKeypresses(self):
+  def testCheckKeypresses_ignoresMismatchesInTEnd(self):
+    curated_rows = [
+        [15.2, 16.0, "SpeechTranscript",
+         "I have <RedactedSensitive time=\"00:00:01.500-00:00:04\">abc</RedactedSensitive> [SpeakerTTS:Sean]"],
+        (30.0, 30.02, "Keypress", "a"),
+        (31.0, 31.11, "Keypress", "b"),
+        (32.0, 33.01, "Keypress", "c")]
+    elan_process_curated.check_keypresses(self.merged_tsv_path, curated_rows)
+
+  def testCheckKeypresses_detectsAddedKeypresses(self):
     curated_rows = [
         (30.0, 30.01, "Keypress", "a"),
         (30.5, 30.51, "Keypress", "A"),
@@ -495,7 +504,7 @@ class CalculuateSpeechCurationStatsTest(tf.test.TestCase):
         (32.0, 32.01, "Keypress", "c")]
     with self.assertRaisesRegex(
         ValueError,
-        r".*keypress row .*30\.5.*30\.51.*A.*missing from the original data.*"):
+        r".*keypress row .*30\.5.*A.*missing from the original data.*"):
       elan_process_curated.check_keypresses(self.merged_tsv_path, curated_rows)
     curated_rows = [
         (30.0, 30.01, "Keypress", "a"),
@@ -503,7 +512,7 @@ class CalculuateSpeechCurationStatsTest(tf.test.TestCase):
         (32.0, 32.01, "Keypress", "c")]
     with self.assertRaisesRegex(
         ValueError,
-        r".*keypress row .*30\.5.*30\.51.*A.*missing from the original data.*"):
+        r".*keypress row .*30\.5.*A.*missing from the original data.*"):
       elan_process_curated.check_keypresses(self.merged_tsv_path, curated_rows)
     curated_rows = [
         [30.0, 30.01, "Keypress", "a"],
@@ -511,21 +520,21 @@ class CalculuateSpeechCurationStatsTest(tf.test.TestCase):
         [32.0, 32.01, "Keypress", "c"]]
     with self.assertRaisesRegex(
         ValueError,
-        r".*keypress row .*31\.0.*31\.01.*B.*missing from the original data.*"):
+        r".*keypress row .*31\.0.*B.*missing from the original data.*"):
       elan_process_curated.check_keypresses(self.merged_tsv_path, curated_rows)
 
-  def testCheckKeypresse_detectsMissingKeypresses(self):
+  def testCheckKeypresses_detectsMissingKeypresses(self):
     curated_rows = [
         (30.0, 30.01, "Keypress", "a"),
         (32.0, 32.01, "Keypress", "c")]
     with self.assertRaisesRegex(
         ValueError,
-        r".*keypress row .*31\.0.*31\.01.*b.*missing from the curated data.*"):
+        r".*keypress row .*31\.0.*b.*missing from the curated data.*"):
       elan_process_curated.check_keypresses(self.merged_tsv_path, curated_rows)
     curated_rows = []
     with self.assertRaisesRegex(
         ValueError,
-        r".*keypress row .*30\.0.*30\.01.*a.*missing from the curated data.*"):
+        r".*keypress row .*30\.0.*a.*missing from the curated data.*"):
       elan_process_curated.check_keypresses(self.merged_tsv_path, curated_rows)
 
 


### PR DESCRIPTION
Turns out that ELAN sometimes messes up the tEnd values. Since
tEnd values for the keypresses are just dummies (hardcoded to
tBegin + 0.1 s currently), it is fine to ignore them.