### PR TITLE
Fix ghost buttons, boolean flag in keypress hook call, use Ctrl+W

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -108,7 +108,7 @@ The WebUI provides a function attached to the global `window` object, namely
 `window.externalKeypressHook()`, which has the following signature:
 
 ```typescript
-function externalKeypressHook(virualKeyCode: number): void;
+function externalKeypressHook(virualKeyCode: number, isExternal: boolean): void;
 ```
 
 wherein the `virtualKeyCode` argument obeys the
@@ -138,6 +138,10 @@ interface BoundObject {
 
   function updateButtonBoxes(componentName: string,
                              boxes: Array<[number, number, number, number]>);
+
+  async function bringWindowToForeground();
+
+  async function bringFocusAppToForeground();
 
   async function setEyeGazeOptions(
       showGazeTracker: boolean, gazeFuzzyRadius: number, dwellDelayMillis: number);
@@ -232,3 +236,9 @@ information about the host app and the environment it is running in.
 
 To request the host app to close the WebUI and quit as a whole, call
 `requestAppQuit()`.
+
+### 3.9. Requesting putting the app or a focus app in foreground
+
+The two functions `bringWindowToForeground()` and `bringFocusAppToForeground()`
+can be used to request the host app to bring the app itself or a focus app
+(e.g., a text editor) to the foreground.

--- a/webui/README.md
+++ b/webui/README.md
@@ -241,4 +241,4 @@ To request the host app to close the WebUI and quit as a whole, call
 
 The two functions `bringWindowToForeground()` and `bringFocusAppToForeground()`
 can be used to request the host app to bring the app itself or a focus app
-(e.g., a text editor) to the foreground.
+(e.g., a text editor) to the foreground, respectively.

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -1,7 +1,6 @@
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {RouterTestingModule} from '@angular/router/testing';
-import {Subject} from 'rxjs';
 
 import * as cefSharp from '../utils/cefsharp';
 

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -166,7 +166,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     });
     registerExternalKeypressHook((vkCode: number) => {
       ExternalEventsComponent.externalKeypressHook(
-          vkCode, /* isExternal= */ true);
+          vkCode, /* isExternal= */ false);
     });
     const resizeObserver = new ResizeObserver(entries => {
       if (entries.length > 1) {

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -2,7 +2,7 @@ import {AfterViewInit, Component, ElementRef, OnDestroy, OnInit, QueryList, View
 import {ActivatedRoute} from '@angular/router';
 import {Subject} from 'rxjs';
 
-import {bindCefSharpListener, registerExternalAccessTokenHook, registerExternalKeypressHook, registerHostWindowFocusHook, resizeWindow, setHostEyeGazeOptions, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from '../utils/cefsharp';
+import {bindCefSharpListener, bringFocusAppToForeground, bringWindowToForeground, registerExternalAccessTokenHook, registerExternalKeypressHook, registerHostWindowFocusHook, resizeWindow, setHostEyeGazeOptions, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from '../utils/cefsharp';
 import {createUuid} from '../utils/uuid';
 
 import {registerAppState} from './app-state-registry';
@@ -164,9 +164,8 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     registerHostWindowFocusHook((isFocused: boolean) => {
       this._isFocused = isFocused;
     });
-    registerExternalKeypressHook((vkCode: number) => {
-      ExternalEventsComponent.externalKeypressHook(
-          vkCode, /* isExternal= */ false);
+    registerExternalKeypressHook((vkCode: number, isExternal: boolean) => {
+      ExternalEventsComponent.externalKeypressHook(vkCode, isExternal);
     });
     const resizeObserver = new ResizeObserver(entries => {
       if (entries.length > 1) {
@@ -189,6 +188,20 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
           updateButtonBoxesForElements(this.instanceId, queryList);
         });
     AppComponent.registerAppResizeCallback(this.appResizeCallback.bind(this));
+    ExternalEventsComponent.registerToggleForegroundCallback(
+        (toForeground: boolean) => {
+          if (toForeground) {  // Bring app to foreground.
+            this.changeAppState(AppState.ABBREVIATION_EXPANSION);
+            setTimeout(() => {
+              bringWindowToForeground();
+            }, 50);
+          } else {  // Bring the focus app to foreground (if it is running).
+            setTimeout(() => {
+              this.changeAppState(AppState.MINIBAR);
+              bringFocusAppToForeground();
+            }, 50);
+          }
+        });
     this.eventLogger.logSessionStart();
   }
 
@@ -291,6 +304,9 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   onMinimizeButtonClicked(event: Event) {
     this.changeAppState(AppState.MINIBAR);
+    setTimeout(() => {
+      bringFocusAppToForeground();
+    }, 50);
   }
 
   onContextStringsUpdated(conversationTurns: ConversationTurn[]) {

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -194,12 +194,12 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
             this.changeAppState(AppState.ABBREVIATION_EXPANSION);
             setTimeout(() => {
               bringWindowToForeground();
-            }, 50);
+            }, 100);
           } else {  // Bring the focus app to foreground (if it is running).
+            this.changeAppState(AppState.MINIBAR);
             setTimeout(() => {
-              this.changeAppState(AppState.MINIBAR);
               bringFocusAppToForeground();
-            }, 50);
+            }, 100);
           }
         });
     this.eventLogger.logSessionStart();
@@ -306,7 +306,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     this.changeAppState(AppState.MINIBAR);
     setTimeout(() => {
       bringFocusAppToForeground();
-    }, 50);
+    }, 100);
   }
 
   onContextStringsUpdated(conversationTurns: ConversationTurn[]) {

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -166,7 +166,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     });
     registerExternalKeypressHook((vkCode: number) => {
       ExternalEventsComponent.externalKeypressHook(
-          vkCode, /* isExternal= */ false);
+          vkCode, /* isExternal= */ true);
     });
     const resizeObserver = new ResizeObserver(entries => {
       if (entries.length > 1) {

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -40,6 +40,10 @@ describe('ExternalEventsComponent', () => {
     resetReconStates();
   });
 
+  afterEach(async () => {
+    ExternalEventsComponent.clearToggleForegroundCallback();
+  });
+
   it('Virtual key codes map has no duplicate values', () => {
     const valueSet = new Set(Object.values(VKCODE_SPECIAL_KEYS));
     expect(Object.values(VKCODE_SPECIAL_KEYS).length).toEqual(valueSet.size);
@@ -731,4 +735,35 @@ describe('ExternalEventsComponent', () => {
 
     expect(ExternalEventsComponent.internalText).toEqual('a hi ');
   });
+
+  it('regstered toggle-foreground callback is called from external', () => {
+    const callFlags: boolean[] = [];
+    ExternalEventsComponent.registerToggleForegroundCallback(
+        (toForeground: boolean) => {callFlags.push(toForeground)});
+    ExternalEventsComponent.externalKeypressHook(162, /* isExternal= */ true);
+    ExternalEventsComponent.externalKeypressHook(71, /* isExternal= */ true);
+
+    expect(callFlags).toEqual([true]);
+  });
+
+  it('regstered toggle-foreground callback is called from external', () => {
+    const callFlags: boolean[] = [];
+    ExternalEventsComponent.registerToggleForegroundCallback(
+        (toForeground: boolean) => {callFlags.push(toForeground)});
+    ExternalEventsComponent.externalKeypressHook(162, /* isExternal= */ false);
+    ExternalEventsComponent.externalKeypressHook(71, /* isExternal= */ false);
+
+    expect(callFlags).toEqual([false]);
+  });
+
+  it('registered toggle-foreground callback not called by incomplete sequences',
+     () => {
+      const callFlags: boolean[] = [];
+      ExternalEventsComponent.registerToggleForegroundCallback(
+          (toForeground: boolean) => {callFlags.push(toForeground)});
+      ExternalEventsComponent.externalKeypressHook(162, /* isExternal= */ true);
+      ExternalEventsComponent.externalKeypressHook(71, /* isExternal= */ false);
+
+      expect(callFlags).toEqual([]);
+     });
 });

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -12,7 +12,7 @@
  * externalKeypressHook(76);  // l
  * externalKeypressHook(190);  // .
  * externalKeypressHook(162);  // LCtrl
- * externalKeypressHook(87);  // Q
+ * externalKeypressHook(87);  // W
  * ```
  */
 
@@ -127,8 +127,10 @@ export const SENTENCE_END_COMBO_KEYS: string[][] = [
   [VIRTUAL_KEY.LSHIFT, '1', VIRTUAL_KEY.SPACE],
 ];
 export const LCTRL_KEY_HEAD_FOR_TTS_TRIGGER = 'w';
-export const TTS_TRIGGER_COMBO_KEY: string[] =
-    [VIRTUAL_KEY.LCTRL, LCTRL_KEY_HEAD_FOR_TTS_TRIGGER];
+export const EXTERNAL_PHRASE_DELIMITERS: string[][] = [
+  [VIRTUAL_KEY.LCTRL, LCTRL_KEY_HEAD_FOR_TTS_TRIGGER],
+  [VIRTUAL_KEY.PERIOD, VIRTUAL_KEY.SPACE],
+];
 export const WORD_BACKSPACE_COMBO_KEY: string[] = [
   VIRTUAL_KEY.LCTRL, VIRTUAL_KEY.LSHIFT, VIRTUAL_KEY.LARROW,
   VIRTUAL_KEY.BACKSPACE
@@ -542,9 +544,10 @@ export class ExternalEventsComponent implements OnInit {
       reconState.numGazeKeypresses++;
     }
     reconState.previousKeypressTimeMillis = nowMillis;
-
     if (isExternal &&
-        (keySequenceEndsWith(reconState.keySequence, TTS_TRIGGER_COMBO_KEY) ||
+        (EXTERNAL_PHRASE_DELIMITERS.some(
+             delimiter =>
+                 keySequenceEndsWith(reconState.keySequence, delimiter)) ||
          SENTENCE_END_COMBO_KEYS.some(
              keys => keySequenceEndsWith(reconState.keySequence, keys)))) {
       // A TTS action has been triggered.

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -4,15 +4,21 @@
  *
  * Test commands in DevTools console:
  * ```javascript
- * externalKeypressHook(72);  // h
- * externalKeypressHook(73);  // i
- * externalKeypressHook(32);  // space
- * externalKeypressHook(80);  // p
- * externalKeypressHook(65);  // a
- * externalKeypressHook(76);  // l
- * externalKeypressHook(190);  // .
- * externalKeypressHook(162);  // LCtrl
- * externalKeypressHook(87);  // W
+ * externalKeypressHook(72, true);  // h
+ * externalKeypressHook(73, true);  // i
+ * externalKeypressHook(32, true);  // space
+ * externalKeypressHook(80, true);  // p
+ * externalKeypressHook(65, true);  // a
+ * externalKeypressHook(76, true);  // l
+ * externalKeypressHook(190, true);  // .
+ * externalKeypressHook(162, true);  // LCtrl
+ * externalKeypressHook(87, true);  // W
+ * ```
+ *
+ * Bring to front combo key:
+ * ```
+ * externalKeypressHook(162, true);  // LCtrl
+ * externalKeypressHook(71, true);  // G
  * ```
  */
 
@@ -135,6 +141,11 @@ export const WORD_BACKSPACE_COMBO_KEY: string[] = [
   VIRTUAL_KEY.LCTRL, VIRTUAL_KEY.LSHIFT, VIRTUAL_KEY.LARROW,
   VIRTUAL_KEY.BACKSPACE
 ];
+
+// Ctrl + G brings the app to the foreground.
+export const LCTRL_KEY_HEAD_FOR_FOREGROUND_TRIGGER = 'g';
+export const BRING_TO_FOREGROUND_COMBO_KEY: string[] =
+    [VIRTUAL_KEY.LCTRL, LCTRL_KEY_HEAD_FOR_FOREGROUND_TRIGGER];
 
 function getKeyFromVirtualKeyCode(vkCode: number): string|null {
   if (vkCode >= 48 && vkCode <= 58) {
@@ -430,7 +441,7 @@ export class ExternalEventsComponent implements OnInit {
   @Input() textEntryEndSubject!: Subject<TextEntryEndEvent>;
 
   private static readonly keypressListeners: KeypressListener[] = [];
-
+  private static toggleForegroundCallback?: (toForeground: boolean) => void;
 
   ExternalEvewntsComponent() {}
 
@@ -467,6 +478,24 @@ export class ExternalEventsComponent implements OnInit {
     const index = ExternalEventsComponent.keypressListeners.indexOf(listener);
     if (index !== -1) {
       ExternalEventsComponent.keypressListeners.splice(index, 1);
+    }
+  }
+
+  /**
+   * Register a callback for when external events (e.g., a special combo key)
+   * cause the app to be put in the foreground. The caller and the callback is
+   * responsible for calling the binding method `bringWindowToForeground()`.
+   * @param callback
+   */
+
+  public static registerToggleForegroundCallback(
+      callback: (toForeground: boolean) => void) {
+    ExternalEventsComponent.toggleForegroundCallback = callback;
+  }
+
+  public static clearToggleForegroundCallback() {
+    if (ExternalEventsComponent.toggleForegroundCallback) {
+      ExternalEventsComponent.toggleForegroundCallback = undefined;
     }
   }
 
@@ -544,7 +573,15 @@ export class ExternalEventsComponent implements OnInit {
       reconState.numGazeKeypresses++;
     }
     reconState.previousKeypressTimeMillis = nowMillis;
-    if (isExternal &&
+    if (keySequenceEndsWith(
+            reconState.keySequence, BRING_TO_FOREGROUND_COMBO_KEY)) {
+      if (ExternalEventsComponent.toggleForegroundCallback) {
+        ExternalEventsComponent.toggleForegroundCallback(
+            /* toForeground= */ isExternal);
+      }
+      return;
+    } else if (
+        isExternal &&
         (EXTERNAL_PHRASE_DELIMITERS.some(
              delimiter =>
                  keySequenceEndsWith(reconState.keySequence, delimiter)) ||

--- a/webui/src/app/settings/settings.component.ts
+++ b/webui/src/app/settings/settings.component.ts
@@ -85,8 +85,12 @@ export class SettingsComponent implements AfterViewInit, OnInit, OnDestroy {
     removeAllButtonBoxes();
     setTimeout(() => {
       // Force reload.
-      window.location.reload(true);
+      this.windowReload();
     }, 100);
+  }
+
+  public windowReload = () => {
+    window.location.reload(true);
   }
 
   onQuitAppButtonClicked(event: Event) {

--- a/webui/src/app/settings/settings.component.ts
+++ b/webui/src/app/settings/settings.component.ts
@@ -1,6 +1,6 @@
 /** Quick phrase list for direct selection. */
 import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, ViewChildren} from '@angular/core';
-import {getHostInfo, requestQuitApp, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
+import {getHostInfo, REMOVE_ALL_GAZE_BUTTONS_DIRECTIVE, removeAllButtonBoxes, requestQuitApp, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {createUuid} from 'src/utils/uuid';
 
 import {HttpEventLogger} from '../event-logger/event-logger-impl';
@@ -81,8 +81,12 @@ export class SettingsComponent implements AfterViewInit, OnInit, OnDestroy {
   }
 
   onReloadAppButtonClicked(event: Event) {
-    // Force reload.
-    window.location.reload(true);
+    // Remove all registered gaze buttons before reloading the entire page.
+    removeAllButtonBoxes();
+    setTimeout(() => {
+      // Force reload.
+      window.location.reload(true);
+    }, 100);
   }
 
   onQuitAppButtonClicked(event: Event) {

--- a/webui/src/app/settings/settings.spec.ts
+++ b/webui/src/app/settings/settings.spec.ts
@@ -1,7 +1,7 @@
 /** Unit tests for settings. */
 import {BOUND_LISTENER_NAME} from '../../utils/cefsharp';
 
-import {clearSettings, ensureAppSettingsLoaded, getAppSettings, LOCAL_STORAGE_ITEM_NAME, modifyAppSettingsForTest, setDwellDelayMillis, setGazeFuzzyRadius, setShowGazeTracker, setTtsSpeakingRate, setGenericTtsVoiceName as setGenericTtsVoiceName, setTtsVoiceType, setTtsVolume, tryLoadSettings, trySaveSettings} from './settings';
+import {clearSettings, ensureAppSettingsLoaded, getAppSettings, LOCAL_STORAGE_ITEM_NAME, modifyAppSettingsForTest, setDwellDelayMillis, setGazeFuzzyRadius, setGenericTtsVoiceName as setGenericTtsVoiceName, setShowGazeTracker, setTtsSpeakingRate, setTtsVoiceType, setTtsVolume, tryLoadSettings, trySaveSettings} from './settings';
 
 describe('settings', () => {
   beforeEach(async () => {

--- a/webui/src/app/settings/version.ts
+++ b/webui/src/app/settings/version.ts
@@ -2,7 +2,7 @@
 
 const MAJOR_VERSION: string = '0';
 const MINOR_VERSION: string = '0';
-const PATCH_VERSION: string = '5';
+const PATCH_VERSION: string = '6';
 
 export const VERSION: string =
     `${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}`;

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -68,6 +68,30 @@ export function updateButtonBoxesForElements(
 }
 
 /**
+ * Bring main window to the foreground.
+ */
+export async function bringWindowToForeground() {
+  if ((window as any)[BOUND_LISTENER_NAME] == null) {
+    console.warn(`Cannot call bringWindowToForeground(), because object ${
+        BOUND_LISTENER_NAME} is not found`)
+    return;
+  }
+  ((window as any)[BOUND_LISTENER_NAME] as any).bringWindowToForeground();
+}
+
+/**
+ * Bring a focus app to the foreground (only if it is running).
+ */
+export async function bringFocusAppToForeground() {
+  if ((window as any)[BOUND_LISTENER_NAME] == null) {
+    console.warn(`Cannot call bringFocusAppToForeground(), because object ${
+        BOUND_LISTENER_NAME} is not found`)
+    return;
+  }
+  ((window as any)[BOUND_LISTENER_NAME] as any).bringFocusAppToForeground();
+}
+
+/**
  * Updates the host app regarding eye tracking options.
  * @param showGazeTracker Whether the dot that tracks the gaze point is
  *     shown.
@@ -161,7 +185,8 @@ export function resizeWindow(height: number, width: number): void {
   ((window as any)[BOUND_LISTENER_NAME] as any).resizeWindow(height, width);
 }
 
-export type ExternalKeypressHook = (vkCode: number) => void;
+export type ExternalKeypressHook = (vkCode: number, isExternal: boolean) =>
+    void;
 
 export function registerExternalKeypressHook(callback: ExternalKeypressHook) {
   (window as any)['externalKeypressHook'] = callback;

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -34,6 +34,8 @@ export function registerNewAccessToken(accessToken: string) {
   console.log('Called registerNewAccessToken()');
 }
 
+export const REMOVE_ALL_GAZE_BUTTONS_DIRECTIVE = '__remove_all__';
+
 /**
  * Update the clickable buttons for a component instance.
  *
@@ -121,6 +123,14 @@ function isRectVisibleInsideContainer(rect: DOMRect, containerRect: DOMRect) {
 /** Remove the clickable buttons of a given instance to an empty array. */
 export function updateButtonBoxesToEmpty(instanceId: string) {
   updateButtonBoxes(instanceId, []);
+}
+
+/**
+ * Remove all buttons from all component instance.
+ * This is done, e.g., when the entire app page reloads.
+ */
+export function removeAllButtonBoxes() {
+  updateButtonBoxes(REMOVE_ALL_GAZE_BUTTONS_DIRECTIVE, []);
 }
 
 function updateButtonBoxes(


### PR DESCRIPTION
* Fix incorrect boolean flag in keypress hook call, use Ctrl+W
* Add cefsharp interface methods:
  - `bringWindowToForeground()`
  - `bringFocusAppToForeground()`
* Remove all registered gaze buttons before page reload.

These subserve toggling between the app and a focus app with a combo key
such as Ctrl + G.

Fixes #280