### PR TITLE
[WebUI] Support unscripted dialogs for study

### DIFF
--- a/webui/src/app/context/context.component.ts
+++ b/webui/src/app/context/context.component.ts
@@ -63,8 +63,6 @@ export class ContextComponent implements OnInit, OnDestroy, AfterViewInit {
         return;
       }
       if (this.studyManager.getDialogId() !== null) {
-        console.log(
-            '*** Calling incrementTurn() with ', textInjection.text);  // DEBUG
         this.studyManager.incrementTurn(textInjection.text);
         this.retrieveContext();
         return;
@@ -237,9 +235,6 @@ export class ContextComponent implements OnInit, OnDestroy, AfterViewInit {
                     resolve(speechContent);
                     return;
                   }
-                  console.log(
-                      '*** timestamp:', timestamp, speechContent);  // DEBUG
-                  console.log('*** minTimestamp:', minTimestamp);   // DEBUG
                 }
                 resolve(null);
               },
@@ -296,7 +291,6 @@ export class ContextComponent implements OnInit, OnDestroy, AfterViewInit {
                 return;
               }
               if (this.studyManager.waitingForPartnerTurnAfter !== null) {
-                console.log('*** B100');  // DEBUG
                 if (data.contextSignals == null ||
                     data.contextSignals.length === 0) {
                   return;
@@ -315,9 +309,9 @@ export class ContextComponent implements OnInit, OnDestroy, AfterViewInit {
                   if (timestamp >
                       this.studyManager.waitingForPartnerTurnAfter) {
                     console.log(
-                        '*** Got manual partner turn:', speechContent,
+                        '*** Received manual partner turn:', speechContent,
                         timestamp,
-                        this.studyManager.waitingForPartnerTurnAfter);  // DEBUG
+                        this.studyManager.waitingForPartnerTurnAfter);
                     this.studyManager.incrementTurn(speechContent);
                     // TODO(cais): Add unit test.
                     return;

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1083,7 +1083,7 @@ describe('InputBarComponent', () => {
        tick();
 
        let focused: DebugElement|null = null;
-       for (let i = 0; i < 4; ++i) {
+       for (let i = 0; i < 10; ++i) {
          focused = fixture.debugElement.query(By.css(':focus'));
          if (focused) {
            break;

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -926,6 +926,7 @@ describe('InputBarComponent', () => {
 
   it('study turn causes instruction and text to be shown', () => {
     studyUserTurnsSubject.next({
+      instruction: 'Enter in abbreviation:',
       text: 'All frequencies open',
       isAbbreviation: true,
       isComplete: false,
@@ -941,11 +942,13 @@ describe('InputBarComponent', () => {
 
   it('null text in study turn subject resets UI state', () => {
     studyUserTurnsSubject.next({
+      instruction: 'Enter in abbreviation:',
       text: 'All frequencies open',
       isAbbreviation: true,
       isComplete: false,
     });
     studyUserTurnsSubject.next({
+      instruction: '',
       text: null,
       isAbbreviation: true,
       isComplete: true,
@@ -958,6 +961,7 @@ describe('InputBarComponent', () => {
 
   it('completed state in study turn subject displays end state', () => {
     studyUserTurnsSubject.next({
+      instruction: '',
       text: null,
       isAbbreviation: true,
       isComplete: true,
@@ -973,6 +977,7 @@ describe('InputBarComponent', () => {
 
   it('error state in study turn subject displays error message', () => {
     studyUserTurnsSubject.next({
+      instruction: '',
       text: null,
       isAbbreviation: true,
       isComplete: true,

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -248,8 +248,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
             });
     this.studyUserTurnsSubscription =
         this.studyManager.studyUserTurns.subscribe(turn => {
-          this._studyUserTurnInstr =
-              turn.isAbbreviation ? 'Enter in abbreviation:' : 'Enter in full:';
+          this._studyUserTurnInstr = turn.instruction;
           this._studyUserTurnText = turn.text;
           this._studyDialogEnded = turn.isComplete;
           this._studyDialogError = turn.error;

--- a/webui/src/app/study/study-manager.spec.ts
+++ b/webui/src/app/study/study-manager.spec.ts
@@ -14,6 +14,10 @@ describe('Study Manager', () => {
       expect(isCommand('Start abbrev dummy1 '));
       expect(isCommand('Start abbrev dummy1 a'));
       expect(isCommand('Start abbrev dummy1 b'));
+      expect(isCommand('Start abbrev u1'));
+      expect(isCommand('Start abbrev u2 '));
+      expect(isCommand('Start abbrev u3 a'));
+      expect(isCommand('Start abbrev u3 b '));
       expect(isCommand(' Dialog stop'));
     });
 
@@ -215,6 +219,13 @@ describe('Study Manager', () => {
       studyManager.maybeHandleRemoteControlCommand('start abbrev u1')
           .then(() => {
             setTimeout(() => {
+              expect(studyUserTurns.length).toEqual(1);
+              expect(studyUserTurns[0].instruction)
+                  .toEqual('Enter your reply in abbreviation.');
+              expect(studyUserTurns[0].text).toEqual('');
+              expect(studyUserTurns[0].isComplete).toBeFalse();
+
+              expect(HttpEventLogger.isFullLogging()).toBeTrue();
               expect(studyManager.getDialogTurnIndex()).toEqual(1);
               expect(studyManager.waitingForPartnerTurnAfter).toBeNull();
 
@@ -230,7 +241,7 @@ describe('Study Manager', () => {
               expect(prevTurns![1].text).toEqual('I like the weather today');
               expect(prevTurns![1].partnerId).toBeNull();
               done();
-            }, 10);
+            }, 20);
           });
     });
 

--- a/webui/src/app/study/study-manager.ts
+++ b/webui/src/app/study/study-manager.ts
@@ -99,7 +99,7 @@ export class StudyManager {
   private turnIndex: number|null = null;
   private actualTurnTexts: {[turnIndex: number]: string} = {};
   private isFullyScripted: boolean = true;
-  // Waitingfor partner turns after the epoch millis timestamp.
+  // Waiting for partner turns after the epoch millis timestamp.
   private _waitingForPartnerTurnAfter: number|null = null;
 
   // A subject for the turns that the user should enter.
@@ -318,7 +318,7 @@ export class StudyManager {
   /**
    * Increments the turn index in the ongoing dialog (if any).
    * @param turnText: The actual entered turn text. Optional. If not provided,
-   *   will use the turns from the script.
+   *   will use the turn from the script.
    * @returns A object with the following fields:
    *   - turnIndex: The 0-based turn index after the turn increment.
    *   - isComplete: A boolean flag for whether the dialog is complete after the


### PR DESCRIPTION
- From the companion app, to start an unscripted dialog with an initial question, send e.g., `start abbrev u1`.
- Ensures that the displayed text is what's actually selected in the input box or via AE:
- Fixes the issue of attending to earlier commands after a command is handled. This bug happened when there were multiple commands in the context history window.

Fixes #323
