### PR TITLE
[WebUI] Fix bug in which inputStringChanged is not called

### DIFF
--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -39,6 +39,7 @@ describe('InputBarComponent', () => {
   let studyUserTurnsSubject: Subject<StudyUserTurn>;
   let fixture: ComponentFixture<InputBarComponent>;
   let speakFasterServiceForTest: SpeakFasterServiceForTest;
+  let inputStringChangedValues: string[];
   let textEntryEndEvents: TextEntryEndEvent[];
   let inputAbbreviationChangeEvents: InputAbbreviationChangedEvent[];
   let LoadLexiconRequests: LoadLexiconRequest[];
@@ -97,6 +98,10 @@ describe('InputBarComponent', () => {
         abbreviationExpansionTriggers;
     fixture.componentInstance.loadPrefixedLexiconRequestSubject =
         loadPrefixedLexiconRequestSubject;
+    inputStringChangedValues = [];
+    fixture.componentInstance.inputStringChanged.subscribe((str) => {
+      inputStringChangedValues.push(str);
+    });
     fixture.detectChanges();
   });
 
@@ -423,6 +428,14 @@ describe('InputBarComponent', () => {
          });
     }
   }
+
+  it('entering keys into text box issues inputStringChanged events', () => {
+    enterKeysIntoComponent('hi');
+
+    expect(inputStringChangedValues.length).toEqual(2);
+    expect(inputStringChangedValues[0]).toEqual('h');
+    expect(inputStringChangedValues[1]).toEqual('hi');
+  });
 
   it('clicking abort after clicking spell resets state', () => {
     enterKeysIntoComponent('abc');
@@ -901,6 +914,7 @@ describe('InputBarComponent', () => {
     expect(inputText.nativeElement.value).toEqual('foo bar');
     expect(fixture.componentInstance.inputString).toEqual('foo bar');
     expect(fixture.componentInstance.state).toEqual(State.ENTERING_BASE_TEXT);
+    expect(inputStringChangedValues).toEqual(['foo bar']);
   });
 
   it('onFavoritePhraseAdded with success issues text-entry end event', () => {
@@ -1090,8 +1104,7 @@ describe('InputBarComponent', () => {
            break;
          }
        }
-       const inputText =
-           fixture.debugElement.query(By.css('.base-text-area'));
+       const inputText = fixture.debugElement.query(By.css('.base-text-area'));
        expect(focused!.nativeElement).toEqual(inputText.nativeElement);
      }));
 

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -298,6 +298,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onInputTextAreaKeyUp(event: KeyboardEvent) {
     this.inputString = this.inputTextArea.nativeElement.value;
+    this.inputStringChanged.next(this.inputString);
     this.eventLogger.logKeypress(event as KeyboardEvent, this.inputString);
     this.scaleInputTextFontSize();
     if (ABBRVIATION_EXPANSION_TRIGGER_SUFFIX.some(
@@ -321,7 +322,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     const element = this.inputTextArea.nativeElement;
     const textLength = this.inputString.length;
-    const widthPx = Math.min(textLength * 22, 600);
+    const widthPx = Math.min(textLength * 27, 600);
     element.style.width = `${widthPx}px`;
     let i = INPUT_TEXT_FONT_SIZE_SCALING_LENGTH_TICKS.length - 1;
     for (; i >= 0; --i) {


### PR DESCRIPTION
a regression after the recent major refactoring.

Also in this PR: Increase multiplier for the width of the `base-text-area` in `InputBarComponent`.

Fixes #327