### PR TITLE
[WebUI] Study improvements

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -427,7 +427,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
     let totalKeywordCount = 0;
     for (const token of abbreviationSpec.tokens) {
       if (token.isKeyword) {
-        totalKeywordCount
+        totalKeywordCount++;
       } else {
         totalAbbrevLength += token.value.length;
       }

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -5,6 +5,7 @@ import {createUuid} from 'src/utils/uuid';
 
 import {injectKeys, injectTextAsKeys, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from '../../utils/cefsharp';
 import {RefinementResult, RefinementType} from '../abbreviation-refinement/abbreviation-refinement.component';
+import {ContextComponent} from '../context/context.component';
 import {getAbbreviationExpansionRequestStats, getAbbreviationExpansionResponseStats, getPhraseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
 import {VIRTUAL_KEY} from '../external/external-events.component';
 import {InputBarControlEvent} from '../input-bar/input-bar.component';
@@ -397,7 +398,9 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
 
   get usedContextStrings(): string[] {
     // TODO(#49): Limit by token length? Increase length.
-    const LIMIT_TURNS = 2;
+    const LIMIT_TURNS = this.isStudyOn ?
+        ContextComponent.MAX_USED_CONTEXT_COUNT_DURING_STUDY :
+        2;
     const LIMIT_CONTEXT_TURN_LENGTH = 60;
     const strings = [...this.conversationTurns.map(
         turn =>

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -422,13 +422,17 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
     if (abbreviationSpec === null) {
       return 128;
     }
-    let maxAbbrevLength = 0;
+    // Total length of the abbreviation part plus the number of
+    let totalAbbrevLength = 0;
+    let totalKeywordCount = 0;
     for (const token of abbreviationSpec.tokens) {
-      if (!token.isKeyword && token.value.length > maxAbbrevLength) {
-        maxAbbrevLength = token.value.length;
+      if (token.isKeyword) {
+        totalKeywordCount
+      } else {
+        totalAbbrevLength += token.value.length;
       }
     }
-    return maxAbbrevLength > 5 ? 256 : 128;
+    return totalAbbrevLength + totalKeywordCount > 5 ? 256 : 128;
   }
 
   get refinementType(): RefinementType {

--- a/webui/src/app/context/context.component.spec.ts
+++ b/webui/src/app/context/context.component.spec.ts
@@ -160,7 +160,6 @@ describe('ContextComponent', () => {
           expect(emittedSelectedTurns[0].length).toEqual(numContextTurns);
           expect(emittedSelectedTurns[0].map(turn => turn.speechContent))
               .toEqual(expectedContextTurns);
-          (studyManager as any).reset();
         });
   }
 });

--- a/webui/src/app/context/context.component.ts
+++ b/webui/src/app/context/context.component.ts
@@ -287,7 +287,6 @@ export class ContextComponent implements OnInit, OnDestroy, AfterViewInit {
             error => {
               this.cleanUpContextSignals();
               this.contextRetrievalError = 'Context retrieval error';
-              // this.populateConversationTurnWithDefault();
             });
   }
 

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -239,7 +239,7 @@
             *ngFor="let chip of chips; let i = index"
             [text]="getChipText(i)"
             [typed]="i === focusChipIndex && isChipTyped(i)"
-            [supportsCut]="state === 'FOCUSED_ON_WORD_CHIP' && i !== chips.length - 1"
+            [supportsCut]="!isStudyOn && (state === 'FOCUSED_ON_WORD_CHIP' && i !== chips.length - 1)"
             [focused]="i === focusChipIndex"
             (click)="onChipClicked(i)"
             (cutClicked)="onChipCutClicked($event, i)"

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -11,7 +11,7 @@ import {InputBarChipComponent} from '../input-bar-chip/input-bar-chip.component'
 import {InputBarChipModule} from '../input-bar-chip/input-bar-chip.module';
 import {LoadLexiconRequest} from '../lexicon/lexicon.component';
 import {FillMaskRequest, SpeakFasterService} from '../speakfaster-service';
-import {StudyManager, StudyUserTurn} from '../study/study-manager';
+import {setDelaysForTesting, StudyManager, StudyUserTurn} from '../study/study-manager';
 import {TestListener} from '../test-utils/test-cefsharp-listener';
 import {InputAbbreviationChangedEvent} from '../types/abbreviation';
 import {AddContextualPhraseRequest, AddContextualPhraseResponse} from '../types/contextual_phrase';
@@ -46,6 +46,7 @@ describe('InputBarComponent', () => {
   let fillMaskRequests: FillMaskRequest[];
 
   beforeEach(async () => {
+    setDelaysForTesting(10e3, 50e3);
     testListener = new TestListener();
     (window as any)[cefSharp.BOUND_LISTENER_NAME] = testListener;
     textEntryEndSubject = new Subject();

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1136,5 +1136,27 @@ describe('InputBarComponent', () => {
         .not.toBeNull();
   });
 
+  it('when study is on, does not show cut-button', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    inputBarControlSubject.next({
+      chips: [
+        {
+          text: 'it',
+        },
+        {
+          text: 'does',
+        },
+      ]
+    });
+    fixture.componentInstance.state = State.CHOOSING_WORD_CHIP;
+    fixture.detectChanges();
+    const chips =
+        fixture.debugElement.queryAll(By.css('app-input-bar-chip-component'));
+    chips[1].nativeElement.click();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.cut-button'))).toBeNull();
+  });
+
   // TODO(cais): Test spelling valid word triggers AE, with debounce.
 });


### PR DESCRIPTION
1. Disable the cut-button for word chips (the "scissor button") when
   study is on.
2. Fixes #320. Support up to five context turns during study, even though only the latest three are displayed.