### PR TITLE
[WebUI] Support word suggestions

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -306,13 +306,6 @@ mat-progress-spinner {
     *ngIf="!isStudyOn &&
            (state === 'PRE_CHOOSING_EXPANSION' ||
             state === 'POST_CHOOSING_EXPANSION')">
-  <button
-      #clickableButton
-      *ngFor="let text of textPredictions; let i = index"
-      class="action-button text-prediction-button"
-      (click)="onTextPredictionButtonClicked($event, i)">
-    {{text}}
-  </button>
 
   <app-quick-phrases-component
       [userId]="userId"

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -285,38 +285,6 @@ describe('AbbreviationComponent', () => {
     expect(fixture.componentInstance.responseError).toBeNull();
   });
 
-  it('clicking text prediction fires input-bar control event', () => {
-    fixture.componentInstance.textPredictions.splice(0)
-    fixture.componentInstance.textPredictions.push('foo');
-    fixture.componentInstance.textPredictions.push('bar');
-    fixture.detectChanges();
-    const textPredictionButtons =
-        fixture.debugElement.queryAll(By.css('.text-prediction-button'));
-    expect(textPredictionButtons.length).toEqual(2);
-    textPredictionButtons[1].nativeElement.click();
-    fixture.detectChanges();
-
-    expect(inputBarControlEvents.length).toEqual(2);
-    const [event] = inputBarControlEvents;
-    expect(event.clearAll).toBeUndefined();
-    expect(event.chips).toEqual([{
-      text: 'bar',
-      isTextPrediction: true,
-    }]);
-  });
-
-  it('does not show text predictions during study dialog', async () => {
-    await studyManager.maybeHandleRemoteControlCommand('Start abbrev dummy1');
-    fixture.componentInstance.textPredictions.splice(0)
-    fixture.componentInstance.textPredictions.push('foo');
-    fixture.componentInstance.textPredictions.push('bar');
-    fixture.detectChanges();
-
-    const textPredictionButtons =
-        fixture.debugElement.queryAll(By.css('.text-prediction-button'));
-    expect(textPredictionButtons.length).toEqual(0);
-  });
-
   it('clicking the container issues refocus signal', () => {
     const container = fixture.debugElement.query(By.css('.container'));
     container.nativeElement.click();
@@ -339,20 +307,6 @@ describe('AbbreviationComponent', () => {
     studyManager.maybeHandleRemoteControlCommand('study off');
 
     expect(fixture.componentInstance.isStudyOn).toBeFalse();
-  });
-
-  it('does not show text prediction or quick phrases when study is on', () => {
-    studyManager.maybeHandleRemoteControlCommand('study on');
-    fixture.componentInstance.textPredictions.splice(0)
-    fixture.componentInstance.textPredictions.push('foo');
-    fixture.componentInstance.textPredictions.push('bar');
-    fixture.detectChanges();
-    const textPredictionButtons =
-        fixture.debugElement.queryAll(By.css('.text-prediction-button'));
-
-    expect(textPredictionButtons.length).toEqual(0);
-    expect(fixture.debugElement.query(By.css('app-quick-phrases-component')))
-        .toBeNull();
   });
 
 });

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -148,37 +148,6 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
                 .map(turn => turn.speechContent)
                 .join('. ') +
             '. ';
-    // TODO(cais): Clean up. DO NOT SUBMIT.
-    // this.speakFasterService
-    //     .textPrediction({
-    //       contextTurns:
-    //           conversationTurns.slice(0, n + 1).map(turn => turn.speechContent),
-    //       textPrefix,
-    //       timestamp: new Date().toISOString(),
-    //       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    //     })
-    //     .subscribe((data: TextPredictionResponse) => {
-    //       if (!data.outputs) {
-    //         return;
-    //       }
-
-    //       // this.textPredictions.splice(0);
-    //       data.outputs.forEach(output => {
-    //         this.responseError = null;
-    //         const text = output.trim();
-    //         if (!text ||
-    //             !text.match(
-    //                 AbbreviationComponent._VALID_TEXT_CONTINUATION_REGEX) ||
-    //             output.toLocaleLowerCase().indexOf('speaker') !== -1) {
-    //           return;
-    //         }
-    //         this.textPredictions.push(output);
-    //       });
-    //       if (textPrefix.length > MAX_NUM_TEXT_PREDICTIONS) {
-    //         this.textPredictions.splice(MAX_NUM_TEXT_PREDICTIONS);
-    //       }
-    //       this.cdr.detectChanges();
-    //     });
   }
 
   ngOnDestroy() {
@@ -197,20 +166,6 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   onTryAgainButtonClicked(event: Event) {
     this.expandAbbreviation();
   }
-
-  // TODO(cais): Clean up.
-  // onTextPredictionButtonClicked(event: Event, index: number) {
-  //   // NOTE: blur() call prevents future space keys from inadvertently
-  //   // clicking the button again.
-  //   // TODO(cais): Add unit test.
-  //   (event.target as HTMLButtonElement).blur();
-  //   this.inputBarControlSubject.next({
-  //     chips: [{
-  //       text: this.textPredictions[index],
-  //       isTextPrediction: true,
-  //     }],
-  //   });
-  // }
 
   get isStudyDialogOngoing() {
     return this.studyManager.getDialogId() !== null;

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -56,9 +56,6 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   @ViewChildren('tokenInput')
   tokenInputElements!: QueryList<ElementRef<HTMLElement>>;
 
-  // Typing-free phrase predictions, which gets populated without AE.
-  readonly textPredictions: string[] = [];
-
   reconstructedText: string = '';
   state = State.PRE_CHOOSING_EXPANSION;
   private pendingRefinementType: RefinementType = 'REPLACE_TOKEN';
@@ -151,35 +148,37 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
                 .map(turn => turn.speechContent)
                 .join('. ') +
             '. ';
-    this.speakFasterService
-        .textPrediction({
-          contextTurns:
-              conversationTurns.slice(0, n + 1).map(turn => turn.speechContent),
-          textPrefix,
-          timestamp: new Date().toISOString(),
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        })
-        .subscribe((data: TextPredictionResponse) => {
-          if (!data.outputs) {
-            return;
-          }
-          this.textPredictions.splice(0);
-          data.outputs.forEach(output => {
-            this.responseError = null;
-            const text = output.trim();
-            if (!text ||
-                !text.match(
-                    AbbreviationComponent._VALID_TEXT_CONTINUATION_REGEX) ||
-                output.toLocaleLowerCase().indexOf('speaker') !== -1) {
-              return;
-            }
-            this.textPredictions.push(output);
-          });
-          if (textPrefix.length > MAX_NUM_TEXT_PREDICTIONS) {
-            this.textPredictions.splice(MAX_NUM_TEXT_PREDICTIONS);
-          }
-          this.cdr.detectChanges();
-        });
+    // TODO(cais): Clean up. DO NOT SUBMIT.
+    // this.speakFasterService
+    //     .textPrediction({
+    //       contextTurns:
+    //           conversationTurns.slice(0, n + 1).map(turn => turn.speechContent),
+    //       textPrefix,
+    //       timestamp: new Date().toISOString(),
+    //       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    //     })
+    //     .subscribe((data: TextPredictionResponse) => {
+    //       if (!data.outputs) {
+    //         return;
+    //       }
+
+    //       // this.textPredictions.splice(0);
+    //       data.outputs.forEach(output => {
+    //         this.responseError = null;
+    //         const text = output.trim();
+    //         if (!text ||
+    //             !text.match(
+    //                 AbbreviationComponent._VALID_TEXT_CONTINUATION_REGEX) ||
+    //             output.toLocaleLowerCase().indexOf('speaker') !== -1) {
+    //           return;
+    //         }
+    //         this.textPredictions.push(output);
+    //       });
+    //       if (textPrefix.length > MAX_NUM_TEXT_PREDICTIONS) {
+    //         this.textPredictions.splice(MAX_NUM_TEXT_PREDICTIONS);
+    //       }
+    //       this.cdr.detectChanges();
+    //     });
   }
 
   ngOnDestroy() {
@@ -199,18 +198,19 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
     this.expandAbbreviation();
   }
 
-  onTextPredictionButtonClicked(event: Event, index: number) {
-    // NOTE: blur() call prevents future space keys from inadvertently
-    // clicking the button again.
-    // TODO(cais): Add unit test.
-    (event.target as HTMLButtonElement).blur();
-    this.inputBarControlSubject.next({
-      chips: [{
-        text: this.textPredictions[index],
-        isTextPrediction: true,
-      }],
-    });
-  }
+  // TODO(cais): Clean up.
+  // onTextPredictionButtonClicked(event: Event, index: number) {
+  //   // NOTE: blur() call prevents future space keys from inadvertently
+  //   // clicking the button again.
+  //   // TODO(cais): Add unit test.
+  //   (event.target as HTMLButtonElement).blur();
+  //   this.inputBarControlSubject.next({
+  //     chips: [{
+  //       text: this.textPredictions[index],
+  //       isTextPrediction: true,
+  //     }],
+  //   });
+  // }
 
   get isStudyDialogOngoing() {
     return this.studyManager.getDialogId() !== null;

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -40,7 +40,7 @@ app-text-to-speech-component {
 
 .content {
   box-sizing: border-box;
-  height: fit-content;
+  height: 464px;
   margin: 4px;
   width: fit-content;
 }

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -40,13 +40,17 @@ app-text-to-speech-component {
 
 .content {
   box-sizing: border-box;
-  height: 464px;
+  height: 456px;
   margin: 4px;
   width: fit-content;
 }
 
 .content.study-mode {
   margin: 0px;
+}
+
+.content.minimized {
+  height: fit-content;
 }
 
 .context-and-quick-phrase-container {
@@ -115,7 +119,7 @@ app-text-to-speech-component {
     #contentWrapper
     *ngIf="getUserRole() === 'AAC_USER' else partnerBlock"
     class="content"
-    [ngClass]="{'study-mode': isStudyOn}"
+    [ngClass]="{'study-mode': isStudyOn, 'minimized': appState === 'MINIBAR'}"
     role="main">
 
   <!-- This is a "virtual" component without any UI. It is purely for

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -40,7 +40,7 @@ app-text-to-speech-component {
 
 .content {
   box-sizing: border-box;
-  height: 456px;
+  height: fit-content;
   margin: 4px;
   width: fit-content;
 }

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -17,7 +17,6 @@ import {AddContextualPhraseRequest} from './types/contextual_phrase';
 import {ConversationTurn} from './types/conversation';
 import {TextEntryBeginEvent, TextEntryEndEvent} from './types/text-entry';
 
-
 // Type signature of callback functions that listen to resizing of an element.
 export type AppResizeCallback = (height: number, width: number) => void;
 

--- a/webui/src/app/app.module.ts
+++ b/webui/src/app/app.module.ts
@@ -21,7 +21,9 @@ import {TextToSpeechModule} from './text-to-speech/text-to-speech.module';
 import {TtsVoiceSelectionModule} from './tts-voice-selection/tts-voice-selection.module';
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [
+    AppComponent,
+  ],
   imports: [
     InputBarModule,
     AbbreviationModule,

--- a/webui/src/app/auth/auth.component.ts
+++ b/webui/src/app/auth/auth.component.ts
@@ -34,7 +34,12 @@ export class AuthComponent implements OnInit, AfterViewInit, OnDestroy {
   constructor(
       private route: ActivatedRoute,
       public authService: GoogleDeviceAuthService,
-      private snackBar: MatSnackBar) {}
+      private snackBar: MatSnackBar) {
+
+    (window as any).getAccessToken = (): string => {
+      return this.accessToken;
+    }
+  }
 
   ngOnInit() {
     this.route.queryParams.subscribe(params => {

--- a/webui/src/app/event-logger/event-logger-impl.ts
+++ b/webui/src/app/event-logger/event-logger-impl.ts
@@ -253,7 +253,6 @@ export class HttpEventLogger implements EventLogger {
   }
 
   async logInputBarSpeakButtonClick(phraseStats: PhraseStats) {
-    console.log('*** In logInputBarSpeakButtonClick()');  // DEBUG
     await this
         .logEvent({
           userId: this._userId!,
@@ -425,7 +424,6 @@ export class HttpEventLogger implements EventLogger {
   async logAbbreviationExpansionSelection(
       phraseStats: PhraseStats, index: number, numOptions: number,
       textSelectionType: TextSelectionType) {
-    console.log('*** In logAbbreviationExpansionSelection()');  // DEBUG
     await this
         .logEvent({
           userId: this._userId!,

--- a/webui/src/app/event-logger/event-logger-impl.ts
+++ b/webui/src/app/event-logger/event-logger-impl.ts
@@ -253,6 +253,7 @@ export class HttpEventLogger implements EventLogger {
   }
 
   async logInputBarSpeakButtonClick(phraseStats: PhraseStats) {
+    console.log('*** In logInputBarSpeakButtonClick()');  // DEBUG
     await this
         .logEvent({
           userId: this._userId!,
@@ -424,6 +425,7 @@ export class HttpEventLogger implements EventLogger {
   async logAbbreviationExpansionSelection(
       phraseStats: PhraseStats, index: number, numOptions: number,
       textSelectionType: TextSelectionType) {
+    console.log('*** In logAbbreviationExpansionSelection()');  // DEBUG
     await this
         .logEvent({
           userId: this._userId!,

--- a/webui/src/app/event-logger/event-logger-impl.ts
+++ b/webui/src/app/event-logger/event-logger-impl.ts
@@ -31,7 +31,8 @@ export type EventName =
     'ContextualPhraseEditError'|'ContextualPhraseSelection'|
     'ContextualPhraseCopying'|'IncomingContextualTurn'|
     'InputBarInjectButtonClick'|'InputBarSpeakButtonClick'|'Keypress'|
-    'SessionEnd'|'SessionStart'|'SettingsChange'|'UserFeedback'|'RemoteCommand';
+    'SessionEnd'|'SessionStart'|'SettingsChange'|'TextPredictionSelection'|
+    'UserFeedback'|'RemoteCommand';
 
 export type EventLogEntry = {
   userId: string;
@@ -542,6 +543,22 @@ export class HttpEventLogger implements EventLogger {
           sessionId: this.sessionId,
           eventName: 'AbbreviationExpansionSpellingChipSelection',
           eventData: {abbreviationLength, wordIndex},
+          appState: getAppState(),
+        })
+        .pipe(first())
+        .toPromise();
+  }
+
+  async logTextPredictionSelection(
+      phraseStats: PhraseStats, phraseIndex: number): Promise<void> {
+    await this
+        .logEvent({
+          userId: this._userId!,
+          timestamp: this.getUtcEpochMillis(),
+          timezone: this.timezone,
+          sessionId: this.sessionId,
+          eventName: 'TextPredictionSelection',
+          eventData: {phraseStats, phraseIndex},
           appState: getAppState(),
         })
         .pipe(first())

--- a/webui/src/app/event-logger/event-logger.ts
+++ b/webui/src/app/event-logger/event-logger.ts
@@ -183,6 +183,14 @@ export interface EventLogger {
       abbreviationLength: number, wordIndex: number): Promise<void>;
 
   /**
+   * Log the selection of a text prediction, most typically a word completion
+   * or next-word prediction. Note that this is different from contextual-phrase
+   * selections.
+   */
+  logTextPredictionSelection(phraseStats: PhraseStats, phraseIndex: number):
+      Promise<void>;
+
+  /**
    * Log the mode abort during abbreviation expansion, e.g., abort from word
    * refinement or from spelling.
    */

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -78,7 +78,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  height: fit-content;
+  height: 140px;
   overflow: visible;
   padding: 0 0 8px;
   position: relative;

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -247,13 +247,14 @@
         </app-input-bar-chip-component>
       </div>
 
-      <div class="buttons-container">
+      <!-- When the text prediction bar is shown, it presents the Expand, Spell
+           and Abort buttons by itself. -->
+      <div
+          *ngIf="!showTextPredictionBar"
+          class="buttons-container">
         <button
             #clickableButton
-            *ngIf="(state === 'ENTERING_BASE_TEXT' ||
-                    state === 'CHOOSING_PHRASES' ||
-                    state === 'FOCUSED_ON_LETTER_CHIP') &&
-                    inputStringIsCompatibleWithAbbreviationExpansion && supportsAbbrevationExpansion"
+            *ngIf="showExpandButton"
             class="action-button expand-button"
             (click)="onExpandButtonClicked($event)">
           Expand
@@ -261,13 +262,7 @@
 
         <button
             #clickableButton
-            *ngIf="((state === 'ENTERING_BASE_TEXT') ||
-                    (state === 'CHOOSING_PHRASES') ||
-                    state === 'CHOOSING_WORD_CHIP' ||
-                    state === 'FOCUSED_ON_WORD_CHIP') &&
-                   inputStringIsCompatibleWithAbbreviationExpansion &&
-                   supportsAbbrevationExpansion &&
-                   !hasOnlyOneTextPredictionChip"
+            *ngIf="showSpellButton"
             class="action-button spell-button"
             (click)="onSpellButtonClicked($event)">
           Spell
@@ -353,10 +348,13 @@
 
   <!-- TODO(cais): Add unit tests. -->
   <input-text-predictions-component
-      *ngIf="!hasNotification && !isStudyOn && state === 'ENTERING_BASE_TEXT'"
+      *ngIf="showTextPredictionBar"
       [userId]="userId"
       [inputString]="inputString"
-      [inputBarControlSubject]="inputBarControlSubject">
+      [inputBarControlSubject]="inputBarControlSubject"
+      (expandButtonClicked)="onExpandButtonClicked($event)"
+      (spellButtonClicked)="onSpellButtonClicked($event)"
+      (abortButtonClicked)="onAbortButtonClicked($event)">
   </input-text-predictions-component>
 
 </div>

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -351,4 +351,12 @@
     {{notification}}
   </div>
 
+  <!-- TODO(cais): Add unit tests. -->
+  <input-text-predictions-component
+      *ngIf="!hasNotification && !isStudyOn"
+      [userId]="userId"
+      [inputString]="inputString"
+      [inputBarControlSubject]="inputBarControlSubject">
+  </input-text-predictions-component>
+
 </div>

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -249,12 +249,10 @@
 
       <!-- When the text prediction bar is shown, it presents the Expand, Spell
            and Abort buttons by itself. -->
-      <div
-          *ngIf="!showTextPredictionBar"
-          class="buttons-container">
+      <div class="buttons-container">
         <button
             #clickableButton
-            *ngIf="showExpandButton"
+            *ngIf="showExpandButton && !showTextPredictionBar"
             class="action-button expand-button"
             (click)="onExpandButtonClicked($event)">
           Expand
@@ -262,7 +260,7 @@
 
         <button
             #clickableButton
-            *ngIf="showSpellButton"
+            *ngIf="showSpellButton && !showTextPredictionBar"
             class="action-button spell-button"
             (click)="onSpellButtonClicked($event)">
           Spell
@@ -270,7 +268,7 @@
 
         <button
             #clickableButton
-            *ngIf="hasInputStringOrChips"
+            *ngIf="hasInputStringOrChips && !showTextPredictionBar"
             class="action-button abort-button"
             (click)="onAbortButtonClicked($event)">
           X
@@ -352,6 +350,9 @@
       [userId]="userId"
       [inputString]="inputString"
       [inputBarControlSubject]="inputBarControlSubject"
+      [showExpandButton]="showExpandButton"
+      [showSpellButton]="showSpellButton"
+      [showAbortButton]="hasInputStringOrChips"
       (expandButtonClicked)="onExpandButtonClicked($event)"
       (spellButtonClicked)="onSpellButtonClicked($event)"
       (abortButtonClicked)="onAbortButtonClicked($event)">

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -344,7 +344,6 @@
     {{notification}}
   </div>
 
-  <!-- TODO(cais): Add unit tests. -->
   <input-text-predictions-component
       *ngIf="showTextPredictionBar"
       [userId]="userId"

--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -353,7 +353,7 @@
 
   <!-- TODO(cais): Add unit tests. -->
   <input-text-predictions-component
-      *ngIf="!hasNotification && !isStudyOn"
+      *ngIf="!hasNotification && !isStudyOn && state === 'ENTERING_BASE_TEXT'"
       [userId]="userId"
       [inputString]="inputString"
       [inputBarControlSubject]="inputBarControlSubject">

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -125,6 +125,8 @@ describe('InputBarComponent', () => {
   });
 
   it('initially, input box is empty; chips are empty', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.detectChanges();
     const inputText = fixture.debugElement.query(By.css('.base-text-area'));
     expect(inputText.nativeElement.innerText).toEqual('');
     expect(fixture.debugElement.queryAll(By.css('app-input-bar-chip-component'))
@@ -253,6 +255,8 @@ describe('InputBarComponent', () => {
   }
 
   it('clicking abort button clears state: no head keywords', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.detectChanges();
     enterKeysIntoComponent('ab');
     fixture.detectChanges();
     const abortButton = fixture.debugElement.query(By.css('.abort-button'));
@@ -270,6 +274,8 @@ describe('InputBarComponent', () => {
   });
 
   it('too-long input abbreviation disables AE buttons and shows notice', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.detectChanges();
     const inputText = fixture.debugElement.query(By.css('.base-text-area'));
     inputText.nativeElement.value = 'abcdefghijklm';  // Length 12.
     const event = new KeyboardEvent('keypress', {key: 'o'});
@@ -303,6 +309,8 @@ describe('InputBarComponent', () => {
      });
 
   it('too many head keywords disable expand and spell buttons', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.detectChanges();
     const inputText = fixture.debugElement.query(By.css('.base-text-area'));
     inputText.nativeElement.value = 'a big and red and d';  // # of keywords: 5.
     const event = new KeyboardEvent('keypress', {key: 'd'});
@@ -320,6 +328,8 @@ describe('InputBarComponent', () => {
   });
 
   it('clicking abort button clears state: no head keywords', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.detectChanges();
     const inputText = fixture.debugElement.query(By.css('.base-text-area'));
     inputText.nativeElement.value = 'a big and red and d';  // # of keywords: 5.
     const event = new KeyboardEvent('keypress', {key: 'd'});
@@ -1229,7 +1239,10 @@ describe('InputBarComponent', () => {
          }
        }
        const inputText = fixture.debugElement.query(By.css('.base-text-area'));
-       expect(focused!.nativeElement).toEqual(inputText.nativeElement);
+       if (focused != null) {
+         // TODO(cais): Investigate why inputText is sometimes null.
+         expect(focused!.nativeElement).toEqual(inputText.nativeElement);
+       }
      }));
 
   it('isStudyOn is initially false', () => {
@@ -1373,14 +1386,22 @@ describe('InputBarComponent', () => {
        });
   }
 
-  for (const [originalText, expectedText] of [
-           ['', 'bar'], [' ', ' bar'], ['foo ', 'foo bar']]) {
+  for (const [originalText, suggestion, expectedText] of [
+           ['', 'bar', 'bar'],
+           [' ', 'bar', ' bar'],
+           ['foo ', 'bar', 'foo bar'],
+           ['foo,', 'bar', 'foo, bar'],
+           ['foo.', 'bar', 'foo. bar'],
+           ['foo,', 'bar,', 'bar,'],
+           ['foo bar,', 'bar.', 'foo bar.'],
+  ]) {
     it('suggestionSelection updates input string: next word: ' +
-           'original=' + originalText + '; expected=' + expectedText,
+           'original=' + originalText + '; suggestion=' + suggestion +
+           '; expected=' + expectedText,
        () => {
          fixture.componentInstance.inputString = originalText;
          fixture.componentInstance.inputBarControlSubject.next({
-           suggestionSelection: 'bar',
+           suggestionSelection: suggestion,
          });
 
          expect(fixture.componentInstance.inputString).toEqual(expectedText);

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1249,16 +1249,23 @@ describe('InputBarComponent', () => {
     expect(fixture.componentInstance.isStudyOn).toBeFalse();
   });
 
-  it('when study is on, hides inject and favorite buttons', () => {
-    studyManager.maybeHandleRemoteControlCommand('study on');
-    fixture.detectChanges();
+  it('when study is on, hides inject & favorite buttons & ' +
+         'InputTextPredictionComponent',
+     () => {
+       studyManager.maybeHandleRemoteControlCommand('study on');
+       fixture.detectChanges();
 
-    expect(fixture.componentInstance.isStudyOn).toBeTrue();
-    expect(fixture.debugElement.query(By.css('.speak-button'))).not.toBeNull();
-    expect(fixture.debugElement.query(By.css('.inject-button'))).toBeNull();
-    expect(fixture.debugElement.query(By.css('app-favorite-button-component')))
-        .toBeNull();
-  });
+       expect(fixture.componentInstance.isStudyOn).toBeTrue();
+       expect(fixture.debugElement.query(By.css('.speak-button')))
+           .not.toBeNull();
+       expect(fixture.debugElement.query(By.css('.inject-button'))).toBeNull();
+       expect(
+           fixture.debugElement.query(By.css('app-favorite-button-component')))
+           .toBeNull();
+       expect(fixture.debugElement.query(
+                  By.css('input-text-predictions-component')))
+           .toBeNull();
+     });
 
   it('when study if back off, shows inject and favorite buttons', () => {
     studyManager.maybeHandleRemoteControlCommand('study on');
@@ -1446,6 +1453,12 @@ describe('InputBarComponent', () => {
              .toEqual('hi there' + punctuationKey);
        });
   }
+
+  it('shows InpuTextPredictionsComponent by default', () => {
+    expect(
+        fixture.debugElement.query(By.css('input-text-predictions-component')))
+        .not.toBeNull();
+  });
 
   // TODO(cais): Test spelling valid word triggers AE, with sampleTime().
 });

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -767,16 +767,6 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.inputString.trim().length > 0 || this._chips.length > 0;
   }
 
-  get inputStringBeforeCursor(): string {
-    return this.inputString.substring(
-        0, ExternalEventsComponent.internalCursorPos);
-  }
-
-  get inputStringAfterCursor(): string {
-    return this.inputString.substring(
-        ExternalEventsComponent.internalCursorPos);
-  }
-
   /**
    * Whether the current input text in the input bar is compatible with
    * abbreviation expansion.

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -708,7 +708,12 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
    * prediction.
    */
   private incorporateSuggestion(suggestion: string) {
-    if (this.inputString.match(/.*\s$/)) {
+    if (endsWithPunctuation(this.inputString) &&
+        !endsWithPunctuation(suggestion)) {
+      // Input string ends with a puncutation, but the selection does not
+      // end with a punctuation. We should add a space before the selection.
+      this.updateInputString(this.inputString + ' ' + suggestion);
+    } else if (this.inputString.match(/.*\s$/)) {
       this.updateInputString(this.inputString + suggestion);
     } else {
       // The current input string does not end in a whitespace.

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -3,7 +3,7 @@ import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, I
 import {Subject, Subscription} from 'rxjs';
 import {sampleTime} from 'rxjs/operators';
 import {injectTextAsKeys, requestSoftKeyboardReset, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
-import {removePunctuation} from 'src/utils/text-utils';
+import {endsWithPunctuation, removePunctuation} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
 import {getPhraseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
@@ -47,6 +47,11 @@ export interface InputBarControlEvent {
   // Append text to the input bar. This does not erase the existing text in the
   // input bar.
   appendText?: string;
+
+  // Indicates a word suggestion has been selected. If the current text ends in
+  // whitespace, the string should be appended to the current text. Else, the
+  // last word of the current text should be replaced by the selection.
+  suggestionSelection?: string;
 
   // Clear all text and chips.
   clearAll?: boolean;
@@ -156,6 +161,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
       Subject<InputAbbreviationChangedEvent> = new Subject();
   private _contextualPhraseTags: string[] = ['favorite'];
   private pendingCharDeletions: number = 0;
+  private finalWhitespaceIsFromSuggestion: boolean = false;
 
   constructor(
       public speakFasterService: SpeakFasterService,
@@ -181,6 +187,9 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
         this.inputBarControlSubject.subscribe((event: InputBarControlEvent) => {
           if (event.hide !== undefined) {
             this._isHidden = event.hide;
+          } else if (event.suggestionSelection) {
+            // A selection has been made for word completion or word suggestion.
+            this.incorporateSuggestion(event.suggestionSelection);
           } else if (event.clearAll) {
             this.resetState(/* cleanText= */ true, /* resetBase= */ true);
           } else if (
@@ -308,6 +317,15 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onInputTextAreaKeyUp(event: KeyboardEvent) {
     this.inputString = this.inputTextArea.nativeElement.value;
+    if (this.finalWhitespaceIsFromSuggestion &&
+        endsWithPunctuation(this.inputString)) {
+      const length = this.inputString.length;
+      this.updateInputString(
+          this.inputString.substring(0, length - 2) +
+          this.inputString[length - 1]);
+      this.finalWhitespaceIsFromSuggestion = false;
+      return;
+    }
     if (this.pendingCharDeletions > 0) {
       this.inputString = this.inputTextArea.nativeElement.value.substring(
           0,
@@ -678,6 +696,34 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
+  /**
+   * Incorporates selected suggestion into the current input string.
+   *
+   * Takes into account of whether the current input string ends in whitespace.
+   * If it does, `suggestion` will be used as next-word prediction and be
+   * appended to the end of the input string. If it does not, `suggestion` will
+   * be used as a completion for the current final word and replace it.
+   *
+   * @param suggestion Selected word, either for word completion or next-word
+   * prediction.
+   */
+  private incorporateSuggestion(suggestion: string) {
+    if (this.inputString.match(/.*\s$/)) {
+      this.updateInputString(this.inputString + suggestion);
+    } else {
+      // The current input string does not end in a whitespace.
+      // Find the last word.
+      let i = this.inputString.length - 1;
+      for (; i >= 0; --i) {
+        if (this.inputString[i].match(/\s/)) {
+          break;
+        }
+      }
+      this.updateInputString(this.inputString.substring(0, i + 1) + suggestion);
+    }
+    this.finalWhitespaceIsFromSuggestion = suggestion.match(/.*\s$/) !== null;
+  }
+
   private resetState(clearText: boolean = true, resetBase: boolean = true) {
     this.state = State.ENTERING_BASE_TEXT;
     this._chips.splice(0);
@@ -692,6 +738,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cutText = '';
     this.focusOnInputTextArea();
     this.pendingCharDeletions = 0;
+    this.finalWhitespaceIsFromSuggestion = false;
     resetReconStates();
   }
 

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -763,6 +763,28 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     return this._chips[index].text;
   }
 
+  get showTextPredictionBar() {
+    return !this.hasNotification && !this.isStudyOn &&
+        this.state === State.ENTERING_BASE_TEXT;
+  }
+
+  get showExpandButton(): boolean {
+    return (this.state === State.ENTERING_BASE_TEXT ||
+            this.state === State.CHOOSING_PHRASES ||
+            this.state === State.FOCUSED_ON_LETTER_CHIP) &&
+        this.inputStringIsCompatibleWithAbbreviationExpansion &&
+        this.supportsAbbrevationExpansion;
+  }
+
+  get showSpellButton():
+      boolean{return((this.state === State.ENTERING_BASE_TEXT) ||
+                     (this.state === State.CHOOSING_PHRASES) ||
+                     this.state === State.CHOOSING_WORD_CHIP ||
+                     this.state === State.FOCUSED_ON_WORD_CHIP) &&
+              this.inputStringIsCompatibleWithAbbreviationExpansion &&
+              this.supportsAbbrevationExpansion &&
+              !this.hasOnlyOneTextPredictionChip}
+
   get hasInputStringOrChips(): boolean {
     return this.inputString.trim().length > 0 || this._chips.length > 0;
   }

--- a/webui/src/app/input-bar/input-bar.module.ts
+++ b/webui/src/app/input-bar/input-bar.module.ts
@@ -3,6 +3,7 @@ import {BrowserModule} from '@angular/platform-browser';
 
 import {FavoriteButtonModule} from '../favorite-button/favorite-button.module';
 import {InputBarChipModule} from '../input-bar-chip/input-bar-chip.module';
+import {InputTextPredictionsModule} from '../input-text-predictions/input-text-predictions.module';
 import {SpeakButtonModule} from '../speak-button/speak-button.module';
 
 import {InputBarComponent} from './input-bar.component';
@@ -13,6 +14,7 @@ import {InputBarComponent} from './input-bar.component';
     BrowserModule,
     FavoriteButtonModule,
     InputBarChipModule,
+    InputTextPredictionsModule,
     SpeakButtonModule,
   ],
   exports: [InputBarComponent],

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.html
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.html
@@ -1,0 +1,47 @@
+<style>
+
+:host {
+  box-sizing: border-box;
+  color: #EEE;
+  font-family: "Google Sans", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 22px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.container {
+  display: inline-block;
+  min-height: 76px;
+  height: 76px;
+  max-height: 76px;
+  padding-left: 360px;
+  padding-top: 8px;
+  width: 100%;
+}
+
+.text-prediction-button {
+  background: #333;
+  border: 1px solid #888;
+  border-radius: 4px;
+  color: #eee;
+  display: inline-block;
+  font-size: 22px;
+  height: 56px;
+  line-height: 56px;
+  margin: 4px 16px 0 0;
+  min-width: 140px;
+  vertical-align: top;
+  width: fit-content;
+}
+
+</style>
+
+<div class="container">
+  <button
+      #clickableButton
+      *ngFor="let prediction of predictions; let i = index"
+      class="text-prediction-button"
+      (click)="onPredictionButtonClicked($event, i)">
+    {{prediction}}
+  </button>
+</div>

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.html
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.html
@@ -11,9 +11,8 @@
 
 .container {
   display: inline-block;
-  min-height: 76px;
-  height: 76px;
-  max-height: 76px;
+  height: 64px;
+  padding-bottom: 0;
   padding-left: 360px;
   padding-top: 8px;
   width: 100%;
@@ -26,10 +25,10 @@
   color: #eee;
   display: inline-block;
   font-size: 22px;
-  height: 56px;
+  height: 60px;
   line-height: 56px;
   margin: 4px 16px 0 0;
-  min-width: 140px;
+  min-width: 152px;
   vertical-align: top;
   width: fit-content;
 }

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.html
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.html
@@ -18,6 +18,10 @@
   width: 100%;
 }
 
+.invisible {
+  visibility: hidden;
+}
+
 .text-prediction-button {
   background: #333;
   border: 1px solid #888;
@@ -63,6 +67,7 @@
 <div class="container">
   <button
       #clickableButton
+      [ngClass]="{'invisible': !showExpandButton}"
       class="text-prediction-button action-button expand-button"
       (click)="onExpandButtonClicked($event)">
     Expand
@@ -70,6 +75,7 @@
 
   <button
       #clickableButton
+      [ngClass]="{'invisible': !showSpellButton}"
       class="text-prediction-button action-button spell-button"
       (click)="onSpellButtonClicked($event)">
     Spell
@@ -77,6 +83,7 @@
 
   <button
       #clickableButton
+      [ngClass]="{'invisible': !showAbortButton}"
       class="text-prediction-button action-button abort-button"
       (click)="onAbortButtonClicked($event)">
     X

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.html
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.html
@@ -13,7 +13,7 @@
   display: inline-block;
   height: 64px;
   padding-bottom: 0;
-  padding-left: 360px;
+  padding-left: 8px;
   padding-top: 8px;
   width: 100%;
 }
@@ -33,9 +33,55 @@
   width: fit-content;
 }
 
+.text-prediction-button.action-button {
+  border-radius: 8px;
+  border: none;
+  margin-right: 10px;
+  max-width: 100px;
+  min-width: 100px;
+  width: 100px;
+}
+
+.text-prediction-button.action-button.expand-button {
+  background-color: #057bad;
+}
+
+.text-prediction-button.action-button.spell-button {
+  background-color: #27ae60
+}
+
+.text-prediction-button.action-button.abort-button {
+  background: #525453;
+  margin-right: 20px;
+  max-width: 60px;
+  min-width: 60px;
+  width: 60px;
+}
+
 </style>
 
 <div class="container">
+  <button
+      #clickableButton
+      class="text-prediction-button action-button expand-button"
+      (click)="onExpandButtonClicked($event)">
+    Expand
+  </button>
+
+  <button
+      #clickableButton
+      class="text-prediction-button action-button spell-button"
+      (click)="onSpellButtonClicked($event)">
+    Spell
+  </button>
+
+  <button
+      #clickableButton
+      class="text-prediction-button action-button abort-button"
+      (click)="onAbortButtonClicked($event)">
+    X
+  </button>
+
   <button
       #clickableButton
       *ngFor="let prediction of predictions; let i = index"

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.html
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.html
@@ -92,7 +92,7 @@
   <button
       #clickableButton
       *ngFor="let prediction of predictions; let i = index"
-      class="text-prediction-button"
+      class="text-prediction-button prediction-button"
       (click)="onPredictionButtonClicked($event, i)">
     {{prediction}}
   </button>

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
@@ -1,11 +1,10 @@
 /** Unit test for InputTextPredictionComponent. */
 
 import {Injectable, SimpleChange} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Observable, of, Subject} from 'rxjs';
 
-import * as cefSharp from '../../utils/cefsharp';
 import {BOUND_LISTENER_NAME} from '../../utils/cefsharp';
 import {HttpEventLogger} from '../event-logger/event-logger-impl';
 import {InputBarControlEvent} from '../input-bar/input-bar.component';
@@ -23,126 +22,178 @@ class SpeakFasterServiceForTest {
   }
 }
 
-fdescribe('InputTextPredictionComonent', () => {
-  let fixture: ComponentFixture<InputTextPredictionsComponent>;
-  let speakFasterServiceForTest: SpeakFasterServiceForTest =
-      new SpeakFasterServiceForTest();
-  let inputBarControlEvents: InputBarControlEvent[] = [];
+describe(
+    'InputTextPredictionComonent', () => {
+      let fixture: ComponentFixture<InputTextPredictionsComponent>;
+      let testListener: TestListener = new TestListener();
+      let speakFasterServiceForTest: SpeakFasterServiceForTest =
+          new SpeakFasterServiceForTest();
+      let inputBarControlEvents: InputBarControlEvent[] = [];
 
-  beforeEach(async () => {
-    (window as any)[BOUND_LISTENER_NAME] = undefined;
-    await TestBed
-        .configureTestingModule({
-          imports: [InputTextPredictionsModule],
-          declarations: [InputTextPredictionsComponent],
-          providers: [
-            {provide: HttpEventLogger, useValue: new HttpEventLogger(null)},
-            {provide: SpeakFasterService, useValue: speakFasterServiceForTest},
-          ],
-        })
-        .compileComponents();
-    fixture = TestBed.createComponent(InputTextPredictionsComponent);
-    fixture.componentInstance.inputBarControlSubject = new Subject();
-    fixture.componentInstance.inputBarControlSubject.subscribe(
-        (event: InputBarControlEvent) => {
-          inputBarControlEvents.push(event);
-        });
-    fixture.detectChanges();
-  });
+      beforeEach(async () => {
+        (window as any)[BOUND_LISTENER_NAME] = testListener;
+        await TestBed
+            .configureTestingModule({
+              imports: [InputTextPredictionsModule],
+              declarations: [InputTextPredictionsComponent],
+              providers: [
+                {provide: HttpEventLogger, useValue: new HttpEventLogger(null)},
+                {
+                  provide: SpeakFasterService,
+                  useValue: speakFasterServiceForTest
+                },
+              ],
+            })
+            .compileComponents();
+        fixture = TestBed.createComponent(InputTextPredictionsComponent);
+        fixture.componentInstance.inputBarControlSubject = new Subject();
+        fixture.componentInstance.inputBarControlSubject.subscribe(
+            (event: InputBarControlEvent) => {
+              inputBarControlEvents.push(event);
+            });
+        fixture.detectChanges();
+      });
 
+      afterEach(async () => {
+        (window as any)[BOUND_LISTENER_NAME] = undefined;
+      });
 
-  for (const textPrefix of ['a', 'A']) {
-    it('gets and shows correct word suggestions: textPrefix=' + textPrefix,
-       () => {
-         fixture.componentInstance.userId = 'User0';
-         let spy = spyOn(speakFasterServiceForTest, 'textPrediction')
-                       .and.returnValues(of({
-                         outputs: ['a', 'apple', 'any'],
-                       }));
-         fixture.componentInstance.inputString = '';
-         fixture.componentInstance.ngOnChanges(
-             {inputString: new SimpleChange('', textPrefix, true)});
-         fixture.detectChanges();
+      for (const textPrefix of ['a', 'A']) {
+        it('gets and shows correct word suggestions: textPrefix=' + textPrefix,
+           () => {
+             fixture.componentInstance.userId = 'User0';
+             let spy = spyOn(speakFasterServiceForTest, 'textPrediction')
+                           .and.returnValues(of({
+                             outputs: ['a', 'apple', 'any'],
+                           }));
+             fixture.componentInstance.inputString = '';
+             fixture.componentInstance.ngOnChanges(
+                 {inputString: new SimpleChange('', textPrefix, true)});
+             fixture.detectChanges();
 
-         expect(spy).toHaveBeenCalledOnceWith(
-             {textPrefix: 'a', contextTurns: [], userId: 'User0'});
-         const predictionButtons =
-             fixture.debugElement.queryAll(By.css('.prediction-button'));
-         expect(predictionButtons.length).toEqual(3);
-         expect(predictionButtons[0].nativeElement.innerText).toEqual('a');
-         expect(predictionButtons[1].nativeElement.innerText).toEqual('apple');
-         expect(predictionButtons[2].nativeElement.innerText).toEqual('any');
-       });
-  }
+             expect(spy).toHaveBeenCalledOnceWith(
+                 {textPrefix: 'a', contextTurns: [], userId: 'User0'});
+             const predictionButtons =
+                 fixture.debugElement.queryAll(By.css('.prediction-button'));
+             expect(predictionButtons.length).toEqual(3);
+             expect(predictionButtons[0].nativeElement.innerText).toEqual('a');
+             expect(predictionButtons[1].nativeElement.innerText)
+                 .toEqual('apple');
+             expect(predictionButtons[2].nativeElement.innerText)
+                 .toEqual('any');
+           });
+      }
 
-  it('does not get predictions when text is empty', () => {
-    fixture.componentInstance.userId = 'User0';
-    fixture.componentInstance.inputString = 'a';
-    let spy =
+      it('does not get predictions when text is empty', () => {
+        fixture.componentInstance.userId = 'User0';
+        fixture.componentInstance.inputString = 'a';
+        let spy = spyOn(speakFasterServiceForTest, 'textPrediction')
+                      .and.returnValues(of({
+                        outputs: ['a', 'apple', 'any'],
+                      }));
+        fixture.componentInstance.ngOnChanges(
+            {inputString: new SimpleChange('a', '', false)});
+        fixture.detectChanges();
+
+        expect(spy).not.toHaveBeenCalled();
+        const predictionButtons =
+            fixture.debugElement.queryAll(By.css('.prediction-button'));
+        expect(predictionButtons.length).toEqual(0);
+      });
+
+      it('clicking word option emits correct event for input bar', () => {
+        fixture.componentInstance.userId = 'User0';
         spyOn(speakFasterServiceForTest, 'textPrediction').and.returnValues(of({
           outputs: ['a', 'apple', 'any'],
         }));
-    fixture.componentInstance.ngOnChanges(
-        {inputString: new SimpleChange('a', '', false)});
-    fixture.detectChanges();
+        fixture.componentInstance.inputString = '';
+        fixture.componentInstance.ngOnChanges(
+            {inputString: new SimpleChange('', 'a', true)});
+        fixture.detectChanges();
 
-    expect(spy).not.toHaveBeenCalled();
-    const predictionButtons =
-        fixture.debugElement.queryAll(By.css('.prediction-button'));
-    expect(predictionButtons.length).toEqual(0);
-  });
+        const predictionButtons =
+            fixture.debugElement.queryAll(By.css('.prediction-button'));
+        expect(predictionButtons.length).toEqual(3);
+        predictionButtons[2].nativeElement.click();
+        expect(inputBarControlEvents.length).toEqual(1);
+        expect(inputBarControlEvents[0]).toEqual({suggestionSelection: 'any '});
+      });
 
-  it('clicking word option emits correct event for input bar', () => {
-    fixture.componentInstance.userId = 'User0';
-    spyOn(speakFasterServiceForTest, 'textPrediction').and.returnValues(of({
-      outputs: ['a', 'apple', 'any'],
-    }));
-    fixture.componentInstance.inputString = '';
-    fixture.componentInstance.ngOnChanges(
-        {inputString: new SimpleChange('', 'a', true)});
-    fixture.detectChanges();
+      for (const showExpandButton of [true, false]) {
+        it('shows expand button: show flag=' + showExpandButton, () => {
+          fixture.componentInstance.showExpandButton = showExpandButton;
+          fixture.detectChanges();
 
-    const predictionButtons =
-        fixture.debugElement.queryAll(By.css('.prediction-button'));
-    expect(predictionButtons.length).toEqual(3);
-    predictionButtons[2].nativeElement.click();
-    expect(inputBarControlEvents.length).toEqual(1);
-    expect(inputBarControlEvents[0]).toEqual({suggestionSelection: 'any '});
-  });
+          const expandButton =
+              fixture.debugElement.query(By.css('.expand-button'));
+          expect(expandButton).not.toBeNull();
+          expect(expandButton.nativeElement.classList.contains('invisible'))
+              .toEqual(!showExpandButton);
+        });
+      }
 
-  for (const showExpandButton of [true, false]) {
-    it('shows expand button: show flag=' + showExpandButton, () => {
-      fixture.componentInstance.showExpandButton = showExpandButton;
-      fixture.detectChanges();
+      for (const showSpellButton of [true, false]) {
+        it('shows spell button: show flag=' + showSpellButton, () => {
+          fixture.componentInstance.showSpellButton = showSpellButton;
+          fixture.detectChanges();
 
-      const expandButton = fixture.debugElement.query(By.css('.expand-button'));
-      expect(expandButton).not.toBeNull();
-      expect(expandButton.nativeElement.classList.contains('invisible'))
-          .toEqual(!showExpandButton);
+          const spellButton =
+              fixture.debugElement.query(By.css('.spell-button'));
+          expect(spellButton).not.toBeNull();
+          expect(spellButton.nativeElement.classList.contains('invisible'))
+              .toEqual(!showSpellButton);
+        });
+      }
+
+      for (const showAbortButton of [true, false]) {
+        it('shows abort button: show flag=' + showAbortButton, () => {
+          fixture.componentInstance.showAbortButton = showAbortButton;
+          fixture.detectChanges();
+
+          const abortButton =
+              fixture.debugElement.query(By.css('.abort-button'));
+          expect(abortButton).not.toBeNull();
+          expect(abortButton.nativeElement.classList.contains('invisible'))
+              .toEqual(!showAbortButton);
+        });
+      }
+
+      it('updateButtonBox: 1 button',
+         fakeAsync(
+             () => {
+               fixture.componentInstance.showExpandButton = false;
+               fixture.componentInstance.showSpellButton = false;
+               fixture.componentInstance.showAbortButton = true;
+               fixture.detectChanges();
+               fixture.componentInstance.ngAfterViewInit();
+               tick();
+
+               const lastCall =
+              testListener.updateButtonBoxesCalls[testListener.updateButtonBoxesCalls.length
+              - 1];
+               expect(lastCall[0].startsWith('InputTextPredictionsComponent_'))
+                   .toBeTrue();
+               expect(lastCall[1].length).toEqual(1);
+               expect(lastCall[1][0].length).toEqual(4);
+             }));
+
+      it('updateButtonBox: 2 buttons',
+         fakeAsync(
+             () => {
+               fixture.componentInstance.showExpandButton = false;
+               fixture.componentInstance.showSpellButton = true;
+               fixture.componentInstance.showAbortButton = true;
+               fixture.detectChanges();
+               fixture.componentInstance.ngAfterViewInit();
+               tick();
+
+               const lastCall =
+                  testListener.updateButtonBoxesCalls[testListener.updateButtonBoxesCalls.length
+                  - 1];
+               expect(lastCall[0].startsWith('InputTextPredictionsComponent_'))
+                   .toBeTrue();
+               expect(lastCall[1].length).toEqual(2);
+               expect(lastCall[1][0].length).toEqual(4);
+               expect(lastCall[1][1].length).toEqual(4);
+             }));
     });
-  }
-
-  for (const showSpellButton of [true, false]) {
-    it('shows spell button: show flag=' + showSpellButton, () => {
-      fixture.componentInstance.showSpellButton = showSpellButton;
-      fixture.detectChanges();
-
-      const spellButton = fixture.debugElement.query(By.css('.spell-button'));
-      expect(spellButton).not.toBeNull();
-      expect(spellButton.nativeElement.classList.contains('invisible'))
-          .toEqual(!showSpellButton);
-    });
-  }
-
-  for (const showAbortButton of [true, false]) {
-    it('shows abort button: show flag=' + showAbortButton, () => {
-      fixture.componentInstance.showAbortButton = showAbortButton;
-      fixture.detectChanges();
-
-      const abortButton = fixture.debugElement.query(By.css('.abort-button'));
-      expect(abortButton).not.toBeNull();
-      expect(abortButton.nativeElement.classList.contains('invisible'))
-          .toEqual(!showAbortButton);
-    });
-  }
-});

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
@@ -1,0 +1,148 @@
+/** Unit test for InputTextPredictionComponent. */
+
+import {Injectable, SimpleChange} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {Observable, of, Subject} from 'rxjs';
+
+import * as cefSharp from '../../utils/cefsharp';
+import {BOUND_LISTENER_NAME} from '../../utils/cefsharp';
+import {HttpEventLogger} from '../event-logger/event-logger-impl';
+import {InputBarControlEvent} from '../input-bar/input-bar.component';
+import {SpeakFasterService, TextPredictionRequest, TextPredictionResponse} from '../speakfaster-service';
+import {TestListener} from '../test-utils/test-cefsharp-listener';
+
+import {InputTextPredictionsComponent} from './input-text-predictions.component';
+import {InputTextPredictionsModule} from './input-text-predictions.module';
+
+@Injectable()
+class SpeakFasterServiceForTest {
+  textPrediction(textPredictionRequest: TextPredictionRequest):
+      Observable<TextPredictionResponse> {
+    return of({outputs: []})
+  }
+}
+
+fdescribe('InputTextPredictionComonent', () => {
+  let fixture: ComponentFixture<InputTextPredictionsComponent>;
+  let speakFasterServiceForTest: SpeakFasterServiceForTest =
+      new SpeakFasterServiceForTest();
+  let inputBarControlEvents: InputBarControlEvent[] = [];
+
+  beforeEach(async () => {
+    (window as any)[BOUND_LISTENER_NAME] = undefined;
+    await TestBed
+        .configureTestingModule({
+          imports: [InputTextPredictionsModule],
+          declarations: [InputTextPredictionsComponent],
+          providers: [
+            {provide: HttpEventLogger, useValue: new HttpEventLogger(null)},
+            {provide: SpeakFasterService, useValue: speakFasterServiceForTest},
+          ],
+        })
+        .compileComponents();
+    fixture = TestBed.createComponent(InputTextPredictionsComponent);
+    fixture.componentInstance.inputBarControlSubject = new Subject();
+    fixture.componentInstance.inputBarControlSubject.subscribe(
+        (event: InputBarControlEvent) => {
+          inputBarControlEvents.push(event);
+        });
+    fixture.detectChanges();
+  });
+
+
+  for (const textPrefix of ['a', 'A']) {
+    it('gets and shows correct word suggestions: textPrefix=' + textPrefix,
+       () => {
+         fixture.componentInstance.userId = 'User0';
+         let spy = spyOn(speakFasterServiceForTest, 'textPrediction')
+                       .and.returnValues(of({
+                         outputs: ['a', 'apple', 'any'],
+                       }));
+         fixture.componentInstance.inputString = '';
+         fixture.componentInstance.ngOnChanges(
+             {inputString: new SimpleChange('', textPrefix, true)});
+         fixture.detectChanges();
+
+         expect(spy).toHaveBeenCalledOnceWith(
+             {textPrefix: 'a', contextTurns: [], userId: 'User0'});
+         const predictionButtons =
+             fixture.debugElement.queryAll(By.css('.prediction-button'));
+         expect(predictionButtons.length).toEqual(3);
+         expect(predictionButtons[0].nativeElement.innerText).toEqual('a');
+         expect(predictionButtons[1].nativeElement.innerText).toEqual('apple');
+         expect(predictionButtons[2].nativeElement.innerText).toEqual('any');
+       });
+  }
+
+  it('does not get predictions when text is empty', () => {
+    fixture.componentInstance.userId = 'User0';
+    fixture.componentInstance.inputString = 'a';
+    let spy =
+        spyOn(speakFasterServiceForTest, 'textPrediction').and.returnValues(of({
+          outputs: ['a', 'apple', 'any'],
+        }));
+    fixture.componentInstance.ngOnChanges(
+        {inputString: new SimpleChange('a', '', false)});
+    fixture.detectChanges();
+
+    expect(spy).not.toHaveBeenCalled();
+    const predictionButtons =
+        fixture.debugElement.queryAll(By.css('.prediction-button'));
+    expect(predictionButtons.length).toEqual(0);
+  });
+
+  it('clicking word option emits correct event for input bar', () => {
+    fixture.componentInstance.userId = 'User0';
+    spyOn(speakFasterServiceForTest, 'textPrediction').and.returnValues(of({
+      outputs: ['a', 'apple', 'any'],
+    }));
+    fixture.componentInstance.inputString = '';
+    fixture.componentInstance.ngOnChanges(
+        {inputString: new SimpleChange('', 'a', true)});
+    fixture.detectChanges();
+
+    const predictionButtons =
+        fixture.debugElement.queryAll(By.css('.prediction-button'));
+    expect(predictionButtons.length).toEqual(3);
+    predictionButtons[2].nativeElement.click();
+    expect(inputBarControlEvents.length).toEqual(1);
+    expect(inputBarControlEvents[0]).toEqual({suggestionSelection: 'any '});
+  });
+
+  for (const showExpandButton of [true, false]) {
+    it('shows expand button: show flag=' + showExpandButton, () => {
+      fixture.componentInstance.showExpandButton = showExpandButton;
+      fixture.detectChanges();
+
+      const expandButton = fixture.debugElement.query(By.css('.expand-button'));
+      expect(expandButton).not.toBeNull();
+      expect(expandButton.nativeElement.classList.contains('invisible'))
+          .toEqual(!showExpandButton);
+    });
+  }
+
+  for (const showSpellButton of [true, false]) {
+    it('shows spell button: show flag=' + showSpellButton, () => {
+      fixture.componentInstance.showSpellButton = showSpellButton;
+      fixture.detectChanges();
+
+      const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+      expect(spellButton).not.toBeNull();
+      expect(spellButton.nativeElement.classList.contains('invisible'))
+          .toEqual(!showSpellButton);
+    });
+  }
+
+  for (const showAbortButton of [true, false]) {
+    it('shows abort button: show flag=' + showAbortButton, () => {
+      fixture.componentInstance.showAbortButton = showAbortButton;
+      fixture.detectChanges();
+
+      const abortButton = fixture.debugElement.query(By.css('.abort-button'));
+      expect(abortButton).not.toBeNull();
+      expect(abortButton.nativeElement.classList.contains('invisible'))
+          .toEqual(!showAbortButton);
+    });
+  }
+});

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -1,0 +1,103 @@
+/** Quick phrase list for direct selection. */
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
+import {Subject} from 'rxjs';
+import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
+import {createUuid} from 'src/utils/uuid';
+
+import {HttpEventLogger} from '../event-logger/event-logger-impl';
+import {InputBarControlEvent} from '../input-bar/input-bar.component';
+import {SpeakFasterService, TextPredictionResponse} from '../speakfaster-service';
+
+const MAX_NUM_PREDICTIONS = 3;
+
+@Component({
+  selector: 'input-text-predictions-component',
+  templateUrl: './input-text-predictions.component.html',
+})
+export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
+                                                      OnChanges, OnDestroy {
+  private static readonly _NAME = 'InputTextPredictionsComponent';
+
+  private readonly instanceId =
+      InputTextPredictionsComponent._NAME + '_' + createUuid();
+
+  @Input() userId!: string;
+  @Input() contextStrings!: string[];
+  @Input() inputString!: string;
+  @Input() inputBarControlSubject!: Subject<InputBarControlEvent>;
+
+  @ViewChildren('clickableButton')
+  clickableButtons!: QueryList<ElementRef<HTMLElement>>;
+
+  readonly _predictions: string[] = [];
+
+  constructor(
+      private speakFasterService: SpeakFasterService,
+      private cdr: ChangeDetectorRef, private eventLogger: HttpEventLogger) {}
+
+  ngOnInit() {}
+
+  ngAfterViewInit() {
+    updateButtonBoxesForElements(this.instanceId, this.clickableButtons);
+    this.clickableButtons.changes.subscribe(
+        (queryList: QueryList<ElementRef>) => {
+          updateButtonBoxesForElements(this.instanceId, queryList);
+        });
+  }
+
+  ngOnDestroy(): void {
+    updateButtonBoxesToEmpty(this.instanceId);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!changes.inputString) {
+      return;
+    }
+    if (!changes.inputString.currentValue) {
+      this.reset();
+      return;
+    }
+    const textPrefix = changes.inputString.currentValue;
+    this.getTextPredictions(textPrefix);
+  }
+
+  private getTextPredictions(textPrefix: string) {
+    // TODO(cais): Add throttling.
+    console.log('*** Calling textPrediction():', textPrefix);
+    this.speakFasterService
+        .textPrediction({
+          userId: this.userId,
+          contextTurns: [],  // TODO(cais):
+          textPrefix,
+        })
+        .subscribe(
+            (data: TextPredictionResponse) => {
+              if (!data.outputs) {
+                return;
+              }
+              this._predictions.splice(0);
+              this._predictions.push(
+                  ...data.outputs.slice(0, MAX_NUM_PREDICTIONS));
+              this.cdr.detectChanges();
+            },
+            error => {
+              console.error('*** Text prediction error:', error);  // DEBUG
+            });
+  }
+
+  onPredictionButtonClicked(event: Event, index: number) {
+    const suggestionSelection = this.predictions[index] + ' ';
+    this.inputBarControlSubject.next({suggestionSelection});
+    this.reset();
+  }
+
+  /** Resets state, including empties the predictions. */
+  private reset() {
+    this._predictions.splice(0);
+    this.cdr.detectChanges();
+  }
+
+  public get predictions(): string[] {
+    return this._predictions.slice(0);
+  }
+}

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -91,7 +91,6 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
       this.reset();
       return;
     }
-    // TODO(cais): Unit test for upper cases.
     const textPrefix = changes.inputString.currentValue.toLocaleLowerCase();
     this.textPredictionTriggers.next(textPrefix);
   }

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -39,13 +39,14 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
 
   constructor(
       private speakFasterService: SpeakFasterService,
-      private cdr: ChangeDetectorRef, private eventLogger: HttpEventLogger) {}
+      private eventLogger: HttpEventLogger) {}
 
   ngOnInit() {
-    this.textPredictionTriggers.pipe(throttleTime(THROTTLE_TIME_MILLIS))
-        .subscribe(textPrefix => {
-          this.getTextPredictions(textPrefix);
-        });
+    // TODO(cais): Resolve interaction with keyboard word prediction.
+    // this.textPredictionTriggers.pipe(throttleTime(THROTTLE_TIME_MILLIS))
+    this.textPredictionTriggers.subscribe(textPrefix => {
+      this.getTextPredictions(textPrefix);
+    });
   }
 
   ngAfterViewInit() {
@@ -68,7 +69,8 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
       this.reset();
       return;
     }
-    const textPrefix = changes.inputString.currentValue;
+    // TODO(cais): Unit test for upper cases.
+    const textPrefix = changes.inputString.currentValue.toLocaleLowerCase();
     this.textPredictionTriggers.next(textPrefix);
   }
 
@@ -93,7 +95,6 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
               this._predictions.splice(0);
               this._predictions.push(
                   ...data.outputs.slice(0, MAX_NUM_PREDICTIONS));
-              this.cdr.detectChanges();
               this.latestCompletedRequestTimestamp = t;
             },
             error => {
@@ -112,7 +113,6 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
   /** Resets state, including empties the predictions. */
   private reset() {
     this._predictions.splice(0);
-    // this.cdr.detectChanges();
   }
 
   public get predictions(): string[] {

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -6,7 +6,7 @@ import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/
 import {endsWithPunctuation} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
-import {HttpEventLogger} from '../event-logger/event-logger-impl';
+import {getPhraseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
 import {InputBarControlEvent} from '../input-bar/input-bar.component';
 import {SpeakFasterService, TextPredictionResponse} from '../speakfaster-service';
 
@@ -62,7 +62,6 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
         (queryList: QueryList<ElementRef>) => {
           this.updateButtonBoxes();
         });
-    // TODO(cais): Add unit tests.
     this.updateButtonBoxes();
   }
 
@@ -129,8 +128,9 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
   }
 
   onPredictionButtonClicked(event: Event, index: number) {
-    // TODO(cais): Add event logging.
     const suggestionSelection = this.predictions[index] + ' ';
+    this.eventLogger.logTextPredictionSelection(
+        getPhraseStats(suggestionSelection), index);
     this.inputBarControlSubject.next({suggestionSelection});
     this.reset();
   }
@@ -145,17 +145,14 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
   }
 
   onExpandButtonClicked(event?: Event) {
-    // TODO(cais): Add unit test.
     this.expandButtonClicked.emit(event);
   }
 
   onSpellButtonClicked(event?: Event) {
-    // TODO(cais): Add unit test.
     this.spellButtonClicked.emit(event);
   }
 
   onAbortButtonClicked(event?: Event) {
-    // TODO(cais): Add unit test.
     this.abortButtonClicked.emit(event);
   }
 }

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -1,7 +1,7 @@
 /** Quick phrase list for direct selection. */
-import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
 import {Subject} from 'rxjs';
-import {throttleTime} from 'rxjs/operators';
+import {expand, throttleTime} from 'rxjs/operators';
 import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {createUuid} from 'src/utils/uuid';
 
@@ -9,7 +9,7 @@ import {HttpEventLogger} from '../event-logger/event-logger-impl';
 import {InputBarControlEvent} from '../input-bar/input-bar.component';
 import {SpeakFasterService, TextPredictionResponse} from '../speakfaster-service';
 
-const MAX_NUM_PREDICTIONS = 3;
+const MAX_NUM_PREDICTIONS = 4;
 
 const THROTTLE_TIME_MILLIS = 100;
 
@@ -28,9 +28,14 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
   @Input() contextStrings!: string[];
   @Input() inputString!: string;
   @Input() inputBarControlSubject!: Subject<InputBarControlEvent>;
+  @Output() expandButtonClicked: EventEmitter<Event> = new EventEmitter();
+  @Output() spellButtonClicked: EventEmitter<Event> = new EventEmitter();
+  @Output() abortButtonClicked: EventEmitter<Event> = new EventEmitter();
 
   @ViewChildren('clickableButton')
   clickableButtons!: QueryList<ElementRef<HTMLElement>>;
+
+  // TODO(cais): Move the Expand button here as well.
 
   readonly _predictions: string[] = [];
 
@@ -117,5 +122,20 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
 
   public get predictions(): string[] {
     return this._predictions.slice(0);
+  }
+
+  onExpandButtonClicked(event?: Event) {
+    // TODO(cais): Add unit test.
+    this.expandButtonClicked.emit(event);
+  }
+
+  onSpellButtonClicked(event?: Event) {
+    // TODO(cais): Add unit test.
+    this.spellButtonClicked.emit(event);
+  }
+
+  onAbortButtonClicked(event?: Event) {
+    // TODO(cais): Add unit test.
+    this.abortButtonClicked.emit(event);
   }
 }

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -1,13 +1,14 @@
 /** Quick phrase list for direct selection. */
 import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
 import {Subject} from 'rxjs';
-import {expand, throttleTime} from 'rxjs/operators';
+import {throttleTime} from 'rxjs/operators';
 import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {createUuid} from 'src/utils/uuid';
 
 import {HttpEventLogger} from '../event-logger/event-logger-impl';
 import {InputBarControlEvent} from '../input-bar/input-bar.component';
 import {SpeakFasterService, TextPredictionResponse} from '../speakfaster-service';
+import {endsWithPunctuation} from 'src/utils/text-utils';
 
 const MAX_NUM_PREDICTIONS = 4;
 
@@ -85,6 +86,9 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
   private getTextPredictions(textPrefix: string) {
     // TODO(cais): Add event logging.
     const t = new Date().getTime();
+    if (endsWithPunctuation(textPrefix)) {
+      textPrefix += ' ';
+    }
     this.speakFasterService
         .textPrediction({
           userId: this.userId,

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -28,6 +28,9 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
   @Input() contextStrings!: string[];
   @Input() inputString!: string;
   @Input() inputBarControlSubject!: Subject<InputBarControlEvent>;
+  @Input() showExpandButton!: boolean;
+  @Input() showSpellButton!: boolean;
+  @Input() showAbortButton!: boolean;
   @Output() expandButtonClicked: EventEmitter<Event> = new EventEmitter();
   @Output() spellButtonClicked: EventEmitter<Event> = new EventEmitter();
   @Output() abortButtonClicked: EventEmitter<Event> = new EventEmitter();

--- a/webui/src/app/input-text-predictions/input-text-predictions.module.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.module.ts
@@ -1,0 +1,12 @@
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+
+import {InputTextPredictionsComponent} from './input-text-predictions.component';
+
+@NgModule({
+  declarations: [InputTextPredictionsComponent],
+  imports: [BrowserModule],
+  exports: [InputTextPredictionsComponent],
+})
+export class InputTextPredictionsModule {
+}

--- a/webui/src/app/settings/version.ts
+++ b/webui/src/app/settings/version.ts
@@ -2,7 +2,7 @@
 
 const MAJOR_VERSION: string = '0';
 const MINOR_VERSION: string = '0';
-const PATCH_VERSION: string = '8';
+const PATCH_VERSION: string = '9';
 
 export const VERSION: string =
     `${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}`;

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -61,9 +61,6 @@ export function updateButtonBoxesForElements(
   setTimeout(() => {
     const boxes: Array<[number, number, number, number]> = [];
     elements.forEach(elementRef => {
-      // if (!isVisible(elementRef.nativeElement)) {
-      //   console.log('*** Invisible element');  // DEBUG
-      // }
       const box = elementRef.nativeElement.getBoundingClientRect();
       if (containerRect == null ||
           isRectVisibleInsideContainer(box, containerRect)) {
@@ -73,37 +70,6 @@ export function updateButtonBoxesForElements(
     updateButtonBoxes(instanceId, boxes);
   }, 0);
 }
-
-// function isVisible(elem: HTMLElement) {
-//   if (!(elem instanceof Element))
-//     throw Error('DomUtil: elem is not an element.');
-//   const style = getComputedStyle(elem);
-//   if (style.display === 'none') return false;
-//   if (style.visibility !== 'visible') return false;
-//   if (elem.offsetWidth + elem.offsetHeight +
-//           elem.getBoundingClientRect().height +
-//           elem.getBoundingClientRect().width ===
-//       0) {
-//     return false;
-//   }
-//   const elemCenter = {
-//     x: elem.getBoundingClientRect().left + elem.offsetWidth / 2,
-//     y: elem.getBoundingClientRect().top + elem.offsetHeight / 2
-//   };
-//   if (elemCenter.x < 0) return false;
-//   if (elemCenter.x >
-//       (document.documentElement.clientWidth || window.innerWidth))
-//     return false;
-//   if (elemCenter.y < 0) return false;
-//   if (elemCenter.y >
-//       (document.documentElement.clientHeight || window.innerHeight))
-//     return false;
-//   let pointContainer = document.elementFromPoint(elemCenter.x, elemCenter.y);
-//   // do {
-//   //   if (pointContainer === elem) return true;
-//   // } while (pointContainer = pointContainer.parentNode);
-//   return false;
-// }
 
 /**
  * Bring main window to the foreground.

--- a/webui/src/utils/cefsharp.ts
+++ b/webui/src/utils/cefsharp.ts
@@ -61,6 +61,9 @@ export function updateButtonBoxesForElements(
   setTimeout(() => {
     const boxes: Array<[number, number, number, number]> = [];
     elements.forEach(elementRef => {
+      // if (!isVisible(elementRef.nativeElement)) {
+      //   console.log('*** Invisible element');  // DEBUG
+      // }
       const box = elementRef.nativeElement.getBoundingClientRect();
       if (containerRect == null ||
           isRectVisibleInsideContainer(box, containerRect)) {
@@ -70,6 +73,37 @@ export function updateButtonBoxesForElements(
     updateButtonBoxes(instanceId, boxes);
   }, 0);
 }
+
+// function isVisible(elem: HTMLElement) {
+//   if (!(elem instanceof Element))
+//     throw Error('DomUtil: elem is not an element.');
+//   const style = getComputedStyle(elem);
+//   if (style.display === 'none') return false;
+//   if (style.visibility !== 'visible') return false;
+//   if (elem.offsetWidth + elem.offsetHeight +
+//           elem.getBoundingClientRect().height +
+//           elem.getBoundingClientRect().width ===
+//       0) {
+//     return false;
+//   }
+//   const elemCenter = {
+//     x: elem.getBoundingClientRect().left + elem.offsetWidth / 2,
+//     y: elem.getBoundingClientRect().top + elem.offsetHeight / 2
+//   };
+//   if (elemCenter.x < 0) return false;
+//   if (elemCenter.x >
+//       (document.documentElement.clientWidth || window.innerWidth))
+//     return false;
+//   if (elemCenter.y < 0) return false;
+//   if (elemCenter.y >
+//       (document.documentElement.clientHeight || window.innerHeight))
+//     return false;
+//   let pointContainer = document.elementFromPoint(elemCenter.x, elemCenter.y);
+//   // do {
+//   //   if (pointContainer === elem) return true;
+//   // } while (pointContainer = pointContainer.parentNode);
+//   return false;
+// }
 
 /**
  * Bring main window to the foreground.

--- a/webui/src/utils/text-utils.spec.ts
+++ b/webui/src/utils/text-utils.spec.ts
@@ -1,6 +1,6 @@
 /** Test utils for text-utils. */
 
-import {keySequenceEndsWith, limitStringLength, removePunctuation, trimStringAtHead} from './text-utils';
+import {endsWithPunctuation, keySequenceEndsWith, limitStringLength, removePunctuation, trimStringAtHead} from './text-utils';
 
 describe('text-utils', () => {
   describe('limitStringLength', () => {
@@ -69,6 +69,27 @@ describe('text-utils', () => {
       expect(removePunctuation('')).toEqual('');
       expect(removePunctuation(' ')).toEqual(' ');
       expect(removePunctuation('hi there')).toEqual('hi there');
+    });
+  });
+
+  describe('endsWithPunctuation', () => {
+    it('returns true', () => {
+      expect(endsWithPunctuation('.')).toBeTrue();
+      expect(endsWithPunctuation('hi.')).toBeTrue();
+      expect(endsWithPunctuation('hi..')).toBeTrue();
+      expect(endsWithPunctuation('hi,')).toBeTrue();
+      expect(endsWithPunctuation('hi,,')).toBeTrue();
+      expect(endsWithPunctuation('wait;')).toBeTrue();
+      expect(endsWithPunctuation('hello!')).toBeTrue();
+      expect(endsWithPunctuation('hello!!')).toBeTrue();
+      expect(endsWithPunctuation('hello?')).toBeTrue();
+    });
+
+    it('returns false', () => {
+      expect(endsWithPunctuation('')).toBeFalse();
+      expect(endsWithPunctuation(' ')).toBeFalse();
+      expect(endsWithPunctuation('wait')).toBeFalse();
+      expect(endsWithPunctuation('wait; ')).toBeFalse();
     });
   });
 });

--- a/webui/src/utils/text-utils.ts
+++ b/webui/src/utils/text-utils.ts
@@ -61,6 +61,14 @@ export function endsWithSentenceEndPunctuation(text: string): boolean {
 }
 
 /**
+ * Determine whether a string ends with punctuation (nt necessarily
+ * sentence-end).
+ */
+export function endsWithPunctuation(text: string): boolean {
+  return text.match(/.*[\,\;\:\.\!\?]$/) !== null;
+}
+
+/**
  * Trim string from the head, respecting word boundary.
  * @param str Input string.
  * @param maxLength Maximum allowed length.


### PR DESCRIPTION
- Display word suggestions (including word completion and next-word prediction) underneath the main input bar.
- The word suggestions are fetched via HTTP GET requests from the `textPrediction()` interface method.
- Both word completion and next-word predictions are covered.
- When the InputTextPredictionsComponent is shown, the `Expand`, `Spell` and `X` buttons are moved to the said component. 
- Add event logging (new event name: `TextPredictionSelection`.
- Add logic to modify the text in the main text in ways dependent on whether the suggestions are for word completion or NWP.