### PR TITLE
[WebUI] Fix bug related to word suggestion w/ input ending punctuation

### DIFF
--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1399,8 +1399,11 @@ describe('InputBarComponent', () => {
            ['foo ', 'bar', 'foo bar'],
            ['foo,', 'bar', 'foo, bar'],
            ['foo.', 'bar', 'foo. bar'],
-           ['foo,', 'bar,', 'bar,'],
-           ['foo bar,', 'bar.', 'foo bar.'],
+           ['foo,', 'bar', 'foo, bar'],
+           ['foo.b', 'bar', 'foo. bar'],
+           ['foo,b', 'bar', 'foo, bar'],
+           ['foo,', 'bar,', 'foo, bar,'],
+           ['foo bar,', 'bar.', 'foo bar, bar.'],
   ]) {
     it('suggestionSelection updates input string: next word: ' +
            'original=' + originalText + '; suggestion=' + suggestion +

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -708,24 +708,21 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
    * prediction.
    */
   private incorporateSuggestion(suggestion: string) {
-    if (endsWithPunctuation(this.inputString) &&
-        !endsWithPunctuation(suggestion)) {
-      // Input string ends with a puncutation, but the selection does not
-      // end with a punctuation. We should add a space before the selection.
-      this.updateInputString(this.inputString + ' ' + suggestion);
-    } else if (this.inputString.match(/.*\s$/)) {
-      this.updateInputString(this.inputString + suggestion);
-    } else {
-      // The current input string does not end in a whitespace.
-      // Find the last word.
-      let i = this.inputString.length - 1;
-      for (; i >= 0; --i) {
-        if (this.inputString[i].match(/\s/)) {
-          break;
-        }
+    let breakingIndex = this.inputString.length - 1;
+    while (breakingIndex >= 0) {
+      if (this.inputString[breakingIndex].match(/\s/) ||
+          endsWithPunctuation(
+              this.inputString.substring(0, breakingIndex + 1))) {
+        break;
       }
-      this.updateInputString(this.inputString.substring(0, i + 1) + suggestion);
+      breakingIndex--;
     }
+    let newString = this.inputString.substring(0, breakingIndex + 1);
+    if (endsWithPunctuation(newString)) {
+      newString += ' ';
+    }
+    newString += suggestion;
+    this.updateInputString(newString);
     this.finalWhitespaceIsFromSuggestion = suggestion.match(/.*\s$/) !== null;
   }
 

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
@@ -58,7 +58,14 @@ describe(
         (window as any)[BOUND_LISTENER_NAME] = undefined;
       });
 
-      for (const textPrefix of ['a', 'A']) {
+      for (const [textPrefix, predCallTextPrefix] of [
+               ['a', 'a'],
+               ['A', 'a'],
+               ['a,', 'a, '],
+               ['a,a', 'a, a'],
+               ['a, a', 'a, a'],
+               ['a,a a,', 'a,a a, '],
+      ]) {
         it('gets and shows correct word suggestions: textPrefix=' + textPrefix,
            () => {
              fixture.componentInstance.userId = 'User0';
@@ -71,8 +78,11 @@ describe(
                  {inputString: new SimpleChange('', textPrefix, true)});
              fixture.detectChanges();
 
-             expect(spy).toHaveBeenCalledOnceWith(
-                 {textPrefix: 'a', contextTurns: [], userId: 'User0'});
+             expect(spy).toHaveBeenCalledOnceWith({
+               textPrefix: predCallTextPrefix,
+               contextTurns: [],
+               userId: 'User0'
+             });
              const predictionButtons =
                  fixture.debugElement.queryAll(By.css('.prediction-button'));
              expect(predictionButtons.length).toEqual(3);


### PR DESCRIPTION
Previously, when the input to the word prediction model is something like 'hi,' and the word suggestion 'there' is selected, the resultant input string was 'hi,there', i.e., without a space between 'hi',' and 'there'.

This PR fixes this issue.