### PR TITLE
[WebUI] Further improvements for study mode

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -303,7 +303,7 @@ mat-progress-spinner {
 </div>
 
 <div
-    *ngIf="!isStudyDialogOngoing &&
+    *ngIf="!isStudyOn &&
            (state === 'PRE_CHOOSING_EXPANSION' ||
             state === 'POST_CHOOSING_EXPANSION')">
   <button

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -355,8 +355,4 @@ describe('AbbreviationComponent', () => {
         .toBeNull();
   });
 
-  it('does not show quick phrase when study is on',
-     () => {
-
-     });
 });

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -340,4 +340,23 @@ describe('AbbreviationComponent', () => {
 
     expect(fixture.componentInstance.isStudyOn).toBeFalse();
   });
+
+  it('does not show text prediction or quick phrases when study is on', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.componentInstance.textPredictions.splice(0)
+    fixture.componentInstance.textPredictions.push('foo');
+    fixture.componentInstance.textPredictions.push('bar');
+    fixture.detectChanges();
+    const textPredictionButtons =
+        fixture.debugElement.queryAll(By.css('.text-prediction-button'));
+
+    expect(textPredictionButtons.length).toEqual(0);
+    expect(fixture.debugElement.query(By.css('app-quick-phrases-component')))
+        .toBeNull();
+  });
+
+  it('does not show quick phrase when study is on',
+     () => {
+
+     });
 });

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -19,10 +19,6 @@ app-context-component {
   height: 84px;
 }
 
-app-context-component.study-mode {
-  height: 64px;
-}
-
 app-text-to-speech-component {
   float: right;
 }
@@ -67,7 +63,8 @@ app-text-to-speech-component {
   display: none;
 }
 
