### PR TITLE
[WebUI] Fix state resetting in input bar; relax external sentence-end sequence

### DIFF
--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -274,7 +274,7 @@ describe('ExternalEventsComponent', () => {
           'hi:/'
         ],
         ['repeating LCtrl key', [72, 73, 162, 162, END_KEY_CODE], 'hi'],
-        ['with new lines', [72, 73, 188, 13, 87, 162, END_KEY_CODE], 'hi,\nw'],
+        ['with new lines', [72, 73, 188, 13, 87, 162, END_KEY_CODE], 'hi, w'],
         ['with backspace', [72, 73, 8, 72, 162, END_KEY_CODE], 'hh'],
         [
           'with left arrow and inserted char',
@@ -297,11 +297,11 @@ describe('ExternalEventsComponent', () => {
         ],
         [
           'new line and home key',
-          [72, 73, 188, 13, 87, 36, 65, 162, END_KEY_CODE], 'hi,\naw'
+          [72, 73, 188, 13, 87, 36, 65, 162, END_KEY_CODE], 'hi, aw'
         ],
         [
           'new line, home and end key',
-          [72, 73, 188, 13, 87, 36, 35, 65, 162, END_KEY_CODE], 'hi,\nwa'
+          [72, 73, 188, 13, 87, 36, 35, 65, 162, END_KEY_CODE], 'hi, wa'
         ],
         ['with noop home key', [36, 72, 73, 162, END_KEY_CODE], 'hi'],
         ['with noop end key', [72, 73, 35, 162, END_KEY_CODE], 'hi'],
@@ -480,9 +480,10 @@ describe('ExternalEventsComponent', () => {
   });
 
   it('reconstructs text based on sentence-end period and space', () => {
-    const vkCodes = [72, 73, 190, 32];
+    const vkCodes = [72, 73, 190];  // h, i, period.
     for (const vkCode of vkCodes) {
-      ExternalEventsComponent.externalKeypressHook(vkCode);
+      ExternalEventsComponent.externalKeypressHook(
+          vkCode, /* isExternal= */ true);
     }
     expect(beginEvents.length).toEqual(1);
     expect(endEvents.length).toEqual(1);
@@ -491,9 +492,10 @@ describe('ExternalEventsComponent', () => {
   });
 
   it('reconstructs text based on sentence-end question mark and space', () => {
-    const vkCodes = [72, 73, 160, 191, 32];
+    const vkCodes = [72, 73, 160, 191];  // h, i, question mark.
     for (const vkCode of vkCodes) {
-      ExternalEventsComponent.externalKeypressHook(vkCode);
+      ExternalEventsComponent.externalKeypressHook(
+          vkCode, /* isExternal= */ true);
     }
     expect(beginEvents.length).toEqual(1);
     expect(endEvents.length).toEqual(1);
@@ -503,14 +505,27 @@ describe('ExternalEventsComponent', () => {
 
   it('reconstructs text based on sentence-end exclamation point and space',
      () => {
-       const vkCodes = [72, 73, 160, 49, 32];
+       const vkCodes = [72, 73, 160, 49];  // h, i, exclamation point.
        for (const vkCode of vkCodes) {
-         ExternalEventsComponent.externalKeypressHook(vkCode);
+         ExternalEventsComponent.externalKeypressHook(
+             vkCode, /* isExternal= */ true);
        }
        expect(beginEvents.length).toEqual(1);
        expect(endEvents.length).toEqual(1);
        expect(endEvents[0].text).toEqual('hi!');
        expect(endEvents[0].isFinal).toBeTrue();
+     });
+
+  it('whitspace followed by sentence-end sequence triggers no end event',
+     () => {
+       const vkCodes = [32, 32, 190];  // Space, space, period.
+       for (const vkCode of vkCodes) {
+         ExternalEventsComponent.externalKeypressHook(
+             vkCode, /* isExternal= */ true);
+       }
+
+       expect(beginEvents.length).toEqual(1);
+       expect(endEvents.length).toEqual(0);
      });
 
   it('whitespace-only text does not trigger end event', () => {
@@ -838,5 +853,4 @@ describe('ExternalEventsComponent', () => {
     expect(ExternalEventsComponent.getEyeTrackingPausedMessage())
         .toEqual('⏸︎ Eye tracking is paused. To re-enable it, use Ctrl+p.');
   });
-
 });

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1537,5 +1537,16 @@ describe('InputBarComponent', () => {
     expect(fixture.debugElement.query(By.css('.notification'))).toBeNull();
   });
 
+  fit('clears all state on clearAll command in control subject', () => {
+    const keySequence = ['a', 'b', 'c'];
+    const reconstructedText = keySequence.join('');
+    enterKeysIntoComponent(keySequence, reconstructedText);
+    inputBarControlSubject.next({
+      clearAll: true,
+    });
+
+    expect(fixture.componentInstance.inputString).toEqual('');
+  });
+
   // TODO(cais): Test spelling valid word triggers AE, with debounce.
 });

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1537,7 +1537,7 @@ describe('InputBarComponent', () => {
     expect(fixture.debugElement.query(By.css('.notification'))).toBeNull();
   });
 
-  fit('clears all state on clearAll command in control subject', () => {
+  it('clears all state on clearAll command in control subject', () => {
     const keySequence = ['a', 'b', 'c'];
     const reconstructedText = keySequence.join('');
     enterKeysIntoComponent(keySequence, reconstructedText);

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -3,7 +3,7 @@ import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, I
 import {Subject, Subscription} from 'rxjs';
 import {debounceTime} from 'rxjs/operators';
 import {injectKeys, requestSoftKeyboardReset, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
-import {endsWithSentenceEndPunctuation, isAlphanumericChar, keySequenceEndsWith} from 'src/utils/text-utils';
+import {endsWithSentenceEndPunctuation, isAlphanumericChar, keySequenceEndsWith, removePunctuation} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
 import {getPhraseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
@@ -60,10 +60,6 @@ export interface InputBarControlEvent {
 
   // `true` means hide the input bar. `false` means unhide (show) the input bar.
   hide?: boolean;
-}
-
-function removePunctuation(str: string) {
-  return str.replace(/[\.\!\?]/g, '');
 }
 
 // Abbreviation expansion can be triggered by entering any of the the
@@ -669,8 +665,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get hasNotification(): boolean {
-    return this.notification !== undefined &&
-        this.notification.length > 0;
+    return this.notification !== undefined && this.notification.length > 0;
   }
 
   onSpeakAsIsButtonClicked(event?: Event) {

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -181,7 +181,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
             this._isHidden = event.hide;
           } else if (event.clearAll) {
             this.baseReconstructedText = this.latestReconstructedString;
-            this.resetState(/* cleanText= */ true, /* resetBase= */ false);
+            this.resetState(/* cleanText= */ true, /* resetBase= */ true);
           } else if (event.appendText !== undefined) {
             ExternalEventsComponent.appendString(
                 event.appendText, /* isExternal= */ false);

--- a/webui/src/utils/text-utils.ts
+++ b/webui/src/utils/text-utils.ts
@@ -77,3 +77,8 @@ export function trimStringAtHead(str: string, maxLength: number): string {
   }
   return trimmed.trim();
 }
+
+/** Remove punctuation characters from a string. */
+export function removePunctuation(str: string): string {
+  return str.replace(/[\.\!\?]/g, '');
+}


### PR DESCRIPTION
- Previously, switching between different tabs may persist some state in the `InputBarComponent` in a confusing way. This PR makes the state resetting more thorough and less surprising.
- Relax the sequence of key codes for detecting sentence end in external app (e.g., Balabolka). The previous period-space sequence is simplified to a single period.

Fixes #278 