### PR TITLE
[WebUI] Support gaze buttons with long threshold duration

### DIFF
--- a/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
@@ -187,23 +187,35 @@ describe(
                expect(lastCall[1][0].length).toEqual(4);
              }));
 
-      it('updateButtonBox: 2 buttons',
-         fakeAsync(
-             () => {
-               fixture.componentInstance.showExpandButton = false;
-               fixture.componentInstance.showSpellButton = true;
-               fixture.componentInstance.showAbortButton = true;
-               fixture.detectChanges();
-               fixture.componentInstance.ngAfterViewInit();
-               tick();
+      it('updateButtonBox: 2 + 2 buttons: long-dwell value',
+          fakeAsync(
+              () => {
+                fixture.componentInstance.showExpandButton = false;
+                fixture.componentInstance.showSpellButton = true;
+                fixture.componentInstance.showAbortButton = true;
+                (fixture.componentInstance as any)._predictions =
+                    ['hi', 'hello'];
+                // 2 buttons are fixed (spell and abort); another 2 buttons are
+                // dynamic word predictions (long dwell).
+                fixture.detectChanges();
+                console.log('=== Calling ngAfterViewInit()')
+                fixture.componentInstance.ngAfterViewInit();
+                tick();
 
-               const lastCall =
+                const lastCall =
                   testListener.updateButtonBoxesCalls[testListener.updateButtonBoxesCalls.length
                   - 1];
-               expect(lastCall[0].startsWith('InputTextPredictionsComponent_'))
-                   .toBeTrue();
-               expect(lastCall[1].length).toEqual(2);
-               expect(lastCall[1][0].length).toEqual(4);
-               expect(lastCall[1][1].length).toEqual(4);
-             }));
+                expect(lastCall[0].startsWith('InputTextPredictionsComponent_'))
+                    .toBeTrue();
+                expect(lastCall[1].length).toEqual(4);
+                expect(lastCall[1][0].length).toEqual(4);
+                expect(lastCall[1][1].length).toEqual(4);
+                // The long-dwell word predicton buttons are called with
+                // length-5 number arrays. The last element of each array is
+                // the custom threshold duration in milliseconds.
+                expect(lastCall[1][2].length).toEqual(5);
+                expect(lastCall[1][2][4]).toEqual(400);
+                expect(lastCall[1][3].length).toEqual(5);
+                expect(lastCall[1][3][4]).toEqual(400);
+              }));
     });

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -2,7 +2,7 @@
 import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
 import {Subject} from 'rxjs';
 import {throttleTime} from 'rxjs/operators';
-import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
+import {LONG_DWELL_ATTRIBUTE_KEY, LONG_DWELL_ATTRIBUTE_VALUE, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {endsWithPunctuation, isAlphanumericChar} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
@@ -70,6 +70,10 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
     const visibleElementRefs: Array<ElementRef<HTMLElement>> = [];
     this.clickableButtons.forEach(elementRef => {
       const element = elementRef.nativeElement;
+      if (element.classList.contains('prediction-button')) {
+        element.setAttribute(
+            LONG_DWELL_ATTRIBUTE_KEY, LONG_DWELL_ATTRIBUTE_VALUE);
+      }
       if (!element.classList.contains('invisible')) {
         visibleElementRefs.push(elementRef);
       }

--- a/webui/src/app/settings/version.ts
+++ b/webui/src/app/settings/version.ts
@@ -2,7 +2,7 @@
 
 const MAJOR_VERSION: string = '0';
 const MINOR_VERSION: string = '0';
-const PATCH_VERSION: string = '9';
+const PATCH_VERSION: string = '10';
 
 export const VERSION: string =
     `${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}`;


### PR DESCRIPTION
Expand the number[][] argument to updateButtonBoxes() in the cefsharp
interface, so that if the length of a number[] array is 5, it will be
interpreted as [left, top, right, bottom] followed by the custom
threshold duration in milliseconds (e.g., 400 ms).

Also bumps version from 0.0.9 to 0.0.10.