-/* During study, make the main-area tall, so it is possible to go into the full-screen mode on mobile devices. */
+/* During study, make the main-area larger, so it is possible to */
+/* go into the full-screen mode on mobile devices. */
 .main-area.study-mode {
   width: 1800px;
   height: 1200px;
@@ -89,10 +86,6 @@ app-text-to-speech-component {
   display: flex;
   flex-direction: column;
   height: fit-content;
-}
-
-.main-right-pane.study-mode {
-  width: 1800px;
 }
 
 .mode-abbreviation-expansion {
@@ -194,9 +187,9 @@ app-text-to-speech-component {
       </div>
     </div>
 
-    <div class="main-right-pane" [ngClass]="{'study-mode': isStudyOn}">
+    <div class="main-right-pane">
       <app-context-component
-        [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION', 'study-mode': isStudyOn}"
+        [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION'}"
         [userId]="userId"
         [textEntryEndSubject]="textEntryEndSubject"
         [isDev]="isDev"

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -19,6 +19,10 @@ app-context-component {
   height: 84px;
 }
 
+app-context-component.study-mode {
+  height: 64px;
+}
+
 app-text-to-speech-component {
   float: right;
 }
@@ -31,9 +35,6 @@ app-text-to-speech-component {
   border: 2px solid yellow;
   border-radius: 7px;
   padding: 10px;
-}
-
-.bottom-area {
 }
 
 .button-image {
@@ -66,8 +67,15 @@ app-text-to-speech-component {
   display: none;
 }
 
+/* During study, make the main-area tall, so it is possible to go into the full-screen mode on mobile devices. */
+.main-area.study-mode {
+  width: 1800px;
+  height: 1200px;
+  border-right: 1px solid white;
+}
+
 .main-left-pane {
-  align-items:flex-end;
+  align-items:flex-start;
   box-sizing: border-box;
   display: flex;
   min-height: 100%;
@@ -81,6 +89,10 @@ app-text-to-speech-component {
   display: flex;
   flex-direction: column;
   height: fit-content;
+}
+
+.main-right-pane.study-mode {
+  width: 1800px;
 }
 
 .mode-abbreviation-expansion {
@@ -152,7 +164,7 @@ app-text-to-speech-component {
   <div
       class="main-area"
       *ngIf="hasAccessToken()"
-      [ngClass]="{'main-area-hidden': appState === 'MINIBAR'}">
+      [ngClass]="{'main-area-hidden': appState === 'MINIBAR', 'study-mode': isStudyOn}">
     <div class="main-left-pane">
       <div class="side-pane-button-container">
         <button
@@ -182,9 +194,9 @@ app-text-to-speech-component {
       </div>
     </div>
 
-    <div class="main-right-pane">
+    <div class="main-right-pane" [ngClass]="{'study-mode': isStudyOn}">
       <app-context-component
-        [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION'}"
+        [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION', 'study-mode': isStudyOn}"
         [userId]="userId"
         [textEntryEndSubject]="textEntryEndSubject"
         [isDev]="isDev"

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -236,7 +236,8 @@ describe('AppComponent', () => {
 
     const mainArea = fixture.debugElement.query(By.css('.main-area'));
     expect(mainArea).not.toBeNull();
-    expect(mainArea.classes['main-area-hidden']).toEqual(true);
+    expect(mainArea.classes['main-area-hidden']).toBeTrue();
+    expect(mainArea.classes['study-mode']).toBeUndefined();
     expect(mainArea.query(By.css('app-input-bar-component'))).not.toBeNull();
     expect(mainArea.query(By.css('app-abbreviation-component'))).not.toBeNull();
     expect(mainArea.query(By.css('app-context-component'))).not.toBeNull();
@@ -321,11 +322,28 @@ describe('AppComponent', () => {
     ]);
   });
 
-  it('nonMinimizedStatesAppStates includes fewer items: study on', () => {
+  it('special states are set after study on', async () => {
+    fixture.componentInstance.onNewAccessToken('foo-access-token');
+    setAppState(AppState.ABBREVIATION_EXPANSION);
     studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.detectChanges();
+    await fixture.whenStable();
 
+    expect(fixture.componentInstance.isStudyOn).toBeTrue();
     expect(fixture.componentInstance.nonMinimizedStatesAppStates).toEqual([
       AppState.ABBREVIATION_EXPANSION,
     ]);
+    const mainArea = fixture.debugElement.query(By.css('.main-area'));
+    expect(mainArea).not.toBeNull();
+    expect(mainArea.classes['study-mode']).toBeTrue();
+  });
+
+  it('isStudyOn reflects off state after on', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    studyManager.maybeHandleRemoteControlCommand('study off');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.isStudyOn).toBeFalse();
+
   });
 });

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -421,6 +421,11 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
+  get isStudyOn(): boolean {
+    // TODO(cais): Add unit test.
+    return this.studyManager.isStudyOn;
+  }
+
   getNonMinimizedStateImgSrc(appState: AppState, isActive: boolean): string {
     const activeStateString = isActive ? 'active' : 'inactive';
     switch (appState) {

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -422,7 +422,6 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   get isStudyOn(): boolean {
-    // TODO(cais): Add unit test.
     return this.studyManager.isStudyOn;
   }
 

--- a/webui/src/app/conversation-turn/conversation-turn.component.html
+++ b/webui/src/app/conversation-turn/conversation-turn.component.html
@@ -5,8 +5,6 @@
   color: #EEE;
   font-family: "Google Sans", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 32px;
-  height: 100%;
-  max-height: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -23,7 +21,7 @@
   display: flex;
   flex-direction: row;
   font-size: 26px;
-  height: 100%;
+  height: 72px;
   margin: 5px;
   min-width: 250px;
   max-width: 360px;

--- a/webui/src/app/conversation-turn/conversation-turn.component.html
+++ b/webui/src/app/conversation-turn/conversation-turn.component.html
@@ -1,12 +1,14 @@
 <style>
 
 :host {
-    box-sizing: border-box;
-    color: #EEE;
-    font-family: "Google Sans", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    font-size: 32px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  box-sizing: border-box;
+  color: #EEE;
+  font-family: "Google Sans", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 32px;
+  height: 100%;
+  max-height: 100%;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .conversation-turn {
@@ -21,7 +23,7 @@
   display: flex;
   flex-direction: row;
   font-size: 26px;
-  height: 72px;
+  height: 100%;
   margin: 5px;
   min-width: 250px;
   max-width: 360px;

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -42,10 +42,11 @@
   align-items: center;
   background: #272626;
   border: none;
+  caret-shape: block;
   color: white;
   display: inline-flex;
   flex-direction: row;
-  font-family: "Google Sans", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: monospace;
   font-size: 30px;
   min-width: 60px;
   outline: none;

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -322,7 +322,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     const element = this.inputTextArea.nativeElement;
     const textLength = this.inputString.length;
-    const widthPx = Math.min(textLength * 27, 600);
+    const widthPx = Math.min(textLength * 25, 600);
     element.style.width = `${widthPx}px`;
     let i = INPUT_TEXT_FONT_SIZE_SCALING_LENGTH_TICKS.length - 1;
     for (; i >= 0; --i) {

--- a/webui/src/app/study/study-manager.spec.ts
+++ b/webui/src/app/study/study-manager.spec.ts
@@ -364,6 +364,7 @@ describe('Study Manager', () => {
       const lastUserTurn = studyUserTurns[studyUserTurns.length - 1];
       expect(lastUserTurn.text).toBeNull();
       expect(lastUserTurn.isComplete).toBeTrue();
+      expect(studyManager.isStudyOn).toBeTrue();
     });
 
     it('Invalid dialog ID throws error', async () => {

--- a/webui/src/app/study/study-manager.ts
+++ b/webui/src/app/study/study-manager.ts
@@ -125,7 +125,7 @@ export class StudyManager {
       this.switchToStudyOnMode();
     } else if (text === COMMAND_STUDY_OFF) {
       HttpEventLogger.setFullLogging(false);
-      this.reset();
+      this.reset(/* error= */ undefined, /* endStudy= */ true);
     } else if (
         text.startsWith(START_ABBREV_PREFIX) ||
         text.startsWith(START_FULL_PREFIX)) {
@@ -185,8 +185,10 @@ export class StudyManager {
     });
   }
 
-  private reset(error?: string) {
-    this._isStudyOn = false;
+  private reset(error?: string, endStudy: boolean = false) {
+    if (endStudy) {
+      this._isStudyOn = false;
+    }
     this.dialogId = null;
     this.userRole = null;
     this.turnIndex = null;


### PR DESCRIPTION
- Under study mode, enable zoom out, so the app UI works in landscape
  mode on a mobile device, without being partially obscured by the
  onscreen keyboard.
- Disable text predictions and quick phrases during study mode in `AbbreviationComponent`
- Change font in the input bar to avoid confusion such as "I" vs. "l"
- Stay in study mode after dialog ends.