### PR TITLE
[WebUI] Make favorite button remember last spoken phrase

### DIFF
--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -3,7 +3,7 @@ import {Subject} from 'rxjs';
 
 import {TextEntryBeginEvent, TextEntryEndEvent} from '../types/text-entry';
 
-import {ExternalEventsComponent, getPunctuationLiteral, getVirtualkeyCode, LCTRL_KEY_HEAD_FOR_TTS_TRIGGER, resetReconStates, TextReconState, tryDetectoMultiKeyChar, VIRTUAL_KEY, VKCODE_SPECIAL_KEYS} from './external-events.component';
+import {ExternalEventsComponent, getPunctuationLiteral, getVirtualkeyCode, LCTRL_KEY_HEAD_FOR_TTS_TRIGGER, resetReconStates, tryDetectoMultiKeyChar, VIRTUAL_KEY, VKCODE_SPECIAL_KEYS} from './external-events.component';
 import {ExternalEventsModule} from './external-events.module';
 
 const END_KEY_CODE = getVirtualkeyCode(LCTRL_KEY_HEAD_FOR_TTS_TRIGGER)[0]

--- a/webui/src/app/favorite-button/favorite-button.component.spec.ts
+++ b/webui/src/app/favorite-button/favorite-button.component.spec.ts
@@ -25,7 +25,7 @@ class SpeakFasterServiceForTest {
   }
 }
 
