### PR TITLE
[WebUI] Support toggling eye gaze button state

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -143,6 +143,8 @@ interface BoundObject {
 
   async function bringFocusAppToForeground();
 
+  async function toggleGazeButtonsState(): boolean;
+
   async function setEyeGazeOptions(
       showGazeTracker: boolean, gazeFuzzyRadius: number, dwellDelayMillis: number);
 
@@ -207,6 +209,10 @@ Calling `updateButtonBoxes()` n times with n different `componentName`s will
 cause n sets of clickable regions to be registered.
 
 ### 3.5. Setting eye-gaze tracking options in host app
+
+The `toggleGazeButtonsState()` interface method allows the WebUI to temporarily
+pause the gaze buttons and subsequently resume them. The boolean return value
+indicates the new enabled state after the function call.
 
 The `setEyeGazeOptions()` interface method allows the WebUI to request
 changes in the host app's eye tracking parameters. The settable parameters

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -250,6 +250,7 @@ app-text-to-speech-component {
             [loadPrefixedLexiconRequestSubject]="loadPrefixedLexiconRequestSubject"
             [abbreviationExpansionTriggers]="abbreviationExpansionTriggers"
             [fillMaskTriggers]="fillMaskTriggers"
+            [notification]="inputBarNotification"
             [isFocused]="isFocused"
             (inputStringChanged)="onInputStringChanged($event)"
         ></app-input-bar-component>

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -7,6 +7,7 @@ import * as cefSharp from '../utils/cefsharp';
 import {AppComponent} from './app.component';
 import {AuthModule} from './auth/auth.module';
 import {HttpEventLogger} from './event-logger/event-logger-impl';
+import {ExternalEventsComponent} from './external/external-events.component';
 import {ExternalEventsModule} from './external/external-events.module';
 import {MetricsModule} from './metrics/metrics.module';
 import {MiniBarModule} from './mini-bar/mini-bar.module';
@@ -290,5 +291,9 @@ describe('AppComponent', () => {
     fixture.componentInstance.onHelpButtonClicked(null as any);
 
     expect(fixture.componentInstance.appState).toEqual(AppState.HELP);
+  });
+
+  it('notification for input bar is initially undefined', () => {
+    expect(fixture.componentInstance.inputBarNotification).toBeUndefined();
   });
 });

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -838,4 +838,5 @@ describe('ExternalEventsComponent', () => {
     expect(ExternalEventsComponent.getEyeTrackingPausedMessage())
         .toEqual('⏸︎ Eye tracking is paused. To re-enable it, use Ctrl+p.');
   });
