### PR TITLE
[WebUI] Sort quick phrases by last usage timestamp

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -256,7 +256,7 @@ mat-progress-spinner {
       [mode]="'indeterminate'"
       [value]="50">
   </mat-progress-spinner>
-  <span class="request-ongoing-message">Getting abbrevation expansions...</span>
+  <span class="request-ongoing-message">Getting abbreviation expansions...</span>
 </div>
 <div *ngIf="responseError !== null" class="info response-error">
   Error: {{responseError}}

--- a/webui/src/app/phrase/phrase.component.ts
+++ b/webui/src/app/phrase/phrase.component.ts
@@ -3,6 +3,8 @@ import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnDestroy, Ou
 import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {createUuid} from 'src/utils/uuid';
 
+import {SpeakFasterService} from '../speakfaster-service';
+
 export enum State {
   READY = 'READY',
   CONFIRMING_DELETION = 'CONFIRMING_DELETION',
@@ -47,6 +49,8 @@ export class PhraseComponent implements AfterViewInit, OnDestroy {
   clickableButtons!: QueryList<ElementRef<HTMLElement>>;
   @ViewChildren('clickableButton,phrase')
   clickableButtonsAndText!: QueryList<ElementRef<HTMLElement>>;
+
+  constructor(private speakFasterService: SpeakFasterService) {}
 
   public updateButtonBoxesWithContainerRect(containerRect: DOMRect) {
     const clicakbleAreas = this.isTextClickable ? this.clickableButtonsAndText :
@@ -98,20 +102,34 @@ export class PhraseComponent implements AfterViewInit, OnDestroy {
 
   onSpeakButtonClicked(event: Event) {
     (event.target as HTMLButtonElement).blur();
-    // TODO(cais): Add unit test.
     this.speakButtonClicked.emit(
         {phraseText: this.phraseText, phraseIndex: this.phraseIndex});
+    this.markContextualPhraseUsage();
   }
 
   onInjectButtonClicked(event: Event) {
     (event.target as HTMLButtonElement).blur();
     this.injectButtonClicked.emit(
         {phraseText: this.phraseText, phraseIndex: this.phraseIndex});
+    this.markContextualPhraseUsage();
   }
 
   onExpandButtonClicked(event: Event) {
     (event.target as HTMLButtonElement).blur();
     this.expandButtonClicked.emit(
         {phraseText: this.phraseText, phraseIndex: this.phraseIndex});
+  }
+
+  private markContextualPhraseUsage() {
+    if (!this.phraseId) {
+      return;
+    }
+    this.speakFasterService
+        .markContextualPhraseUsage({
+          userId: this.userId,
+          phraseId: this.phraseId,
+          lastUsedTimestamp: new Date().toISOString(),
+        })
+        .subscribe((data) => {});
   }
 }

--- a/webui/src/app/quick-phrases/quick-phrases.component.spec.ts
+++ b/webui/src/app/quick-phrases/quick-phrases.component.spec.ts
@@ -27,13 +27,24 @@ class SpeakFasterServiceForTest {
     this.contextualPhrases.push(
         ...[{
           phraseId: createUuid(),
-          text: 'Hello',
+          text: 'hello',
           tags: ['favorite'],
+          lastUsedTimestamp: '2022-04-01T00:00:00.000Z',
         },
+            {
+              phraseId: createUuid(),
+              text: 'Nice day today',
+              tags: ['favorite'],
+              lastUsedTimestamp: '2022-04-01T00:00:00.000Z',
+            },
+            // Among the phrases with the 'favorite' tag, the 'Thank you' phrase
+            // should be shown first due to the later lastUsedTimestamp, despite
+            // lexicographical order.
             {
               phraseId: createUuid(),
               text: 'Thank you',
               tags: ['favorite'],
+              lastUsedTimestamp: '2022-04-01T00:00:10.000Z',
             },
             {
               phraseId: createUuid(),
@@ -129,12 +140,14 @@ describe('QuickPhrasesComponent', () => {
         fixture.debugElement.queryAll(By.css('.scroll-button'));
     const error = fixture.debugElement.query(By.css('.error'));
 
-    expect(phraseComponents.length).toEqual(2);
-    expect(phraseComponents[0].componentInstance.phraseText).toEqual('Hello');
-    expect(phraseComponents[0].componentInstance.phraseIndex).toEqual(0);
-    expect(phraseComponents[1].componentInstance.phraseText)
+    expect(phraseComponents.length).toEqual(3);
+    expect(phraseComponents[0].componentInstance.phraseText)
         .toEqual('Thank you');
+    expect(phraseComponents[0].componentInstance.phraseIndex).toEqual(0);
+    expect(phraseComponents[1].componentInstance.phraseText).toEqual('hello');
     expect(phraseComponents[1].componentInstance.phraseIndex).toEqual(1);
+    expect(phraseComponents[2].componentInstance.phraseText).toEqual('Nice day today');
+    expect(phraseComponents[2].componentInstance.phraseIndex).toEqual(2);
     expect(noQuickPhrases).toBeNull();
     expect(scrollButtons).toEqual([]);
     expect(error).toBeNull();
@@ -202,12 +215,12 @@ describe('QuickPhrasesComponent', () => {
     const phraseComponents =
         fixture.debugElement.queryAll(By.css('app-phrase-component'));
     phraseComponents[0].componentInstance.speakButtonClicked.emit(
-        {phraseText: 'Hello', phraseIndex: 0});
+        {phraseText: 'Thank you', phraseIndex: 0});
 
     expect(beginEvents.length).toEqual(1);
     expect(beginEvents[0].timestampMillis).toBeGreaterThan(0);
     expect(endEvents.length).toEqual(1);
-    expect(endEvents[0].text).toEqual('Hello');
+    expect(endEvents[0].text).toEqual('Thank you');
     expect(endEvents[0].timestampMillis)
         .toBeGreaterThan(beginEvents[0].timestampMillis);
     expect(endEvents[0].injectedKeys).toBeUndefined();

--- a/webui/src/app/quick-phrases/quick-phrases.component.ts
+++ b/webui/src/app/quick-phrases/quick-phrases.component.ts
@@ -90,18 +90,40 @@ export class QuickPhrasesComponent implements AfterViewInit, OnInit, OnChanges,
                 }
                 this.phrases.sort(
                     (a: ContextualPhrase, b: ContextualPhrase) => {
-                      const dateA = new Date(a.createdTimestamp!).getTime();
-                      const dateB = new Date(b.createdTimestamp!).getTime();
-                      if (dateA === dateB) {
-                        if (a.text > b.text) {
+                      // Sorting is done by tiers:
+                      // 1. Last-usage timestamp
+                      // 2. In case of a tie in last-usage timestamp, sort by
+                      // creation timestamp.
+                      // 3. In case of a tie in creation timestamp, sort by
+                      // lexicographical order.
+                      const lastUsedDateA = a.lastUsedTimestamp ?
+                          new Date(a.lastUsedTimestamp).getTime() :
+                          0;
+                      const lastUsedDateB = b.lastUsedTimestamp ?
+                          new Date(b.lastUsedTimestamp).getTime() :
+                          0;
+                      if (lastUsedDateA > lastUsedDateB) {
+                        return -1;
+                      }
+                      if (lastUsedDateA < lastUsedDateB) {
+                        return 1;
+                      }
+                      const createdDateA =
+                          new Date(a.createdTimestamp!).getTime();
+                      const createdDateB =
+                          new Date(b.createdTimestamp!).getTime();
+                      if (createdDateA === createdDateB) {
+                        const textA = a.text.trim().toLocaleUpperCase();
+                        const textB = b.text.trim().toLocaleUpperCase();
+                        if (textA > textB) {
                           return 1;
-                        } else if (a.text < b.text) {
+                        } else if (textA < textB) {
                           return -1;
                         } else {
                           return 0;
                         }
                       } else {
-                        return dateB - dateA;
+                        return createdDateB - createdDateA;
                       }
                     });
                 if (this.maxNumPhrases !== null &&

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -8,7 +8,7 @@ import {trimStringAtHead} from 'src/utils/text-utils';
 
 import {AbbreviationSpec} from './types/abbreviation';
 import {ContextSignal} from './types/context';
-import {AddContextualPhraseRequest, AddContextualPhraseResponse, ContextualPhrase, DeleteContextualPhraseRequest, DeleteContextualPhraseResponse} from './types/contextual_phrase';
+import {AddContextualPhraseRequest, AddContextualPhraseResponse, ContextualPhrase, DeleteContextualPhraseRequest, DeleteContextualPhraseResponse, MarkContextualPhraseUsageRequest, MarkContextualPhraseUsageResponse} from './types/contextual_phrase';
 
 export interface PingResponse {
   ping_response: string;
@@ -129,6 +129,9 @@ export interface SpeakFasterServiceStub {
 
   deleteContextualPhrase(request: DeleteContextualPhraseRequest):
       Observable<DeleteContextualPhraseResponse>;
+
+  markContextualPhraseUsage(request: MarkContextualPhraseUsageRequest):
+      Observable<MarkContextualPhraseUsageResponse>;
 
   fillMask(request: FillMaskRequest): Observable<FillMaskResponse>;
 
@@ -331,6 +334,27 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
         .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
                 return throwError(makeTimeoutErrorMessage(
                     'Delete context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
+              }));
+  }
+
+  markContextualPhraseUsage(request: MarkContextualPhraseUsageRequest):
+      Observable<MarkContextualPhraseUsageResponse> {
+    const {endpoint, headers, withCredentials} = this.getServerCallParams();
+    const params: any = {
+      mode: 'mark_contextual_phrase_usage',
+      userId: request.userId,
+      phraseId: request.phraseId,
+      lastUsedTimestamp: new Date().toISOString(),
+    };
+    return this.http
+        .get<MarkContextualPhraseUsageResponse>(endpoint, {
+          params,
+          withCredentials,
+          headers,
+        })
+        .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
+                return throwError(makeTimeoutErrorMessage(
+                    'Mark context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
               }));
   }
 

--- a/webui/src/app/types/abbreviation.ts
+++ b/webui/src/app/types/abbreviation.ts
@@ -57,7 +57,7 @@ export interface AbbreviationSpec {
 
 /** An event that signifies the change in an input abbreviation */
 export interface InputAbbreviationChangedEvent {
-  // Specification for the abbrevation.
+  // Specification for the abbreviation.
   readonly abbreviationSpec: AbbreviationSpec;
 
   // Whether abbreviation expansion is requested.

--- a/webui/src/app/types/contextual_phrase.ts
+++ b/webui/src/app/types/contextual_phrase.ts
@@ -48,6 +48,9 @@ export interface ContextualPhrase {
 
   // Last modified timestamp (if any), in ISO format. Assume UTC time zone.
   lastModifiedTimestamp?: string;
+
+  // Last used timetamp (if any).
+  lastUsedTimestamp?: string;
 }
 
 // Request to add a contextual phrase (i.e., "quick phrase").
@@ -84,4 +87,22 @@ export interface DeleteContextualPhraseResponse {
   phraseId?: string
 
   errorMessage?: string;
+}
+
+// Request to mark the usage of a contextual phrase.
+export interface MarkContextualPhraseUsageRequest {
+  // The ID of the user to which the contextual phrase belongs.
+  userId: string;
+
+  // ID of the phrase to mark usage for.
+  phraseId: string;
+
+  // Last usage timestamp, in ISO format. Assume UTC time zone.
+  lastUsedTimestamp: string;
+}
+
+// Response to a qurest to mark a contextual phrase for usage.
+export interface MarkContextualPhraseUsageResponse {
+  // Echoed phrase ID.
+  phraseId: string;
 }


### PR DESCRIPTION
    
Sorting is by tier:
1. By descending order of last used timestamp
2. In case of tie, sort by creation timestamp
3. In case of tie, sort lexicographically
    
Fixes https://github.com/TeamGleason/SpeakFaster/issues/241
