### PR TITLE
[WebUI] Input text prediction and input bar: Styling & behavior fixes

### DIFF
--- a/webui/src/app/input-bar/input-bar.component.html
+++ b/webui/src/app/input-bar/input-bar.component.html
@@ -78,7 +78,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  height: 140px;
+  height: 160px;
   overflow: visible;
   padding: 0 0 8px;
   position: relative;

--- a/webui/src/app/input-text-predictions/input-text-predictions.component.html
+++ b/webui/src/app/input-text-predictions/input-text-predictions.component.html
@@ -11,10 +11,10 @@
 
 .container {
   display: inline-block;
-  height: 64px;
+  height: 80px;
   padding-bottom: 0;
   padding-left: 8px;
-  padding-top: 8px;
+  padding-top: 32px;
   width: 100%;
 }
 
@@ -32,7 +32,7 @@
   height: 60px;
   line-height: 56px;
   margin: 4px 16px 0 0;
-  min-width: 152px;
+  min-width: 140px;
   vertical-align: top;
   width: fit-content;
 }


### PR DESCRIPTION
- Increase the spacing between the word suggestions and the main input bar, to reduce the chance of accidentally hitting one of the word suggestions when scanning the already-entered text.