-fdescribe('FavoriteButton', () => {
+describe('FavoriteButton', () => {
   let fixture: ComponentFixture<FavoriteButtonComponent>;
   let speakFasterServiceForTest: SpeakFasterServiceForTest;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;

--- a/webui/src/app/favorite-button/favorite-button.component.spec.ts
+++ b/webui/src/app/favorite-button/favorite-button.component.spec.ts
@@ -2,12 +2,13 @@
 
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {Observable, of, Subject, throwError} from 'rxjs';
+import {Observable, of, Subject} from 'rxjs';
 
 import {HttpEventLogger} from '../event-logger/event-logger-impl';
 import {InputBarControlEvent} from '../input-bar/input-bar.component';
 import {SpeakFasterService} from '../speakfaster-service';
 import {AddContextualPhraseRequest, AddContextualPhraseResponse, DeleteContextualPhraseRequest, DeleteContextualPhraseResponse} from '../types/contextual_phrase';
+import {TextEntryEndEvent} from '../types/text-entry';
 
 import {FavoriteButtonComponent, State} from './favorite-button.component';
 import {FavoriteButtonModule} from './favorite-button.module';
@@ -24,9 +25,10 @@ class SpeakFasterServiceForTest {
   }
 }
 
-describe('FavoriteButton', () => {
+fdescribe('FavoriteButton', () => {
   let fixture: ComponentFixture<FavoriteButtonComponent>;
   let speakFasterServiceForTest: SpeakFasterServiceForTest;
+  let textEntryEndSubject: Subject<TextEntryEndEvent>;
   let inputBarControlSubject: Subject<InputBarControlEvent>;
   let inputBarControlEvents: InputBarControlEvent[];
   let addedEvents: Array<{text: string, success: boolean}>;
@@ -34,6 +36,7 @@ describe('FavoriteButton', () => {
 
   beforeEach(async () => {
     speakFasterServiceForTest = new SpeakFasterServiceForTest();
+    textEntryEndSubject = new Subject();
     inputBarControlSubject = new Subject();
     inputBarControlEvents = [];
     inputBarControlSubject.subscribe((event) => {
@@ -54,6 +57,7 @@ describe('FavoriteButton', () => {
     addedEvents = [];
     fixture.componentInstance.favoritePhraseAdded.subscribe(
         event => addedEvents.push(event));
+    fixture.componentInstance.textEntryEndSubject = textEntryEndSubject;
     fixture.componentInstance.inputBarControlSubject = inputBarControlSubject;
     fixture.detectChanges();
   });
@@ -146,9 +150,9 @@ describe('FavoriteButton', () => {
          },
        });
        expect(addedEvents).toEqual([{
-        text: 'hi there!',
-        success: false,
-      }]);
+         text: 'hi there!',
+         success: false,
+       }]);
 
        tick(2000);
        expect(fixture.componentInstance.state).toEqual(State.READY);
@@ -238,4 +242,40 @@ describe('FavoriteButton', () => {
        expect(fixture.componentInstance.state).toEqual(State.READY);
        expect(spy).not.toHaveBeenCalled();
      });
+
+  it('click w/ empty phrase and remembered non-empty phrase adds to favorite',
+     () => {
+       fixture.componentInstance.userId = 'testuser1';
+       textEntryEndSubject.next({
+         text: 'This was spoken before',
+         isFinal: true,
+         timestampMillis: Date.now(),
+       });
+       const button = fixture.debugElement.query(By.css('.favorite-button'));
+       const spy = spyOn(speakFasterServiceForTest, 'addContextualPhrase');
+       fixture.componentInstance.phrase = '';
+       fixture.detectChanges();
+       button.nativeElement.click();
+
+       expect(spy).toHaveBeenCalledWith({
+         userId: 'testuser1',
+         contextualPhrase: {
+           phraseId: '',
+           text: 'This was spoken before',
+           tags: ['favorite'],
+         }
+       });
+       expect(fixture.componentInstance.state).toEqual(State.REQUESTING);
+     });
+
+  it('click w/ empty phrase and no remembered phrase has no effect', () => {
+    fixture.componentInstance.userId = 'testuser1';
+    fixture.componentInstance.phrase = '';
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('.favorite-button'));
+    const spy = spyOn(speakFasterServiceForTest, 'addContextualPhrase');
+    button.nativeElement.click();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
 });

--- a/webui/src/app/favorite-button/favorite-button.component.ts
+++ b/webui/src/app/favorite-button/favorite-button.component.ts
@@ -65,7 +65,6 @@ export class FavoriteButtonComponent implements OnInit, OnDestroy {
             }
             // Remember the last-entered, non-empty phrase.
             this.lastNonEmptyText = event.text.trim();
-            console.log('*** Non-empty text:', event.text);  // DEBUG
           });
     }
   }

--- a/webui/src/app/favorite-button/favorite-button.component.ts
+++ b/webui/src/app/favorite-button/favorite-button.component.ts
@@ -3,12 +3,13 @@
  * indicates states such as ongoing request, success and error.
  */
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
-import {Subject} from 'rxjs';
+import {Subject, Subscription} from 'rxjs';
 
 import {getContextualPhraseStats, getPhraseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
 import {InputBarControlEvent} from '../input-bar/input-bar.component';
 import {SpeakFasterService} from '../speakfaster-service';
 import {AddContextualPhraseResponse, ContextualPhrase} from '../types/contextual_phrase';
+import {TextEntryEndEvent} from '../types/text-entry';
 
 export enum State {
   READY = 'READY',
@@ -33,6 +34,10 @@ export class FavoriteButtonComponent implements OnInit, OnDestroy {
   @Input() phraseDisplayText?: string;
   // Phrase ID: must be provided if isDeleteion is true.
   @Input() phraseId?: string;
+  // If provided, will use the events to remember the last entered non-empty
+  // text, and when the button is clicked while `phrase` is empty, the remebered
+  // non-empty text will be added to favorite.
+  @Input() textEntryEndSubject?: Subject<TextEntryEndEvent>;
   @Input() sendAsUserFeedback: boolean = false;
   @Input()
   tags: string[]|undefined =
@@ -43,17 +48,37 @@ export class FavoriteButtonComponent implements OnInit, OnDestroy {
       new EventEmitter();
 
   state: State = State.READY;
+  private textEntryEndSubjectSubscription?: Subscription;
+  private lastNonEmptyText: string|null = null;
 
   constructor(
       public speakFasterService: SpeakFasterService,
       private eventLogger: HttpEventLogger) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    if (this.textEntryEndSubject) {
+      this.textEntryEndSubjectSubscription =
+          this.textEntryEndSubject.subscribe((event: TextEntryEndEvent) => {
+            if (!event.isFinal || event.repeatLastNonEmpty || event.isAborted ||
+                !event.text.trim()) {
+              return;
+            }
+            // Remember the last-entered, non-empty phrase.
+            this.lastNonEmptyText = event.text.trim();
+            console.log('*** Non-empty text:', event.text);  // DEBUG
+          });
+    }
+  }
 
-  ngOnDestroy() {}
+  ngOnDestroy() {
+    if (this.textEntryEndSubjectSubscription) {
+      this.textEntryEndSubjectSubscription.unsubscribe();
+    }
+  }
 
   onFavoriteButtonClicked(event: Event) {
-    if (this.phrase.trim() === '') {
+    let phrase = this.phrase.trim() || this.lastNonEmptyText;
+    if (!phrase) {
       return;
     }
     if (!this.userId) {
@@ -68,7 +93,7 @@ export class FavoriteButtonComponent implements OnInit, OnDestroy {
         // Send as user feedback.
         this.eventLogger
             .logUserFeedback({
-              feedbackMessage: this.phrase.trim(),
+              feedbackMessage: phrase.trim(),
             })
             .then(
                 () => {
@@ -81,8 +106,7 @@ export class FavoriteButtonComponent implements OnInit, OnDestroy {
                 });
       } else {
         // Add contextual phrase.
-        const text = this.phrase.trim();
-
+        const text = phrase.trim();
         const contextualPhrase: ContextualPhrase = {
           phraseId: '',  // For AddContextualPhraseRequest, this is ignored.
           text,
@@ -139,7 +163,7 @@ export class FavoriteButtonComponent implements OnInit, OnDestroy {
         throw new Error('Cannot delete phrase: Empty phrase ID');
       }
       this.state = State.REQUESTING;
-      this.eventLogger.logContextualPhraseDelete(getPhraseStats(this.phrase));
+      this.eventLogger.logContextualPhraseDelete(getPhraseStats(phrase));
       this.speakFasterService
           .deleteContextualPhrase({
             userId: this.userId,

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -303,6 +303,7 @@
             [phrase]="effectivePhrase"
             [sendAsUserFeedback]="favoriteButtonSendsUserFeedback"
             [inputBarControlSubject]="inputBarControlSubject"
+            [textEntryEndSubject]="textEntryEndSubject"
             [tags]="contextualPhraseTags"
             (favoritePhraseAdded)="onFavoritePhraseAdded($event)">
         </app-favorite-button-component>

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -245,24 +245,24 @@ describe('InputBarComponent', () => {
   for (const [anchorOffset, expectedText] of [[0, '|ba'], [1, 'b|a']] as
        Array<[number, string]>) {
     it(`clicking in text box updates cursor position: offset=${anchorOffset}`,
-        () => {
-          enterKeysIntoComponent(['b', 'a'], 'ba');
-          ExternalEvents.setInternalReconStateForTest({
-            previousKeypressTimeMillis: null,
-            numGazeKeypresses: 3,
-            keySequence: ['b', 'a'],
-            text: 'ba',
-            cursorPos: 2,
-            isShiftOn: false,
-          });
+       () => {
+         enterKeysIntoComponent(['b', 'a'], 'ba');
+         ExternalEvents.setInternalReconStateForTest({
+           previousKeypressTimeMillis: null,
+           numGazeKeypresses: 3,
+           keySequence: ['b', 'a'],
+           text: 'ba',
+           cursorPos: 2,
+           isShiftOn: false,
+         });
 
-          spyOn(fixture.componentInstance, 'getWindowSelectionAnchorOffset')
-              .and.returnValue(anchorOffset);
-          const inputText = fixture.debugElement.query(By.css('.input-text'));
-          inputText.nativeElement.click();
-          fixture.detectChanges();
-          expect(inputText.nativeElement.innerText).toEqual(expectedText);
-        });
+         spyOn(fixture.componentInstance, 'getWindowSelectionAnchorOffset')
+             .and.returnValue(anchorOffset);
+         const inputText = fixture.debugElement.query(By.css('.input-text'));
+         inputText.nativeElement.click();
+         fixture.detectChanges();
+         expect(inputText.nativeElement.innerText).toEqual(expectedText);
+       });
   }
 
   it('clicking abort button clears state: no head keywords', () => {
@@ -1072,6 +1072,32 @@ describe('InputBarComponent', () => {
        expect(calls[0]).toEqual([65, 76, 76, 32, 71, 79, 79, 68, 190, 32]);
        expect(testListener.injectedTextCalls).toEqual(['all good. ']);
      });
+
+  it('clicking inject button with previous non-empty works', () => {
+    textEntryEndSubject.next({
+      text: 'Previous phrase',
+      isFinal: true,
+      timestampMillis: Date.now(),
+    });
+    fixture.componentInstance.inputString = '';
+    fixture.detectChanges();
+    const injectButton = fixture.debugElement.query(By.css('.inject-button'));
+    injectButton.nativeElement.click();
+
+    expect(textEntryEndEvents.length).toEqual(2);
+    const event = textEntryEndEvents[1];
+    expect(event.isFinal).toBeTrue();
+    expect(event.text).toEqual('Previous phrase. ');
+  });
+
+  it('clicking inject button without previous non-empty has no effect', () => {
+    fixture.componentInstance.inputString = '';
+    fixture.detectChanges();
+    const injectButton = fixture.debugElement.query(By.css('.inject-button'));
+    injectButton.nativeElement.click();
+
+    expect(textEntryEndEvents.length).toEqual(0);
+  });
 
   it('clicking inject text button injects keypresses without added final period',
      () => {

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -140,6 +140,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   private latestReconstructedString = '';
   private baseReconstructedText: string = '';
   private cutText = '';
+  private lastNonEmptyPhrase: string|null = null;
 
   private textEntryEndSubjectSubscription?: Subscription;
   private inputBarChipsSubscription?: Subscription;
@@ -164,6 +165,10 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
             this.resetState();
           } else {
             this.updateInputString(textInjection.text);
+          }
+          if (textInjection.isFinal && !textInjection.repeatLastNonEmpty &&
+              !textInjection.isAborted && textInjection.text.trim()) {
+            this.lastNonEmptyPhrase = textInjection.text.trim();
           }
         });
     ExternalEventsComponent.registerIgnoreKeySequence(
@@ -676,7 +681,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onInjectButtonClicked(event?: Event) {
-    let text = this.effectivePhrase;
+    let text = this.effectivePhrase || this.lastNonEmptyPhrase;
     if (!text) {
       return;
     }

--- a/webui/src/app/text-to-speech/text-to-speech.component.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.ts
@@ -3,7 +3,7 @@ import {HttpErrorResponse} from '@angular/common/http';
 import {ChangeDetectorRef, Component, ElementRef, Input, OnInit, QueryList, ViewChildren} from '@angular/core';
 import {Subject} from 'rxjs';
 
-import {AppSettings, getAppSettings, setGenericTtsVoiceName} from '../settings/settings';
+import {AppSettings, getAppSettings} from '../settings/settings';
 import {TextToSpeechErrorResponse, TextToSpeechService} from '../text-to-speech-service';
 import {setUtteranceVoice} from '../tts-voice-selection/tts-voice-selection.component';
 import {TextEntryEndEvent} from '../types/text-entry';


### PR DESCRIPTION
Previously, the "repeat last non-empty" feature worked only for the Speak button. This PR makes it work for the Inject and Add-to-favorite buttons as well.

Fixes #307