### PR TITLE
[WebUI] Fix key-sequence ignoring, spell-mode speak button click, etc.

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -392,7 +392,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   }
 
   get phraseBackgroundColor(): string {
-    return '#0687BE';
+    return '#057bad';
   }
 
   get usedContextStrings(): string[] {

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -250,7 +250,7 @@ app-text-to-speech-component {
             [contextStrings]="contextStringsSelected.slice()"
             [languageCode]="languageCode"
             [textEntryEndSubject]="textEntryEndSubject"
-            [supportsAbbrevationExpansion]="appState === 'ABBREVIATION_EXPANSION'"
+            [supportsAbbrevationExpansion]="supportsAbbrevationExpansion"
             [favoriteButtonSendsUserFeedback]="appState === 'SETTINGS' || appState === 'HELP'"
             [inputBarControlSubject]="inputBarControlSubject"
             [loadPrefixedLexiconRequestSubject]="loadPrefixedLexiconRequestSubject"

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -124,7 +124,8 @@ app-text-to-speech-component {
   <app-external-events-component
       #externalEvents
       [textEntryBeginSubject]="textEntryBeginSubject"
-      [textEntryEndSubject]="textEntryEndSubject">
+      [textEntryEndSubject]="textEntryEndSubject"
+      [inputBarControlSubject]="inputBarControlSubject">
   </app-external-events-component>
 
   <app-text-to-speech-component

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -338,12 +338,45 @@ describe('AppComponent', () => {
     expect(mainArea.classes['study-mode']).toBeTrue();
   });
 
-  it('isStudyOn reflects off state after on', () => {
+  it('isStudyOn reflects off state after on', async () => {
     studyManager.maybeHandleRemoteControlCommand('study on');
     studyManager.maybeHandleRemoteControlCommand('study off');
     fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.componentInstance.isStudyOn).toBeFalse();
+  });
+
+  it('supportsAbbrevationExpansion reflects study manager full mode',
+     async () => {
+       setAppState(AppState.ABBREVIATION_EXPANSION);
+       fixture.detectChanges();
+       studyManager.maybeHandleRemoteControlCommand('start full dummy1');
+       fixture.detectChanges();
+       await fixture.whenStable();
+
+       expect(fixture.componentInstance.supportsAbbrevationExpansion)
+           .toBeFalse();
+     });
+
+  it('supportsAbbrevationExpansion reflects study manager abbrev mode',
+     async () => {
+       setAppState(AppState.ABBREVIATION_EXPANSION);
+       fixture.detectChanges();
+       studyManager.maybeHandleRemoteControlCommand('start abbrev dummy1');
+       fixture.detectChanges();
+       await fixture.whenStable();
+
+       expect(fixture.componentInstance.supportsAbbrevationExpansion)
+           .toBeTrue();
+     });
+
+  it('supportsAbbrevationExpansion reflects non-study mode', async () => {
+    setAppState(AppState.ABBREVIATION_EXPANSION);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.supportsAbbrevationExpansion).toBeTrue();
   });
 
   it('eye tracker disconnection updates input-bar notification', () => {

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -439,6 +439,13 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     return this.studyManager.isStudyOn;
   }
 
+  get supportsAbbrevationExpansion(): boolean {
+    if (this.studyManager.isStudyOn && !this.studyManager.isAbbreviationMode) {
+      return false;
+    }
+    return this.appState === AppState.ABBREVIATION_EXPANSION;
+  }
+
   getNonMinimizedStateImgSrc(appState: AppState, isActive: boolean): string {
     const activeStateString = isActive ? 'active' : 'inactive';
     switch (appState) {

--- a/webui/src/app/external/external-events-component.spec.ts
+++ b/webui/src/app/external/external-events-component.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 
+import {InputBarControlEvent} from '../input-bar/input-bar.component';
 import {TextEntryBeginEvent, TextEntryEndEvent} from '../types/text-entry';
 
 import {ExternalEventsComponent, getPunctuationLiteral, getVirtualkeyCode, LCTRL_KEY_HEAD_FOR_TTS_TRIGGER, resetReconStates, tryDetectoMultiKeyChar, VIRTUAL_KEY, VKCODE_SPECIAL_KEYS} from './external-events.component';
@@ -11,10 +12,12 @@ const END_KEY_CODE = getVirtualkeyCode(LCTRL_KEY_HEAD_FOR_TTS_TRIGGER)[0]
 describe('ExternalEventsComponent', () => {
   let textEntryBeginSubject: Subject<TextEntryBeginEvent>;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
+  let inputBarControlSubject: Subject<InputBarControlEvent>;
   let fixture: ComponentFixture<ExternalEventsComponent>;
   let component: ExternalEventsComponent;
   let beginEvents: TextEntryBeginEvent[];
   let endEvents: TextEntryEndEvent[];
+  let inputBarControlEvents: InputBarControlEvent[];
 
   beforeEach(async () => {
     await TestBed
@@ -25,14 +28,19 @@ describe('ExternalEventsComponent', () => {
         .compileComponents();
     textEntryBeginSubject = new Subject();
     textEntryEndSubject = new Subject();
+    inputBarControlSubject = new Subject();
     beginEvents = [];
     endEvents = [];
+    inputBarControlEvents = [];
     textEntryBeginSubject.subscribe((event) => beginEvents.push(event));
     textEntryEndSubject.subscribe((event) => endEvents.push(event));
+    inputBarControlSubject.subscribe(
+        (event) => inputBarControlEvents.push(event));
     fixture = TestBed.createComponent(ExternalEventsComponent);
     component = fixture.componentInstance;
     fixture.componentInstance.textEntryBeginSubject = textEntryBeginSubject;
     fixture.componentInstance.textEntryEndSubject = textEntryEndSubject;
+    fixture.componentInstance.inputBarControlSubject = inputBarControlSubject;
     fixture.detectChanges();
     jasmine.getEnv().allowRespy(true);
     ExternalEventsComponent.clearKeypressListeners();
@@ -632,6 +640,8 @@ describe('ExternalEventsComponent', () => {
       ['a'], ['a', ' '], ['a', ' ', ','], ['a', ' ', ',']
     ]);
     expect(reconstructedTexts).toEqual(['a', 'a ', 'a ,', 'a ,']);
+    expect(inputBarControlEvents.length).toEqual(1);
+    expect(inputBarControlEvents[0]).toEqual({numCharsToDeleteFromEnd: 1});
   });
 
   it('registerIgnoreKeySequence does not ignores human sequence', () => {

--- a/webui/src/app/external/external-events.component.ts
+++ b/webui/src/app/external/external-events.component.ts
@@ -218,7 +218,6 @@ function processIgnoreMachineKeySequences(
     for (const ignoreConfig of ignoreMachineKeySequenceConfigs) {
       if (keySequenceEndsWith(
               reconState.keySequence, ignoreConfig.keySequence)) {
-        console.log('*** Ends with:', ignoreConfig.keySequence);  // DEBUG
         numDisacrdedChars =
             ignoreConfig.keySequence.length - ignoreConfig.ignoreStartIndex;
       }
@@ -724,9 +723,6 @@ export class ExternalEventsComponent implements OnInit {
       textEntryBeginSubject.next({timestampMillis: Date.now()});
     }
 
-    console.log(
-        '*** isInferredMachineKey=', isInferredMachineKey,
-        isExternal);  // DEBUG
     processIgnoreMachineKeySequences(
         isInferredMachineKey, reconState,
         isExternal ? undefined : inputBarControlSubject);

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -30,7 +30,7 @@
 }
 
 .action-button.expand-button {
-  background-color: #525453;
+  background-color: #057bad;
   width: 100px;
 }
 
@@ -42,7 +42,6 @@
   align-items: center;
   background: #272626;
   border: none;
-  caret-shape: block;
   color: white;
   display: inline-flex;
   flex-direction: row;

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -294,6 +294,7 @@
     <div class="right-buttons-container">
       <button
           #clickableButton
+          *ngIf="!hideSpeakButton"
           class="action-button speak-button">
         <app-speak-button-component
             [phrase]="effectivePhrase"

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -614,6 +614,92 @@ describe('InputBarComponent', () => {
     expect(spellButton).not.toBeNull();
   });
 
+  it('clicking speak button when choosing from 3 letters to spell is no-op',
+     () => {
+       fixture.componentInstance.inputString = 'ifg';
+       inputBarControlSubject.next({
+         chips: [
+           {
+             text: 'i',
+           },
+           {
+             text: 'feel',
+           },
+           {
+             text: 'great',
+           }
+         ]
+       });
+       fixture.detectChanges();
+       const wordChips =
+           fixture.debugElement.queryAll(By.css('app-input-bar-chip-component'))
+       wordChips[1].nativeElement.click();
+       const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+       spellButton.nativeElement.click();
+       fixture.detectChanges();
+       const speakButton = fixture.debugElement.query(By.css('.speak-button'))
+                               .query(By.css('.speak-button'));
+       speakButton.nativeElement.click();
+
+       expect(fixture.componentInstance.state)
+           .toEqual(State.CHOOSING_LETTER_CHIP);
+       expect(textEntryEndEvents.length).toEqual(0);
+     });
+
+  it('clicking speak button when spelling single word speaks word', () => {
+    enterKeysIntoComponent('b');
+    const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+    spellButton.nativeElement.click();
+    fixture.detectChanges();
+    fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+    fixture.componentInstance.onChipTextChanged({text: 'bit '}, 0);
+    fixture.detectChanges();
+    const speakButton = fixture.debugElement.query(By.css('.speak-button'))
+                            .query(By.css('.speak-button'));
+    speakButton.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(textEntryEndEvents.length).toEqual(1);
+    expect(textEntryEndEvents[0].text).toEqual('bit');
+    expect(fixture.componentInstance.state).toEqual(State.ENTERING_BASE_TEXT);
+  });
+
+  it('clicking speak button when spelling single word empty is no-op', () => {
+    enterKeysIntoComponent('b');
+    const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+    spellButton.nativeElement.click();
+    fixture.detectChanges();
+    fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+    fixture.componentInstance.onChipTextChanged({text: ' '}, 0);
+    fixture.detectChanges();
+    const speakButton = fixture.debugElement.query(By.css('.speak-button'))
+                            .query(By.css('.speak-button'));
+    speakButton.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(textEntryEndEvents.length).toEqual(0);
+    expect(fixture.componentInstance.state)
+        .toEqual(State.FOCUSED_ON_LETTER_CHIP);
+  });
+
+  it('clicking speak button when spelling > 1 words is no-op', () => {
+    enterKeysIntoComponent('abc');
+    const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+    spellButton.nativeElement.click();
+    fixture.detectChanges();
+    fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+    fixture.componentInstance.onChipTextChanged({text: 'bit '}, 1);
+    fixture.detectChanges();
+    const speakButton = fixture.debugElement.query(By.css('.speak-button'))
+                            .query(By.css('.speak-button'));
+    speakButton.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(textEntryEndEvents.length).toEqual(0);
+    expect(fixture.componentInstance.state)
+        .toEqual(State.FOCUSED_ON_LETTER_CHIP);
+  });
+
   it('spell button is shown when word chip is chosen', () => {
     fixture.componentInstance.inputString = 'ifg';
     inputBarControlSubject.next({

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -499,6 +499,31 @@ describe('InputBarComponent', () => {
     expect(fillMaskRequests.length).toEqual(0);
   });
 
+  it('chip injection remembers previous text', () => {
+    let inputText = fixture.debugElement.query(By.css('.base-text-area'));
+    inputText.nativeElement.value = 'xyz';
+    inputBarControlSubject.next({
+      chips: [
+        {
+          text: 'i',
+        },
+        {
+          text: 'feel',
+        },
+        {
+          text: 'great',
+        }
+      ]
+    });
+    fixture.detectChanges();
+    const abortButton = fixture.debugElement.query(By.css('.abort-button'));
+    abortButton.nativeElement.click();
+    fixture.detectChanges();
+
+    inputText = fixture.debugElement.query(By.css('.base-text-area'));
+    expect(inputText.nativeElement.value).toEqual('xyz');
+  });
+
   it('clicking word chip during refinement sets correct state', () => {
     inputBarControlSubject.next({
       chips: [

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -578,6 +578,7 @@ describe('InputBarComponent', () => {
   it('clicking speak button clears text & clicking again triggers repeat',
      () => {
        enterKeysIntoComponent('it');
+       fixture.componentInstance.state = State.ENTERING_BASE_TEXT;
        const speakButton = fixture.debugElement.query(By.css('.speak-button'))
                                .query(By.css('.speak-button'));
        speakButton.nativeElement.click();

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1159,5 +1159,24 @@ describe('InputBarComponent', () => {
     expect(fixture.debugElement.query(By.css('.cut-button'))).toBeNull();
   });
 
+  it('numCharsToDeleteFromEnd truncates text from the end', () => {
+    inputBarControlSubject.next({
+      numCharsToDeleteFromEnd: 1,
+    });
+
+    const inputText = fixture.debugElement.query(By.css('.base-text-area'));
+    inputText.nativeElement.value = 'hi there, ';
+    const event1 = new KeyboardEvent('keypress', {key: ' '});
+    fixture.componentInstance.onInputTextAreaKeyUp(event1);
+    expect(inputText.nativeElement.value).toEqual('hi there,');
+    expect(fixture.componentInstance.inputString).toEqual('hi there,');
+
+    inputText.nativeElement.value = 'hi there, fine, ';
+    const event2 = new KeyboardEvent('keypress', {key: ' '});
+    fixture.componentInstance.onInputTextAreaKeyUp(event2);
+    expect(inputText.nativeElement.value).toEqual('hi there, fine, ');
+    expect(fixture.componentInstance.inputString).toEqual('hi there, fine, ');
+  });
+
   // TODO(cais): Test spelling valid word triggers AE, with debounce.
 });

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1265,5 +1265,37 @@ describe('InputBarComponent', () => {
     expect(fixture.componentInstance.inputString).toEqual('hi there, fine, ');
   });
 
+  for (const state of [State.ENTERING_BASE_TEXT, State.CHOOSING_LETTER_CHIP]) {
+    it('study abbrev mode: hides speak button: state=' + state, async () => {
+      await studyManager.maybeHandleRemoteControlCommand('start abbrev dummy1');
+      fixture.componentInstance.state = state;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.speak-button'))).toBeNull();
+    });
+  }
+
+  for (const state of [State.CHOOSING_WORD_CHIP, State.FOCUSED_ON_WORD_CHIP]) {
+    it('study abbrev mode: shows speak button: state=' + state, async () => {
+      await studyManager.maybeHandleRemoteControlCommand('start abbrev dummy1');
+      fixture.componentInstance.state = state;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.speak-button')))
+          .not.toBeNull();
+    });
+  }
+
+  for (const state of [State.ENTERING_BASE_TEXT]) {
+    it('study full mode: shows speak button: state=' + state, async () => {
+      await studyManager.maybeHandleRemoteControlCommand('start full dummy1');
+      fixture.componentInstance.state = state;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.speak-button')))
+          .not.toBeNull();
+    });
+  }
+
   // TODO(cais): Test spelling valid word triggers AE, with debounce.
 });

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -234,6 +234,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
                   this._chips.map(chip => chip.text.trim()).join(' ') + ' ';
               this.inputString = this.cutText;
             }
+            this.saveInputTextAreaState();
           } else if (event.refocus) {
             if (this.inputTextArea) {
               this.focusOnInputTextArea();

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -807,13 +807,12 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get hideSpeakButton(): boolean {
-    const canOutputTextInBar =
+    const canOutputTextFromInputBar =
         (this.state === State.CHOOSING_WORD_CHIP ||
-         this.state === State.CHOOSING_LETTER_CHIP ||
          this.state === State.FOCUSED_ON_WORD_CHIP ||
          (this.state === State.FOCUSED_ON_LETTER_CHIP &&
           this._chips.length === 1));
     return this.isStudyOn && this.studyManager.isAbbreviationMode &&
-        !canOutputTextInBar;
+        !canOutputTextFromInputBar;
   }
 }

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -186,8 +186,6 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
           } else if (
               event.numCharsToDeleteFromEnd &&
               event.numCharsToDeleteFromEnd > 0) {
-            console.log(
-                '*** Deleting chars:', event.numCharsToDeleteFromEnd);  // DEBUG
             this.pendingCharDeletions = event.numCharsToDeleteFromEnd;
           } else if (event.appendText !== undefined) {
             ExternalEventsComponent.appendString(
@@ -616,6 +614,11 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
         });
       }
       return words.join(' ');
+    } else if (
+        this.state === State.FOCUSED_ON_LETTER_CHIP &&
+        this._chips.length === 1 && this._chipTypedText !== null &&
+        this._chipTypedText[0] !== null) {
+      return this._chipTypedText[0].trim();
     } else if (this.state === State.ENTERING_BASE_TEXT) {
       return this.inputString;
     }
@@ -632,6 +635,15 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onSpeakAsIsButtonClicked(event?: Event) {
+    if (this.state === State.CHOOSING_LETTER_CHIP ||
+        (this.state === State.FOCUSED_ON_LETTER_CHIP &&
+             this._chips.length > 1 ||
+         this._chipTypedText === null || this._chipTypedText[0] === null ||
+         this._chipTypedText[0].trim() === '')) {
+      // The Speak button should do nothing when spelling a word, unless there
+      // is only one word.
+      return;
+    }
     const text = this.effectivePhrase;
     const repeatLastNonEmpty = text === '';
     this.eventLogger.logInputBarSpeakButtonClick(getPhraseStats(text));

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -224,6 +224,10 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
                 this._chipTypedText![i] = chip.text;
               }
             });
+            if (this.inputTextArea && this.inputTextArea.nativeElement) {
+              // TODO(cais): Add unit test.
+              this.saveInputTextAreaState();
+            }
             if (this._chips.length > 1) {
               this.state = State.CHOOSING_WORD_CHIP;
               this.eventLogger.logAbbreviationExpansionStartWordRefinementMode(
@@ -234,7 +238,6 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
                   this._chips.map(chip => chip.text.trim()).join(' ') + ' ';
               this.inputString = this.cutText;
             }
-            this.saveInputTextAreaState();
           } else if (event.refocus) {
             if (this.inputTextArea) {
               this.focusOnInputTextArea();

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -224,10 +224,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
                 this._chipTypedText![i] = chip.text;
               }
             });
-            if (this.inputTextArea && this.inputTextArea.nativeElement) {
-              // TODO(cais): Add unit test.
-              this.saveInputTextAreaState();
-            }
+            this.saveInputTextAreaState();
             if (this._chips.length > 1) {
               this.state = State.CHOOSING_WORD_CHIP;
               this.eventLogger.logAbbreviationExpansionStartWordRefinementMode(
@@ -492,6 +489,9 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private saveInputTextAreaState() {
+    if (!this.inputTextArea || !this.inputTextArea.nativeElement) {
+      return;
+    }
     InputBarComponent.savedInputString = this.inputTextArea.nativeElement.value;
   }
 

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -787,7 +787,6 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get isStudyOn(): boolean {
-    console.log('*** this.state=', this.state);  // DEBUG
     return this.studyManager.isStudyOn;
   }
 

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -637,9 +637,9 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   onSpeakAsIsButtonClicked(event?: Event) {
     if (this.state === State.CHOOSING_LETTER_CHIP ||
         (this.state === State.FOCUSED_ON_LETTER_CHIP &&
-             this._chips.length > 1 ||
-         this._chipTypedText === null || this._chipTypedText[0] === null ||
-         this._chipTypedText[0].trim() === '')) {
+         (this._chips.length > 1 || this._chipTypedText === null ||
+          this._chipTypedText[0] === null ||
+          this._chipTypedText[0].trim() === ''))) {
       // The Speak button should do nothing when spelling a word, unless there
       // is only one word.
       return;
@@ -787,6 +787,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get isStudyOn(): boolean {
+    console.log('*** this.state=', this.state);  // DEBUG
     return this.studyManager.isStudyOn;
   }
 
@@ -804,5 +805,16 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
 
   get studyDialogError(): string|undefined {
     return this._studyDialogError;
+  }
+
+  get hideSpeakButton(): boolean {
+    const canOutputTextInBar =
+        (this.state === State.CHOOSING_WORD_CHIP ||
+         this.state === State.CHOOSING_LETTER_CHIP ||
+         this.state === State.FOCUSED_ON_WORD_CHIP ||
+         (this.state === State.FOCUSED_ON_LETTER_CHIP &&
+          this._chips.length === 1));
+    return this.isStudyOn && this.studyManager.isAbbreviationMode &&
+        !canOutputTextInBar;
   }
 }

--- a/webui/src/app/study/study-manager.spec.ts
+++ b/webui/src/app/study/study-manager.spec.ts
@@ -50,8 +50,9 @@ describe('Study Manager', () => {
       studyUserTurnsSubscription.unsubscribe();
     });
 
-    it('isStudyOn is initially false', () => {
+    it('isStudyOn isAbbreviationMode are initially false', () => {
       expect(studyManager.isStudyOn).toBeFalse();
+      expect(studyManager.isAbbreviationMode).toBeFalse();
     });
 
     it('sets logging mode to full for command study on', async () => {
@@ -60,6 +61,7 @@ describe('Study Manager', () => {
 
       expect(handled).toBeTrue();
       expect(studyManager.isStudyOn).toBeTrue();
+      expect(studyManager.isAbbreviationMode).toBeFalse();
       expect(HttpEventLogger.isFullLogging()).toBeTrue();
     });
 
@@ -70,6 +72,7 @@ describe('Study Manager', () => {
 
       expect(handled).toBeTrue();
       expect(studyManager.isStudyOn).toBeFalse();
+      expect(studyManager.isAbbreviationMode).toBeFalse();
       expect(HttpEventLogger.isFullLogging()).toBeFalse();
     });
 
@@ -87,6 +90,7 @@ describe('Study Manager', () => {
 
       expect(handled).toBeTrue();
       expect(HttpEventLogger.isFullLogging()).toBeTrue();
+      expect(studyManager.isAbbreviationMode).toBeTrue();
       expect(studyManager.waitingForPartnerTurnAfter).toBeNull();
       expect(studyManager.getDialogId()).toBe('dummy1');
       expect(studyManager.getDialogTurnIndex()).toEqual(0);
@@ -101,6 +105,7 @@ describe('Study Manager', () => {
       const incrementResult = studyManager.incrementTurn();
 
       expect(studyManager.isStudyOn).toBeTrue();
+      expect(studyManager.isAbbreviationMode).toBeTrue();
       expect(incrementResult.turnIndex).toEqual(1);
       expect(incrementResult.isComplete).toBeFalse();
       expect(studyManager.getDialogId()).toBe('dummy1');
@@ -123,6 +128,7 @@ describe('Study Manager', () => {
 
             setTimeout(() => {
               expect(studyManager.isStudyOn).toBeTrue();
+              expect(studyManager.isAbbreviationMode).toBeTrue();
               expect(studyManager.getDialogId()).toBe('dummy1');
               expect(studyManager.waitingForPartnerTurnAfter).toBeNull();
               expect(studyManager.getDialogTurnIndex()).toEqual(2);
@@ -159,6 +165,7 @@ describe('Study Manager', () => {
             setTimeout(() => {
               const incrementResult = studyManager.incrementTurn();
               expect(studyManager.isStudyOn).toBeTrue();
+              expect(studyManager.isAbbreviationMode).toBeTrue();
               expect(incrementResult.turnIndex).toEqual(3);
               expect(incrementResult.isComplete).toBeFalse();
               expect(studyManager.getDialogId()).toBe('dummy1');
@@ -190,6 +197,7 @@ describe('Study Manager', () => {
             studyManager.incrementTurn('unexpected question');
             setTimeout(() => {
               expect(studyManager.isStudyOn).toBeTrue();
+              expect(studyManager.isAbbreviationMode).toBeTrue();
               expect(studyManager.getDialogTurnIndex()).toEqual(2);
               expect(studyManager.waitingForPartnerTurnAfter).toBeNull();
               const prevTurns = studyManager.getPreviousDialogTurns();
@@ -209,6 +217,7 @@ describe('Study Manager', () => {
           .then(() => {
             setTimeout(() => {
               expect(studyManager.isStudyOn).toBeTrue();
+              expect(studyManager.isAbbreviationMode).toBeTrue();
               expect(studyManager.getDialogTurnIndex()).toEqual(1);
               studyManager.incrementTurn('random reply');
 
@@ -231,6 +240,7 @@ describe('Study Manager', () => {
           .then(() => {
             setTimeout(() => {
               expect(studyManager.isStudyOn).toBeTrue();
+              expect(studyManager.isAbbreviationMode).toBeTrue();
               expect(studyUserTurns.length).toEqual(1);
               expect(studyUserTurns[0].instruction)
                   .toEqual('Enter your reply in abbreviation.');
@@ -303,6 +313,7 @@ describe('Study Manager', () => {
     ] as Array<[string, boolean, string]>) {
       it('start from partner turn: auto increments initially', done => {
         studyManager.maybeHandleRemoteControlCommand(command).then(() => {
+          expect(studyManager.isAbbreviationMode).toEqual(isAbbreviation);
           expect(studyManager.getDialogId()).toEqual('dummy1');
           expect(studyManager.getDialogTurnIndex()).toEqual(1);
           expect(studyManager.getDialogTurnText())

--- a/webui/src/app/study/study-manager.ts
+++ b/webui/src/app/study/study-manager.ts
@@ -262,6 +262,10 @@ export class StudyManager {
     return this._isStudyOn;
   }
 
+  public get isAbbreviationMode(): boolean {
+    return this.isAbbreviation === true;
+  }
+
   /**
    * Gets the ID of the current ongoing dialog, if any. Returns `null` if and
    * only if there is no ongoing dialog.


### PR DESCRIPTION
- Correctly enforce ignore sequence (e.g., comma followed immediately by a space) in the new textarea in `InputBarComponent`
- During study mode `full`, hide the `Expand` button
- During study mode `abbrev`, hide the `Speak` button, unless under special states including `CHOOSING_WORD_CHIP`, `FOCUSED_ON_WORD_CHIP` and `FOCUSED_ON_LETTER_CHIP` for numChips = 1. Fixes #333.
- Fix the behavior of clicking the Speak button when spelling words: Fixes #334 
  - If there is only a single word and it is spelled out to be non-empty, speak the word out loud
  - If there are multiple words, and the user is either choosing a letter chip or focused on a letter chip, it is a no-op.
- Adjust the color of the "Expand" button to blue, to make it more salient.
- Fix #336: save input textarea text when adding chips.
