### PR TITLE
[WebUI] Support basic cursor navigation in InputBarComponent

### DIFF
--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -227,7 +227,7 @@ fdescribe('ExternalEventsComponent', () => {
 
   for (const [posArg, expectedPos] of [
            [-1, 0], [0, 0], [1, 1], [2, 2], [3, 3], [4, 3]]) {
-    it(`placeCursor moves cursor: arg=${posArg}`, () => {
+    it(`placeCursor moves cursor: pos=${posArg}`, () => {
       const isExternal = false;
       ExternalEventsComponent.externalKeypressHook(65, isExternal);
       ExternalEventsComponent.externalKeypressHook(66, isExternal);
@@ -236,6 +236,22 @@ fdescribe('ExternalEventsComponent', () => {
       // const reconState = createReconStateForTest('foo bar');
       ExternalEventsComponent.placeCursor(posArg, isExternal);
       expect(ExternalEventsComponent.internalCursorPos).toEqual(expectedPos);
+    });
+  }
+
+  for (const [posArg, expectedFinalText] of [
+           [0, 'zabc'], [1, 'azbc'], [2, 'abzc'], [3, 'abcz']] as
+       Array<[number, string]>) {
+    it(`Entering keys after placing cursor works: pos=${posArg}`, () => {
+      const isExternal = false;
+      ExternalEventsComponent.externalKeypressHook(65, isExternal);
+      ExternalEventsComponent.externalKeypressHook(66, isExternal);
+      ExternalEventsComponent.externalKeypressHook(67, isExternal);
+      ExternalEventsComponent.placeCursor(posArg, isExternal);
+      ExternalEventsComponent.externalKeypressHook(90, isExternal);
+
+      expect(ExternalEventsComponent.internalText).toEqual(expectedFinalText);
+      expect(ExternalEventsComponent.internalCursorPos).toEqual(posArg + 1);
     });
   }
 

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -12,7 +12,6 @@ describe('ExternalEventsComponent', () => {
   let textEntryBeginSubject: Subject<TextEntryBeginEvent>;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
   let fixture: ComponentFixture<ExternalEventsComponent>;
-  let component: ExternalEventsComponent;
   let beginEvents: TextEntryBeginEvent[];
   let endEvents: TextEntryEndEvent[];
 

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -217,7 +217,6 @@ describe('ExternalEventsComponent', () => {
       ExternalEventsComponent.externalKeypressHook(66, isExternal);
       ExternalEventsComponent.externalKeypressHook(67, isExternal);
 
-      // const reconState = createReconStateForTest('foo bar');
       ExternalEventsComponent.placeCursor(posArg, isExternal);
       expect(ExternalEventsComponent.internalCursorPos).toEqual(expectedPos);
     });

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -8,29 +8,13 @@ import {ExternalEventsModule} from './external-events.module';
 
 const END_KEY_CODE = getVirtualkeyCode(LCTRL_KEY_HEAD_FOR_TTS_TRIGGER)[0]
 
-// function createReconStateForTest(text: string):
-//     TextReconState {
-//       const reconState: TextReconState = {
-//         previousKeypressTimeMillis: 1000,
-//         numGazeKeypresses: text.length,
-//         text,
-//         cursorPos: text.length,
-//         isShiftOn: false,
-//         keySequence: text.split(''),
-//       };
-//       return reconState;
-//     }
-
-
-fdescribe('ExternalEventsComponent', () => {
+describe('ExternalEventsComponent', () => {
   let textEntryBeginSubject: Subject<TextEntryBeginEvent>;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
   let fixture: ComponentFixture<ExternalEventsComponent>;
   let component: ExternalEventsComponent;
   let beginEvents: TextEntryBeginEvent[];
   let endEvents: TextEntryEndEvent[];
-
-
 
   beforeEach(async () => {
     await TestBed
@@ -401,6 +385,28 @@ fdescribe('ExternalEventsComponent', () => {
       expect(endEvents[0].timestampMillis)
           .toBeGreaterThanOrEqual(beginEvents[0].timestampMillis);
     });
+  }
+
+  for (const [cursorPos, expectedText] of [[2, ' w1'], [3, 'w1']] as
+       Array<[number, string]>) {
+    it(`Word backspace after cursor placement works: cursor pos=${cursorPos}`,
+        () => {
+          // hi w1.
+          const isExternal = false;
+          const vkCodes = [72, 73, 32, 87, 49];
+          for (const vkCode of vkCodes) {
+            ExternalEventsComponent.externalKeypressHook(vkCode, isExternal);
+          }
+          ExternalEventsComponent.placeCursor(cursorPos, isExternal);
+          // LCTRL + LSHIFT + LARROW + BACKSPACE.
+          const vkCodesWordBack = [162, 160, 37, 8];
+          for (const vkCode of vkCodesWordBack) {
+            ExternalEventsComponent.externalKeypressHook(vkCode, isExternal);
+          }
+
+          expect(ExternalEventsComponent.internalText).toEqual(expectedText);
+          expect(ExternalEventsComponent.internalCursorPos).toEqual(0);
+        });
   }
 
   it('LShift key enters upper case letter', () => {

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -1,19 +1,36 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Subject, Subscription} from 'rxjs';
+import {Subject} from 'rxjs';
 
 import {TextEntryBeginEvent, TextEntryEndEvent} from '../types/text-entry';
 
-import {ExternalEventsComponent, getPunctuationLiteral, getVirtualkeyCode, LCTRL_KEY_HEAD_FOR_TTS_TRIGGER, resetReconStates, tryDetectoMultiKeyChar, VIRTUAL_KEY, VKCODE_SPECIAL_KEYS} from './external-events.component';
+import {ExternalEventsComponent, getPunctuationLiteral, getVirtualkeyCode, LCTRL_KEY_HEAD_FOR_TTS_TRIGGER, resetReconStates, TextReconState, tryDetectoMultiKeyChar, VIRTUAL_KEY, VKCODE_SPECIAL_KEYS} from './external-events.component';
 import {ExternalEventsModule} from './external-events.module';
 
 const END_KEY_CODE = getVirtualkeyCode(LCTRL_KEY_HEAD_FOR_TTS_TRIGGER)[0]
 
-describe('ExternalEventsComponent', () => {
+// function createReconStateForTest(text: string):
+//     TextReconState {
+//       const reconState: TextReconState = {
+//         previousKeypressTimeMillis: 1000,
+//         numGazeKeypresses: text.length,
+//         text,
+//         cursorPos: text.length,
+//         isShiftOn: false,
+//         keySequence: text.split(''),
+//       };
+//       return reconState;
+//     }
+
+
+fdescribe('ExternalEventsComponent', () => {
   let textEntryBeginSubject: Subject<TextEntryBeginEvent>;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
   let fixture: ComponentFixture<ExternalEventsComponent>;
+  let component: ExternalEventsComponent;
   let beginEvents: TextEntryBeginEvent[];
   let endEvents: TextEntryEndEvent[];
+
+
 
   beforeEach(async () => {
     await TestBed
@@ -207,6 +224,20 @@ describe('ExternalEventsComponent', () => {
     ]);
     expect(reconstructedTexts).toEqual(['9', '98', '981', '9810']);
   });
+
+  for (const [posArg, expectedPos] of [
+           [-1, 0], [0, 0], [1, 1], [2, 2], [3, 3], [4, 3]]) {
+    it(`placeCursor moves cursor: arg=${posArg}`, () => {
+      const isExternal = false;
+      ExternalEventsComponent.externalKeypressHook(65, isExternal);
+      ExternalEventsComponent.externalKeypressHook(66, isExternal);
+      ExternalEventsComponent.externalKeypressHook(67, isExternal);
+
+      // const reconState = createReconStateForTest('foo bar');
+      ExternalEventsComponent.placeCursor(posArg, isExternal);
+      expect(ExternalEventsComponent.internalCursorPos).toEqual(expectedPos);
+    });
+  }
 
   it('Reistering keypress listener updates listener count', () => {
     ExternalEventsComponent.registerKeypressListener(
@@ -757,12 +788,14 @@ describe('ExternalEventsComponent', () => {
 
   it('registered toggle-foreground callback not called by incomplete sequences',
      () => {
-      const callFlags: boolean[] = [];
-      ExternalEventsComponent.registerToggleForegroundCallback(
-          (toForeground: boolean) => {callFlags.push(toForeground)});
-      ExternalEventsComponent.externalKeypressHook(162, /* isExternal= */ true);
-      ExternalEventsComponent.externalKeypressHook(71, /* isExternal= */ false);
+       const callFlags: boolean[] = [];
+       ExternalEventsComponent.registerToggleForegroundCallback(
+           (toForeground: boolean) => {callFlags.push(toForeground)});
+       ExternalEventsComponent.externalKeypressHook(
+           162, /* isExternal= */ true);
+       ExternalEventsComponent.externalKeypressHook(
+           71, /* isExternal= */ false);
 
-      expect(callFlags).toEqual([]);
+       expect(callFlags).toEqual([]);
      });
 });

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -170,7 +170,6 @@ function insertCharAsCursorPos(char: string, reconState: TextReconState) {
         casedChar + reconState.text.slice(reconState.cursorPos);
   }
   reconState.cursorPos += 1;
-  console.log('*** insertCharAtCursorPos():', reconState.cursorPos);  // DEBUG
 }
 
 function getHomeKeyDestination(reconState: TextReconState): number {
@@ -681,15 +680,15 @@ export class ExternalEventsComponent implements OnInit {
   }
 
   public static placeCursor(cursorPos: number, isExternal = false) {
-    // TODO(cais): Add unit test.
     const reconState = isExternal ? externalReconState : internalReconState;
+    console.log('*** text length=', reconState.text.length);  // DEBUG
     if (cursorPos > reconState.text.length) {
       reconState.cursorPos = reconState.text.length;
     } else if (cursorPos < 0) {
       reconState.cursorPos = 0;
+    } else {
+      reconState.cursorPos = cursorPos;
     }
-    reconState.cursorPos = cursorPos;
-    console.log('*** Placed cusor at:', cursorPos);  // DEBUG
   }
 
   /**

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -196,6 +196,7 @@ function wordBackspace(reconState: TextReconState) {
       break;
     }
   }
+  // TODO(cais): Handle non-final cursor position.
   reconState.text = reconState.text.slice(0, j + 1) +
       reconState.text.slice(reconState.cursorPos);
   reconState.cursorPos = j + 1;

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -170,7 +170,6 @@ function insertCharAsCursorPos(char: string, reconState: TextReconState) {
         casedChar + reconState.text.slice(reconState.cursorPos);
   }
   reconState.cursorPos += 1;
-  console.log('*** insertCharAtCursorPos:', reconState.cursorPos);  // DEBUG
 }
 
 function getHomeKeyDestination(reconState: TextReconState): number {
@@ -180,11 +179,7 @@ function getHomeKeyDestination(reconState: TextReconState): number {
 }
 
 function wordBackspace(reconState: TextReconState) {
-  // reconState.cursorPos = reconState.keySequence.length;
-  // Find the last non-whitespace chararcter.
-  // let j = reconState.text.length - 1;
   let j = reconState.cursorPos - 1;
-  console.log('*** wordBackspace:', JSON.stringify(reconState));  // DEBUG
   for (; j >= 0; --j) {
     const char = reconState.text[j];
     if (char !== ' ' && char !== '\n') {
@@ -434,6 +429,10 @@ const externalReconState = createInitialTextReconState();
 const ignoreMachineKeySequenceConfigs: IgnoreMachineKeySequenceConfig[] = [];
 let textEntryBeginSubject: Subject<TextEntryBeginEvent>;
 let textEntryEndSubject: Subject<TextEntryEndEvent>;
+
+export function setInternalReconStateForTest(reconState: TextReconState) {
+  Object.assign(internalReconState, reconState);
+}
 
 @Component({
   selector: 'app-external-events-component',
@@ -693,7 +692,6 @@ export class ExternalEventsComponent implements OnInit {
 
   public static placeCursor(cursorPos: number, isExternal = false) {
     const reconState = isExternal ? externalReconState : internalReconState;
-    console.log('*** text length=', reconState.text.length);  // DEBUG
     if (cursorPos > reconState.text.length) {
       reconState.cursorPos = reconState.text.length;
     } else if (cursorPos < 0) {

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -170,6 +170,7 @@ function insertCharAsCursorPos(char: string, reconState: TextReconState) {
         casedChar + reconState.text.slice(reconState.cursorPos);
   }
   reconState.cursorPos += 1;
+  console.log('*** insertCharAtCursorPos():', reconState.cursorPos);  // DEBUG
 }
 
 function getHomeKeyDestination(reconState: TextReconState): number {
@@ -678,6 +679,18 @@ export class ExternalEventsComponent implements OnInit {
     // TODO(cais): Take care of Shift+Backspace and Shift+Delete.
   }
 
+  public static placeCursor(cursorPos: number, isExternal = false) {
+    // TODO(cais): Add unit test.
+    const reconState = isExternal ? externalReconState : internalReconState;
+    if (cursorPos > reconState.text.length) {
+      reconState.cursorPos = reconState.text.length;
+    } else if (cursorPos < 0) {
+      reconState.cursorPos = 0;
+    }
+    reconState.cursorPos = cursorPos;
+    console.log('*** Placed cusor at:', cursorPos);  // DEBUG
+  }
+
   /**
    * Append a string to the current reconstruction state.
    *
@@ -712,5 +725,9 @@ export class ExternalEventsComponent implements OnInit {
 
   static get internalText(): string {
     return internalReconState.text;
+  }
+
+  static get internalCursorPos(): number {
+    return internalReconState.cursorPos;
   }
 }

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -39,7 +39,10 @@
 }
 
 .base-text-area {
-  display: inline-block;
+  align-items: center;
+  display: inline-flex;
+  flex-direction: row;
+  margin-right: 4px;
 }
 
 .buttons-container {
@@ -163,14 +166,14 @@
 
 .simulated-cursor {
   animation: blink 1.1s linear infinite alternate;
-  box-sizing:   content-box;
-  font-weight: 100;
+  display: inline-block;
   font-size: 30px;
-  height: 0;
+  font-weight: 900;
+  left: -4px;
   margin: 0;
-  max-height: 0;
   max-width: 0;
   overflow: visible;
+  position: relative;
   width: 0;
 }
 
@@ -207,12 +210,12 @@
                  state !== 'FOCUSED_ON_LETTER_CHIP' &&
                  state !== 'CHOOSING_WORD_CHIP' &&
                  state !== 'FOCUSED_ON_WORD_CHIP'">
-        <span
+        <div
             class="input-text"
-            (click)="onInputBoxBeforeCursorClicked($event)">{{inputStringBeforeCursor}}<span
+            (click)="onTextBeforeCursorClicked($event)">{{inputStringBeforeCursor}}<div
                 class="simulated-cursor"
                 [ngClass]="{'simulated-cursor-hidden': !isFocused}"
-            >|</span><span (click)="onInputBoxAfterCursorClicked($event)">{{inputStringAfterCursor}}</span></span>
+            >|</div><div class="input-text" (click)="onTextAfterCursorClicked($event)">{{inputStringAfterCursor}}</div></div>
       </div>
       <div
           class="chips-container"

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -121,7 +121,7 @@
   line-height: 66px;
   margin: 0 8px;
   min-width: 100%;
-  padding: 0 4px;
+  padding: 0 4px 0 8px;
   width: 100%;
 }
 

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -130,7 +130,7 @@
   display: inline-block;
   line-height: 30px;
   overflow-wrap: break-word;
-  white-space: pre-line;
+  white-space: pre-wrap;
   word-break: break-word;
 }
 
@@ -174,7 +174,7 @@
   max-width: 0;
   overflow: visible;
   position: relative;
-  white-space: pre-line;
+  white-space: pre-wrap;
   width: 0;
 }
 
@@ -211,12 +211,12 @@
                  state !== 'FOCUSED_ON_LETTER_CHIP' &&
                  state !== 'CHOOSING_WORD_CHIP' &&
                  state !== 'FOCUSED_ON_WORD_CHIP'">
-        <span
+        <div
             class="input-text"
-            (click)="onTextBeforeCursorClicked($event)">{{inputStringBeforeCursor}}<span
+            (click)="onTextBeforeCursorClicked($event)">{{inputStringBeforeCursor}}<div
                 class="simulated-cursor"
                 [ngClass]="{'simulated-cursor-hidden': !isFocused}"
-            >|</span><span class="input-text" (click)="onTextAfterCursorClicked($event)">{{inputStringAfterCursor}}</span></span>
+            >|</div><div class="input-text" (click)="onTextAfterCursorClicked($event)">{{inputStringAfterCursor}}</div></div>
       </div>
       <div
           class="chips-container"

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -130,7 +130,7 @@
   display: inline-block;
   line-height: 30px;
   overflow-wrap: break-word;
-  white-space: pre-wrap;
+  white-space: pre-line;
   word-break: break-word;
 }
 
@@ -174,6 +174,7 @@
   max-width: 0;
   overflow: visible;
   position: relative;
+  white-space: pre-line;
   width: 0;
 }
 
@@ -210,12 +211,12 @@
                  state !== 'FOCUSED_ON_LETTER_CHIP' &&
                  state !== 'CHOOSING_WORD_CHIP' &&
                  state !== 'FOCUSED_ON_WORD_CHIP'">
-        <div
+        <span
             class="input-text"
-            (click)="onTextBeforeCursorClicked($event)">{{inputStringBeforeCursor}}<div
+            (click)="onTextBeforeCursorClicked($event)">{{inputStringBeforeCursor}}<span
                 class="simulated-cursor"
                 [ngClass]="{'simulated-cursor-hidden': !isFocused}"
-            >|</div><div class="input-text" (click)="onTextAfterCursorClicked($event)">{{inputStringAfterCursor}}</div></div>
+            >|</span><span class="input-text" (click)="onTextAfterCursorClicked($event)">{{inputStringAfterCursor}}</span></span>
       </div>
       <div
           class="chips-container"

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -163,9 +163,15 @@
 
 .simulated-cursor {
   animation: blink 1.1s linear infinite alternate;
-  font-weight: 900;
+  box-sizing:   content-box;
+  font-weight: 100;
   font-size: 30px;
-  margin-left: 0.1em;
+  height: 0;
+  margin: 0;
+  max-height: 0;
+  max-width: 0;
+  overflow: visible;
+  width: 0;
 }
 
 .simulated-cursor-hidden {
@@ -195,16 +201,18 @@
   <div class="input-box">
     <div class="main-area">
       <div
+          #inputText
           class="base-text-area"
           *ngIf="state !== 'CHOOSING_LETTER_CHIP' &&
                  state !== 'FOCUSED_ON_LETTER_CHIP' &&
                  state !== 'CHOOSING_WORD_CHIP' &&
                  state !== 'FOCUSED_ON_WORD_CHIP'">
         <span
-            #inputText class="input-text">{{inputString}}<span
+            class="input-text"
+            (click)="onInputBoxBeforeCursorClicked($event)">{{inputStringBeforeCursor}}<span
                 class="simulated-cursor"
                 [ngClass]="{'simulated-cursor-hidden': !isFocused}"
-            >|</span></span>
+            >|</span><span (click)="onInputBoxAfterCursorClicked($event)">{{inputStringAfterCursor}}</span></span>
       </div>
       <div
           class="chips-container"

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -6,7 +6,8 @@ import {Observable, Subject} from 'rxjs';
 
 import * as cefSharp from '../../utils/cefsharp';
 import {HttpEventLogger} from '../event-logger/event-logger-impl';
-import {repeatVirtualKey, resetReconStates, VIRTUAL_KEY} from '../external/external-events.component';
+import * as ExternalEvents from '../external/external-events.component';
+import {ExternalEventsComponent, repeatVirtualKey, resetReconStates, VIRTUAL_KEY} from '../external/external-events.component';
 import {InputBarChipComponent} from '../input-bar-chip/input-bar-chip.component';
 import {InputBarChipModule} from '../input-bar-chip/input-bar-chip.module';
 import {LoadLexiconRequest} from '../lexicon/lexicon.component';
@@ -137,8 +138,18 @@ describe('InputBarComponent', () => {
             currentKeySequence,
             reconstructedText[i].slice(0, baseLength + i + 1));
       }
-      fixture.detectChanges();
     }
+    ExternalEvents.setInternalReconStateForTest({
+      previousKeypressTimeMillis: null,
+      numGazeKeypresses: keySequence.length,
+      keySequence,
+      text: Array.isArray(reconstructedText) ?
+          reconstructedText[reconstructedText.length - 1] :
+          reconstructedText,
+      cursorPos: reconstructedText.length,
+      isShiftOn: false,
+    });
+    fixture.detectChanges();
   }
 
   for (const [keySequence, reconstructedText, expectedText] of [
@@ -155,6 +166,7 @@ describe('InputBarComponent', () => {
            `key sequence = ${JSON.stringify(keySequence)}`,
        () => {
          enterKeysIntoComponent(keySequence, reconstructedText);
+         fixture.detectChanges();
 
          const inputText = fixture.debugElement.query(By.css('.input-text'));
          expect(inputText.nativeElement.innerText).toEqual(expectedText + '|');

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -723,11 +723,8 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!selection) {
       return;
     }
-    console.log('*** Before cursor:', event.target, selection);  // DEBUG
     ExternalEventsComponent.placeCursor(
         selection.anchorOffset, /* isExternal= */ false);
-    // console.log('***:', selection.focusNode.data[selection.focusOffset]);
-    // alert(selection.focusOffset);
   }
 
   onTextAfterCursorClicked(event: Event) {
@@ -737,11 +734,9 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!selection) {
       return;
     }
-    console.log('*** After cursor:', event.target, selection);  // DEBUG
     ExternalEventsComponent.placeCursor(
-        selection.anchorOffset + this.inputStringBeforeCursor.length, /* isExternal= */ false);
-    // console.log('***:', selection.focusNode.data[selection.focusOffset]);
-    // alert(selection.focusOffset);
+        selection.anchorOffset + this.inputStringBeforeCursor.length,
+        /* isExternal= */ false);
   }
 
   getChipText(index: number): string {
@@ -760,11 +755,17 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get inputStringBeforeCursor(): string {
-    return this.inputString.substring(0, ExternalEventsComponent.internalCursorPos);
+    console.log(
+        '*** ExternalEventsComponent.internalCursorPos:',
+        ExternalEventsComponent.internalCursorPos,
+        ExternalEventsComponent.internalText);  // DEBUG
+    return this.inputString.substring(
+        0, ExternalEventsComponent.internalCursorPos);
   }
 
   get inputStringAfterCursor(): string {
-    return this.inputString.substring(ExternalEventsComponent.internalCursorPos);
+    return this.inputString.substring(
+        ExternalEventsComponent.internalCursorPos);
   }
 
   /**

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -76,7 +76,7 @@ export const ABBRVIATION_EXPANSION_TRIGGER_KEY_SEQUENCES: Array<string[]> =
 
 const INPUT_TEXT_BASE_FONT_SIZE = 30;
 const INPUT_TEXT_FONT_SIZE_SCALING_FACTORS =
-    [1.0, 1 / 1.35, 1 / 1.6, 1 / 1.8, 1 / 1.95];
+    [1.0, 1 / 1.4, 1 / 1.65, 1 / 1.85, 1 / 2.00];
 const INPUT_TEXT_FONT_SIZE_SCALING_LENGTH_TICKS = [0, 50, 100, 150, 250];
 
 export const ABBREVIATION_MAX_PROPER_LENGTH = 12;
@@ -183,6 +183,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
             this.state = State.ENTERING_BASE_TEXT;
             this.eventLogger.logContextualPhraseCopying(
                 getPhraseStats(event.appendText));
+            this.scaleInputTextFontSize();
           } else if (event.contextualPhraseTags) {
             this._contextualPhraseTags.splice(0);
             this._contextualPhraseTags.push(...event.contextualPhraseTags);
@@ -719,12 +720,19 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   onTextBeforeCursorClicked(event: Event) {
     event.preventDefault();
     event.stopPropagation();
-    const selection = window.getSelection();
-    if (!selection) {
+    const anchorOffset = this.getWindowSelectionAnchorOffset();
+    if (anchorOffset === null) {
       return;
     }
-    ExternalEventsComponent.placeCursor(
-        selection.anchorOffset, /* isExternal= */ false);
+    ExternalEventsComponent.placeCursor(anchorOffset, /* isExternal= */ false);
+  }
+
+  getWindowSelectionAnchorOffset(): number|null {
+    const selection = window.getSelection();
+    if (!selection) {
+      return null;
+    }
+    return selection.anchorOffset;
   }
 
   onTextAfterCursorClicked(event: Event) {
@@ -755,10 +763,6 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get inputStringBeforeCursor(): string {
-    console.log(
-        '*** ExternalEventsComponent.internalCursorPos:',
-        ExternalEventsComponent.internalCursorPos,
-        ExternalEventsComponent.internalText);  // DEBUG
     return this.inputString.substring(
         0, ExternalEventsComponent.internalCursorPos);
   }

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -7,7 +7,7 @@ import {endsWithSentenceEndPunctuation, isAlphanumericChar, keySequenceEndsWith}
 import {createUuid} from 'src/utils/uuid';
 
 import {getPhraseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
-import {ExternalEventsComponent, IgnoreMachineKeySequenceConfig, repeatVirtualKey, VIRTUAL_KEY} from '../external/external-events.component';
+import {ExternalEventsComponent, IgnoreMachineKeySequenceConfig, repeatVirtualKey, resetReconStates, VIRTUAL_KEY} from '../external/external-events.component';
 import {LexiconComponent, LoadLexiconRequest} from '../lexicon/lexicon.component';
 import {FillMaskRequest, SpeakFasterService} from '../speakfaster-service';
 import {StudyManager} from '../study/study-manager';
@@ -709,6 +709,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     this.baseReconstructedText = '';
     this.cutText = '';
+    resetReconStates();
   }
 
   private updateInputString(newStringValue: string) {

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -716,7 +716,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     updateButtonBoxesForElements(this.instanceId, this.buttons);
   }
 
-  onInputBoxBeforeCursorClicked(event: Event) {
+  onTextBeforeCursorClicked(event: Event) {
     event.preventDefault();
     event.stopPropagation();
     const selection = window.getSelection();
@@ -730,7 +730,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     // alert(selection.focusOffset);
   }
 
-  onInputBoxAfterCursorClicked(event: Event) {
+  onTextAfterCursorClicked(event: Event) {
     event.preventDefault();
     event.stopPropagation();
     const selection = window.getSelection();

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -716,6 +716,34 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     updateButtonBoxesForElements(this.instanceId, this.buttons);
   }
 
+  onInputBoxBeforeCursorClicked(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const selection = window.getSelection();
+    if (!selection) {
+      return;
+    }
+    console.log('*** Before cursor:', event.target, selection);  // DEBUG
+    ExternalEventsComponent.placeCursor(
+        selection.anchorOffset, /* isExternal= */ false);
+    // console.log('***:', selection.focusNode.data[selection.focusOffset]);
+    // alert(selection.focusOffset);
+  }
+
+  onInputBoxAfterCursorClicked(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const selection = window.getSelection();
+    if (!selection) {
+      return;
+    }
+    console.log('*** After cursor:', event.target, selection);  // DEBUG
+    ExternalEventsComponent.placeCursor(
+        selection.anchorOffset + this.inputStringBeforeCursor.length, /* isExternal= */ false);
+    // console.log('***:', selection.focusNode.data[selection.focusOffset]);
+    // alert(selection.focusOffset);
+  }
+
   getChipText(index: number): string {
     if (this._chipTypedText !== null) {
       if (this._chipTypedText[index] === null) {
@@ -729,6 +757,14 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
 
   get hasInputStringOrChips(): boolean {
     return this.inputString.trim().length > 0 || this._chips.length > 0;
+  }
+
+  get inputStringBeforeCursor(): string {
+    return this.inputString.substring(0, ExternalEventsComponent.internalCursorPos);
+  }
+
+  get inputStringAfterCursor(): string {
+    return this.inputString.substring(ExternalEventsComponent.internalCursorPos);
   }
 
   /**


### PR DESCRIPTION
Click events in the `InputBarComponent`'s input-text div previous didn't get handled. In this PR, the events are now handled and are used to place the cursor in the corresponding location.

This PR also fixes the logical for word-backspace (Ctrl+Backspace or Ctrl,Shift,Left,Backspace) for non-final cursor locations.

When cursor is not at the final location, it can insert text into the text in the input bar.

See screenshot:
![image](https://user-images.githubusercontent.com/16824702/167274497-9b01887d-2464-45e7-877a-e1ef261500e2.png)

Known issues: When there is line wrapping in input-text, placing the cursor changes the wrapping, because a line break is inserted right after the cursor. 