### PR TITLE
[WebUI] Fix text logging during study

### DIFF
--- a/webui/src/app/event-logger/event-logger-impl.ts
+++ b/webui/src/app/event-logger/event-logger-impl.ts
@@ -50,8 +50,8 @@ export interface EventLogResponse {
 
 /**
  * Format / escape a text string for logging. Special characters such as single
- * and double quotes are escaped to prevent a class of issues during server-side
- * string parsing.
+ * and double quotes and newline characters are escaped to prevent a class of
+ * issues during server-side string parsing.
  */
 export function formatTextForLogging(text: string): string {
   // NOTE: `encodeURIComponent()` doesn't escape single quote.
@@ -234,6 +234,8 @@ export class HttpEventLogger implements EventLogger {
         getVirtualkeyCode(keyboardEvent.key);
     if (!HttpEventLogger.isFullLogging()) {
       text = null;
+    } else if (text !== null) {
+      text = formatTextForLogging(text);
     }
     // TODO(cais): Add unit test.
     await this
@@ -646,7 +648,7 @@ export class HttpEventLogger implements EventLogger {
         .pipe(retryWhen(
             error => error.pipe(
                 concatMap((error, count) => {
-                  if (count <= MAX_RETRIES) {
+                  if (count < MAX_RETRIES) {
                     return of(error);
                   }
                   return throwError(error);

--- a/webui/src/app/event-logger/event-logger-impl.ts
+++ b/webui/src/app/event-logger/event-logger-impl.ts
@@ -2,8 +2,8 @@
 
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Observable, of} from 'rxjs';
-import {first} from 'rxjs/operators';
+import {Observable, of, throwError} from 'rxjs';
+import {concatMap, delay, first, retryWhen} from 'rxjs/operators';
 import {isTextContentKey} from 'src/utils/keyboard-utils';
 import {createUuid} from 'src/utils/uuid';
 
@@ -116,6 +116,9 @@ export function getContextualPhraseStats(phrase: ContextualPhrase):
   }
   return output;
 }
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MILLIS = 1000;
 
 @Injectable({
   providedIn: 'root',
@@ -637,7 +640,17 @@ export class HttpEventLogger implements EventLogger {
         'Content-Type': 'application/json',
       }),
     };
-    return this.http.post<EventLogResponse>(
-        EVENT_LOGS_ENDPOINT, JSON.stringify(eventLogEntry), httpOptions);
+    return this.http
+        .post<EventLogResponse>(
+            EVENT_LOGS_ENDPOINT, JSON.stringify(eventLogEntry), httpOptions)
+        .pipe(retryWhen(
+            error => error.pipe(
+                concatMap((error, count) => {
+                  if (count <= MAX_RETRIES) {
+                    return of(error);
+                  }
+                  return throwError(error);
+                }),
+                delay(RETRY_DELAY_MILLIS))));
   }
 }

--- a/webui/src/app/event-logger/event-logger.spec.ts
+++ b/webui/src/app/event-logger/event-logger.spec.ts
@@ -13,6 +13,11 @@ describe('EventLogger', () => {
       expect(formatTextForLogging('I\'m not saying \"you can\'t do it\"'))
           .toEqual('I%27m%20not%20saying%20%22you%20can%27t%20do%20it%22');
     });
+
+    it('Escapes newline character', () => {
+      expect(formatTextForLogging('Don\'t do it\nPlease\n'))
+      .toEqual('Don%27t%20do%20it%0APlease%0A');
+    });
   });
 
   describe('isFullLogging()', () => {


### PR DESCRIPTION
- The logging error occurred when there was the single quote or apostrophe (`'`) character in the text. The error occurred because the character was not properly URL-encoded. This PR adds the encoding. 
- For extra safety, this PR adds retry logic to event logging impl.

Fixes #339 .