+
 });

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -42,6 +42,7 @@ describe('ExternalEventsComponent', () => {
 
   afterEach(async () => {
     ExternalEventsComponent.clearToggleForegroundCallback();
+    ExternalEventsComponent.clearToggleEyeTrackingCallback();
   });
 
   it('Virtual key codes map has no duplicate values', () => {
@@ -391,23 +392,23 @@ describe('ExternalEventsComponent', () => {
   for (const [cursorPos, expectedText] of [[2, ' w1'], [3, 'w1']] as
        Array<[number, string]>) {
     it(`Word backspace after cursor placement works: cursor pos=${cursorPos}`,
-        () => {
-          // hi w1.
-          const isExternal = false;
-          const vkCodes = [72, 73, 32, 87, 49];
-          for (const vkCode of vkCodes) {
-            ExternalEventsComponent.externalKeypressHook(vkCode, isExternal);
-          }
-          ExternalEventsComponent.placeCursor(cursorPos, isExternal);
-          // LCTRL + LSHIFT + LARROW + BACKSPACE.
-          const vkCodesWordBack = [162, 160, 37, 8];
-          for (const vkCode of vkCodesWordBack) {
-            ExternalEventsComponent.externalKeypressHook(vkCode, isExternal);
-          }
+       () => {
+         // hi w1.
+         const isExternal = false;
+         const vkCodes = [72, 73, 32, 87, 49];
+         for (const vkCode of vkCodes) {
+           ExternalEventsComponent.externalKeypressHook(vkCode, isExternal);
+         }
+         ExternalEventsComponent.placeCursor(cursorPos, isExternal);
+         // LCTRL + LSHIFT + LARROW + BACKSPACE.
+         const vkCodesWordBack = [162, 160, 37, 8];
+         for (const vkCode of vkCodesWordBack) {
+           ExternalEventsComponent.externalKeypressHook(vkCode, isExternal);
+         }
 
-          expect(ExternalEventsComponent.internalText).toEqual(expectedText);
-          expect(ExternalEventsComponent.internalCursorPos).toEqual(0);
-        });
+         expect(ExternalEventsComponent.internalText).toEqual(expectedText);
+         expect(ExternalEventsComponent.internalCursorPos).toEqual(0);
+       });
   }
 
   it('LShift key enters upper case letter', () => {
@@ -821,4 +822,20 @@ describe('ExternalEventsComponent', () => {
 
        expect(callFlags).toEqual([]);
      });
+
+  it('registered eye-gaze toggling callback is called from external', () => {
+    let callCount = 0;
+    ExternalEventsComponent.registerToggleEyeTrackingCallback(() => {
+      callCount++;
+    });
+    ExternalEventsComponent.externalKeypressHook(162, /* isExternal= */ false);
+    ExternalEventsComponent.externalKeypressHook(80, /* isExternal= */ false);
+
+    expect(callCount).toEqual(1);
+  });
+
+  it('returns correct eye-tracking paused message', () => {
+    expect(ExternalEventsComponent.getEyeTrackingPausedMessage())
+        .toEqual('⏸︎ Eye tracking is paused. To re-enable it, use Ctrl+p.');
+  });
 });

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -147,6 +147,11 @@ export const LCTRL_KEY_HEAD_FOR_FOREGROUND_TRIGGER = 'g';
 export const BRING_TO_FOREGROUND_COMBO_KEY: string[] =
     [VIRTUAL_KEY.LCTRL, LCTRL_KEY_HEAD_FOR_FOREGROUND_TRIGGER];
 
+// Ctrl + P pauses/resumes the eye tracking.
+export const LCTRL_KEY_HEAD_FOR_EYE_TRACKING_TOGGLE = 'p';
+export const EYE_TRACKING_TOGGLE_COMBO_KEY: string[] =
+    [VIRTUAL_KEY.LCTRL, LCTRL_KEY_HEAD_FOR_EYE_TRACKING_TOGGLE];
+
 function getKeyFromVirtualKeyCode(vkCode: number): string|null {
   if (vkCode >= 48 && vkCode <= 58) {
     return String.fromCharCode(vkCode);
@@ -447,6 +452,7 @@ export class ExternalEventsComponent implements OnInit {
 
   private static readonly keypressListeners: KeypressListener[] = [];
   private static toggleForegroundCallback?: (toForeground: boolean) => void;
+  private static toggleEyeTrackingCallback?: () => void;
 
   ExternalEvewntsComponent() {}
 
@@ -492,7 +498,6 @@ export class ExternalEventsComponent implements OnInit {
    * responsible for calling the binding method `bringWindowToForeground()`.
    * @param callback
    */
-
   public static registerToggleForegroundCallback(
       callback: (toForeground: boolean) => void) {
     ExternalEventsComponent.toggleForegroundCallback = callback;
@@ -502,6 +507,25 @@ export class ExternalEventsComponent implements OnInit {
     if (ExternalEventsComponent.toggleForegroundCallback) {
       ExternalEventsComponent.toggleForegroundCallback = undefined;
     }
+  }
+
+  // TODO(cais): Add doc string and unit tests.
+  /**
+   * Register a callback for when the shortcut key for toggling eye gaze (gaze
+   * buttons' enabled state) is pressed.
+   * @param callback
+   */
+  public static registerToggleEyeTrackingCallback(callback: () => void) {
+    ExternalEventsComponent.toggleEyeTrackingCallback = callback;
+  }
+
+  public static clearToggleEyeTrackingCallback() {
+    ExternalEventsComponent.toggleEyeTrackingCallback = undefined;
+  }
+
+  public static getEyeTrackingPausedMessage(): string {
+    return `⏸︎ Eye tracking is paused. To re-enable it, use Ctrl+${
+        LCTRL_KEY_HEAD_FOR_EYE_TRACKING_TOGGLE}.`;
   }
 
   /**
@@ -583,6 +607,12 @@ export class ExternalEventsComponent implements OnInit {
       if (ExternalEventsComponent.toggleForegroundCallback) {
         ExternalEventsComponent.toggleForegroundCallback(
             /* toForeground= */ isExternal);
+      }
+      return;
+    } else if (keySequenceEndsWith(
+                   reconState.keySequence, EYE_TRACKING_TOGGLE_COMBO_KEY)) {
+      if (ExternalEventsComponent.toggleEyeTrackingCallback) {
+        ExternalEventsComponent.toggleEyeTrackingCallback();
       }
       return;
     } else if (

--- a/webui/src/app/help/help.component.html
+++ b/webui/src/app/help/help.component.html
@@ -25,12 +25,6 @@ h3 {
   padding: 0 4px;
 }
 
-.abbreviation-rules {
-  font-size: 18px;
-  color: #ccc;
-  margin: 0 8px;
-}
-
 .container {
   display: flex;
   flex-direction: row;
@@ -52,12 +46,26 @@ h3 {
   padding: 0 4px;
 }
 
+ul {
+  font-size: 18px;
+  color: #ccc;
+  margin: 0 8px;
+}
+
 </style>
 
 <div class="container">
   <div
      #scrollTarget
      class="help-container">
+    <h3>
+      How to pause and resume gaze tracking
+    </h3>
+
+    <ul>
+      <li>Use the combo key <b>Ctrl + p</b></li>
+    </ul>
+
     <h3>
       How to abbreviate a phrase
     </h3>

--- a/webui/src/app/help/help.component.spec.ts
+++ b/webui/src/app/help/help.component.spec.ts
@@ -23,6 +23,6 @@ describe('HelpComponent', () => {
   it('shows correct abbreviation length limit', async () => {
     const listItems = fixture.debugElement.queryAll(By.css('li'));
 
-    expect(listItems[0].nativeElement.innerText).toEqual('Maximum allowed length of abbreviation: 12 characters')
+    expect(listItems[1].nativeElement.innerText).toEqual('Maximum allowed length of abbreviation: 12 characters')
   });
 });

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -153,6 +153,18 @@
   flex: 1;
 }
 
+.notification {
+  align-items: center;
+  color: yellow;
+  display: flex;
+  flex-direction: row;
+  font-size: 24px;
+  margin-top: 2px;
+  overflow: visible;
+  padding-left: 20px;
+  width: 1000px;
+}
+
 .right-buttons-container {
   align-items: center;
   display: flex;
@@ -328,6 +340,12 @@
       {{studyDialogError}}
     </div>
     <div *ngIf="!studyDialogError">Dialog is complete.</div>
+  </div>
+
+  <div
+      *ngIf="hasNotification"
+      class="notification">
+    {{notification}}
   </div>
 
 </div>

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1485,7 +1485,7 @@ describe('InputBarComponent', () => {
     expect(fixture.debugElement.query(By.css('.to-enter-text'))).toBeNull();
   });
 
-  it('copmleted state in study turn subject displays end state', () => {
+  it('completed state in study turn subject displays end state', () => {
     studyUserTurnsSubject.next({
       text: null,
       isAbbreviation: true,
@@ -1516,6 +1516,25 @@ describe('InputBarComponent', () => {
     expect(fixture.debugElement.query(By.css('.dialog-error'))
                .nativeElement.innerText)
         .toEqual('Failed to load dialog "foo"');
+  });
+
+  it('displays notification when set to non-empty', () => {
+    fixture.componentInstance.notification = 'testing foo.';
+    fixture.detectChanges();
+
+    const notification = fixture.debugElement.query(By.css('.notification'));
+    expect(notification.nativeElement.innerText).toEqual('testing foo.');
+  });
+
+  it('shows no notification if text is empty', () => {
+    fixture.componentInstance.notification = '';
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.notification'))).toBeNull();
+  });
+
+  it('shows no notification by default', () => {
+    expect(fixture.debugElement.query(By.css('.notification'))).toBeNull();
   });
 
   // TODO(cais): Test spelling valid word triggers AE, with debounce.

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -119,6 +119,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() inputBarControlSubject!: Subject<InputBarControlEvent>;
   @Input() loadPrefixedLexiconRequestSubject!: Subject<LoadLexiconRequest>;
   @Input() isFocused: boolean = true;
+  @Input() notification?: string;
   @Output() inputStringChanged: EventEmitter<string> = new EventEmitter();
 
   private _studyUserTurnInstr: string|null = null;
@@ -665,6 +666,11 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
         this._chips[0].isTextPrediction === true &&
         (this.latestReconstructedString.length ===
          this.baseReconstructedText.length);
+  }
+
+  get hasNotification(): boolean {
+    return this.notification !== undefined &&
+        this.notification.length > 0;
   }
 
   onSpeakAsIsButtonClicked(event?: Event) {

--- a/webui/src/app/keyboard/keyboard.component.ts
+++ b/webui/src/app/keyboard/keyboard.component.ts
@@ -6,9 +6,6 @@ import {getVirtualkeyCode} from '../external/external-events.component';
 // The return value indicates whether the event has been handled.
 export type KeyboardCallback = (event: KeyboardEvent) => boolean;
 
-const callbackStack: Array<{callbackName: string, callback: KeyboardCallback}> =
-    [];
-
 @Component({
   selector: 'app-keyboard-component',
   templateUrl: './keyboard.component.html',
@@ -31,6 +28,7 @@ export class KeyboardComponent {
         // ensure correct reconstruction of the text from keypresses.
         const vkCode: number = vkCodes[vkCodes.length - 1];
         (window as any).externalKeypressHook(vkCode, /* isExternal= */ false);
+        event.preventDefault();  // TODO(cais): Confirm! DO NOT SUBMIT.
       } catch (error) {
       }
     }

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -93,12 +93,28 @@ export async function bringFocusAppToForeground() {
   ((window as any)[BOUND_LISTENER_NAME] as any).bringFocusAppToForeground();
 }
 
+
+/**
+ * Toggle the enabled/disabled state of gaze buttons.
+ * @returns The new enabled state after toggling.
+ */
+export async function toggleGazeButtonsState(): Promise<boolean> {
+  if ((window as any)[BOUND_LISTENER_NAME] == null) {
+    console.warn(`Cannot call toggleGazeButtonsState(), because object ${
+        BOUND_LISTENER_NAME} is not found`)
+    return true;
+  }
+  return ((window as any)[BOUND_LISTENER_NAME] as any)
+             .toggleGazeButtonsState() as boolean;
+}
+
 /**
  * Updates the host app regarding eye tracking options.
  * @param showGazeTracker Whether the dot that tracks the gaze point is
  *     shown.
  * @param gazeFuzzyRadius The radius for the fuzzy gaze pointer (e.g, 20).
- * @param dwellDelayMillis The dwell delay for gaze clicking, in milliseconds.
+ * @param dwellDelayMillis The dwell delay for gaze clicking, in
+ *     milliseconds.
  */
 export function setEyeGazeOptions(
     showGazeTracker: boolean, gazeFuzzyRadius: number,

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -104,7 +104,7 @@ export async function toggleGazeButtonsState(): Promise<boolean> {
         BOUND_LISTENER_NAME} is not found`)
     return true;
   }
-  return ((window as any)[BOUND_LISTENER_NAME] as any)
+  return await ((window as any)[BOUND_LISTENER_NAME] as any)
              .toggleGazeButtonsState() as boolean;
 }
 


### PR DESCRIPTION
- When gaze buttons are paused, show status message under the input bar
- Update README.md to document the new cefsharp interface method: `toggleGazeButtonsState()`
- Add info about the `Ctrl + p` toggle combo key to the help component

Fixes #309.