### PR TITLE
[WebUI] Prevent word suggestions from showing up when input is empty

### DIFF
--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -1216,7 +1216,7 @@ describe('InputBarComponent', () => {
        const prevNumCalls1 = testListener.updateButtonBoxesCalls.length;
        inputBarControlSubject.next({appendText: 'foo bar'});
        fixture.detectChanges();
-       tick();
+       tick(100);
 
        expect(prevNumCalls1).toBeGreaterThan(prevNumCalls0);
        expect(testListener.updateButtonBoxesCalls.length)

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -354,7 +354,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     this.focusOnInputTextArea();
   }
 
-  private scaleInputTextFontSize(): void {
+  private scaleInputTextFontSize(scrollToBottom = false): void {
     // TODO(cais): Limit on over all text length.
     if (!this.inputTextArea) {
       return;
@@ -383,6 +383,9 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     } else {
       element.style.fontSize = `${INPUT_TEXT_BASE_FONT_SIZE}px`;
       element.style.lineHeight = `${INPUT_TEXT_BASE_FONT_SIZE}px`;
+    }
+    if (scrollToBottom) {
+      element.scrollTop = element.scrollHeight;
     }
     updateButtonBoxesForElements(this.instanceId, this.buttons);
   }
@@ -724,6 +727,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     newString += suggestion;
     this.updateInputString(newString);
     this.finalWhitespaceIsFromSuggestion = suggestion.match(/.*\s$/) !== null;
+    this.scaleInputTextFontSize(/* scrollToBottom= */ true);
   }
 
   private resetState(clearText: boolean = true, resetBase: boolean = true) {

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
@@ -215,7 +215,6 @@ describe(
                // 2 buttons are fixed (spell and abort); another 2 buttons are
                // dynamic word predictions (long dwell).
                fixture.detectChanges();
-               console.log('=== Calling ngAfterViewInit()')
                fixture.componentInstance.ngAfterViewInit();
                tick();
 

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.spec.ts
@@ -73,7 +73,7 @@ describe(
                            .and.returnValues(of({
                              outputs: ['a', 'apple', 'any'],
                            }));
-             fixture.componentInstance.inputString = '';
+             fixture.componentInstance.inputString = 'a';
              fixture.componentInstance.ngOnChanges(
                  {inputString: new SimpleChange('', textPrefix, true)});
              fixture.detectChanges();
@@ -93,6 +93,23 @@ describe(
                  .toEqual('any');
            });
       }
+
+      it('does not display suggestion when input string is empty', () => {
+        fixture.componentInstance.userId = 'User0';
+        let spy = spyOn(speakFasterServiceForTest, 'textPrediction')
+                      .and.returnValues(of({
+                        outputs: ['a', 'apple', 'any'],
+                      }));
+        fixture.componentInstance.inputString = '';
+        const textPrefix = 'a';
+        fixture.componentInstance.ngOnChanges(
+            {inputString: new SimpleChange('', textPrefix, true)});
+        fixture.detectChanges();
+
+        const predictionButtons =
+            fixture.debugElement.queryAll(By.css('.prediction-button'));
+        expect(predictionButtons.length).toEqual(0);
+      });
 
       it('does not get predictions when text is empty', () => {
         fixture.componentInstance.userId = 'User0';
@@ -116,7 +133,7 @@ describe(
         spyOn(speakFasterServiceForTest, 'textPrediction').and.returnValues(of({
           outputs: ['a', 'apple', 'any'],
         }));
-        fixture.componentInstance.inputString = '';
+        fixture.componentInstance.inputString = 'a';
         fixture.componentInstance.ngOnChanges(
             {inputString: new SimpleChange('', 'a', true)});
         fixture.detectChanges();
@@ -188,34 +205,34 @@ describe(
              }));
 
       it('updateButtonBox: 2 + 2 buttons: long-dwell value',
-          fakeAsync(
-              () => {
-                fixture.componentInstance.showExpandButton = false;
-                fixture.componentInstance.showSpellButton = true;
-                fixture.componentInstance.showAbortButton = true;
-                (fixture.componentInstance as any)._predictions =
-                    ['hi', 'hello'];
-                // 2 buttons are fixed (spell and abort); another 2 buttons are
-                // dynamic word predictions (long dwell).
-                fixture.detectChanges();
-                console.log('=== Calling ngAfterViewInit()')
-                fixture.componentInstance.ngAfterViewInit();
-                tick();
+         fakeAsync(
+             () => {
+               fixture.componentInstance.showExpandButton = false;
+               fixture.componentInstance.showSpellButton = true;
+               fixture.componentInstance.showAbortButton = true;
+               (fixture.componentInstance as any)._predictions =
+                   ['hi', 'hello'];
+               // 2 buttons are fixed (spell and abort); another 2 buttons are
+               // dynamic word predictions (long dwell).
+               fixture.detectChanges();
+               console.log('=== Calling ngAfterViewInit()')
+               fixture.componentInstance.ngAfterViewInit();
+               tick();
 
-                const lastCall =
+               const lastCall =
                   testListener.updateButtonBoxesCalls[testListener.updateButtonBoxesCalls.length
                   - 1];
-                expect(lastCall[0].startsWith('InputTextPredictionsComponent_'))
-                    .toBeTrue();
-                expect(lastCall[1].length).toEqual(4);
-                expect(lastCall[1][0].length).toEqual(4);
-                expect(lastCall[1][1].length).toEqual(4);
-                // The long-dwell word predicton buttons are called with
-                // length-5 number arrays. The last element of each array is
-                // the custom threshold duration in milliseconds.
-                expect(lastCall[1][2].length).toEqual(5);
-                expect(lastCall[1][2][4]).toEqual(400);
-                expect(lastCall[1][3].length).toEqual(5);
-                expect(lastCall[1][3][4]).toEqual(400);
-              }));
+               expect(lastCall[0].startsWith('InputTextPredictionsComponent_'))
+                   .toBeTrue();
+               expect(lastCall[1].length).toEqual(4);
+               expect(lastCall[1][0].length).toEqual(4);
+               expect(lastCall[1][1].length).toEqual(4);
+               // The long-dwell word predicton buttons are called with
+               // length-5 number arrays. The last element of each array is
+               // the custom threshold duration in milliseconds.
+               expect(lastCall[1][2].length).toEqual(5);
+               expect(lastCall[1][2][4]).toEqual(400);
+               expect(lastCall[1][3].length).toEqual(5);
+               expect(lastCall[1][3][4]).toEqual(400);
+             }));
     });

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.ts
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.ts
@@ -3,7 +3,7 @@ import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, On
 import {Subject} from 'rxjs';
 import {throttleTime} from 'rxjs/operators';
 import {LONG_DWELL_ATTRIBUTE_KEY, LONG_DWELL_ATTRIBUTE_VALUE, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
-import {endsWithPunctuation, isAlphanumericChar} from 'src/utils/text-utils';
+import {endsWithPunctuation} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
 import {getPhraseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
@@ -12,7 +12,7 @@ import {SpeakFasterService, TextPredictionResponse} from '../speakfaster-service
 
 const MAX_NUM_PREDICTIONS = 4;
 
-const THROTTLE_TIME_MILLIS = 100;
+const THROTTLE_TIME_MILLIS = 50;
 
 @Component({
   selector: 'input-text-predictions-component',
@@ -50,10 +50,10 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
 
   ngOnInit() {
     // TODO(cais): Resolve interaction with keyboard word prediction.
-    // this.textPredictionTriggers.pipe(throttleTime(THROTTLE_TIME_MILLIS))
-    this.textPredictionTriggers.subscribe(textPrefix => {
-      this.getTextPredictions(textPrefix);
-    });
+    this.textPredictionTriggers.pipe(throttleTime(THROTTLE_TIME_MILLIS))
+        .subscribe(textPrefix => {
+          this.getTextPredictions(textPrefix);
+        });
   }
 
   ngAfterViewInit() {
@@ -135,6 +135,9 @@ export class InputTextPredictionsComponent implements AfterViewInit, OnInit,
                 return;
               }
               this._predictions.splice(0);
+              if (!this.inputString) {
+                return;
+              }
               this._predictions.push(
                   ...data.outputs.slice(0, MAX_NUM_PREDICTIONS));
               this.latestCompletedRequestTimestamp = t;


### PR DESCRIPTION
Also ensures that the input bar auto-scrolls to the bottom when word predictions are appended.

Fixes #349