### PR TITLE
[WebUI] Support inckw AE

### DIFF
--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -12,6 +12,7 @@ import {InputBarChipModule} from '../input-bar-chip/input-bar-chip.module';
 import {InputTextPredictionsComponent} from '../input-text-predictions/input-text-predictions.component';
 import {InputTextPredictionsModule} from '../input-text-predictions/input-text-predictions.module';
 import {LoadLexiconRequest} from '../lexicon/lexicon.component';
+import {clearSettings, LOCAL_STORAGE_ITEM_NAME, setEnableInckw} from '../settings/settings';
 import {FillMaskRequest, SpeakFasterService, TextPredictionRequest, TextPredictionResponse} from '../speakfaster-service';
 import {setDelaysForTesting, StudyManager, StudyUserTurn} from '../study/study-manager';
 import {TestListener} from '../test-utils/test-cefsharp-listener';
@@ -35,7 +36,7 @@ class SpeakFasterServiceForTest {
   }
 }
 
-fdescribe('InputBarComponent', () => {
+describe('InputBarComponent', () => {
   let testListener: TestListener;
   let studyManager: StudyManager;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
@@ -49,10 +50,13 @@ fdescribe('InputBarComponent', () => {
   let inputStringChangedValues: string[];
   let textEntryEndEvents: TextEntryEndEvent[];
   let inputAbbreviationChangeEvents: InputAbbreviationChangedEvent[];
+  let inFlightAbbreviationChangeEvents: InputAbbreviationChangedEvent[];
   let LoadLexiconRequests: LoadLexiconRequest[];
   let fillMaskRequests: FillMaskRequest[];
 
   beforeEach(async () => {
+    clearSettings();
+    localStorage.removeItem(LOCAL_STORAGE_ITEM_NAME);
     setDelaysForTesting(10e3, 50e3);
     testListener = new TestListener();
     (window as any)[cefSharp.BOUND_LISTENER_NAME] = testListener;
@@ -72,6 +76,7 @@ fdescribe('InputBarComponent', () => {
         (event: InputAbbreviationChangedEvent) => {
           inputAbbreviationChangeEvents.push(event);
         });
+
     LoadLexiconRequests = [];
     loadPrefixedLexiconRequestSubject.subscribe(
         (request: LoadLexiconRequest) => {
@@ -114,6 +119,11 @@ fdescribe('InputBarComponent', () => {
     fixture.componentInstance.inputStringChanged.subscribe((str) => {
       inputStringChangedValues.push(str);
     });
+    inFlightAbbreviationChangeEvents = [];
+    fixture.componentInstance.inFlightAbbreviationExpansionTriggers.subscribe(
+        (event: InputAbbreviationChangedEvent) => {
+          inFlightAbbreviationChangeEvents.push(event);
+        });
     fixture.detectChanges();
   });
 
@@ -202,14 +212,14 @@ fdescribe('InputBarComponent', () => {
            ['abc ', ' '],
   ] as Array<[string, string]>) {
     it(`Keys trigger abbreviation expansion: ${originalText}: ${newKey}`,
-       () => {
+       async () => {
          const inputText =
              fixture.debugElement.query(By.css('.base-text-area'));
          inputText.nativeElement.value = originalText;
          fixture.detectChanges();
          inputText.nativeElement.value = originalText + newKey;
          const event = new KeyboardEvent('keypress', {key: '\n'});
-         fixture.componentInstance.onInputTextAreaKeyUp(event);
+         await fixture.componentInstance.onInputTextAreaKeyUp(event);
          fixture.detectChanges();
 
          expect(inputAbbreviationChangeEvents.length).toEqual(1);
@@ -229,14 +239,14 @@ fdescribe('InputBarComponent', () => {
   ] as Array<[string, string]>) {
     it('Keys trigger abbreviation multi-token abbreviation expansion:' +
            `original text=${originalText}, trigger=${triggerKey}`,
-       () => {
+       async () => {
          const inputText =
              fixture.debugElement.query(By.css('.base-text-area'));
          inputText.nativeElement.value = originalText;
          fixture.detectChanges();
          inputText.nativeElement.value = originalText + triggerKey;
          const event = new KeyboardEvent('keypress', {key: triggerKey});
-         fixture.componentInstance.onInputTextAreaKeyUp(event);
+         await fixture.componentInstance.onInputTextAreaKeyUp(event);
          fixture.detectChanges();
 
          expect(inputAbbreviationChangeEvents.length).toEqual(1);
@@ -415,34 +425,83 @@ fdescribe('InputBarComponent', () => {
     expect(testListener.numRequestSoftkeyboardResetCalls).toEqual(1);
   });
 
-  fit('spelling word then enter trigger key triggers AE: ',
-      async () => {
-        enterKeysIntoComponent('abc');
-        const spellButton = fixture.debugElement.query(By.css('.spell-button'));
-        spellButton.nativeElement.click();
-        fixture.detectChanges();
-        // The ending punctuation should be ignored by keyword AE.
-        fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
-        fixture.componentInstance.onChipTextChanged({text: 'bit'}, 1);
-        fixture.detectChanges();
-        const expandButton =
-            fixture.debugElement.query(By.css('.expand-button'));
-        expandButton.nativeElement.click();
-        fixture.detectChanges();
+  it('spelling valid word triggers AE', async () => {
+    enterKeysIntoComponent('abc');
+    const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+    spellButton.nativeElement.click();
+    fixture.detectChanges();
+    fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+    spyOn(fixture.componentInstance, 'isValidWord').and.returnValue(true);
+    await fixture.componentInstance.onChipTextChanged({text: 'bit'}, 1);
+    fixture.detectChanges();
 
-        expect(fixture.componentInstance
-                   .inputStringIsCompatibleWithAbbreviationExpansion)
-            .toBeTrue();
-        expect(inputAbbreviationChangeEvents.length).toEqual(1);
-        expect(inputAbbreviationChangeEvents[0].requestExpansion).toBeTrue();
-        const {abbreviationSpec} = inputAbbreviationChangeEvents[0];
-        expect(abbreviationSpec.tokens.length).toEqual(3);
-        expect(abbreviationSpec.readableString).toEqual('a bit c');
-        const {tokens} = abbreviationSpec;
-        expect(tokens[0]).toEqual({value: 'a', isKeyword: false});
-        expect(tokens[1]).toEqual({value: 'bit', isKeyword: true});
-        expect(tokens[2]).toEqual({value: 'c', isKeyword: false});
-      });
+    expect(fixture.componentInstance
+               .inputStringIsCompatibleWithAbbreviationExpansion)
+        .toBeTrue();
+    expect(inFlightAbbreviationChangeEvents.length).toEqual(1);
+    expect(inFlightAbbreviationChangeEvents[0].requestExpansion).toBeTrue();
+    const {abbreviationSpec} = inFlightAbbreviationChangeEvents[0];
+    expect(abbreviationSpec.tokens.length).toEqual(3);
+    expect(abbreviationSpec.readableString).toEqual('a bit c');
+    const {tokens} = abbreviationSpec;
+    expect(tokens[0]).toEqual({value: 'a', isKeyword: false});
+    expect(tokens[1]).toEqual(
+        {value: 'bit', isKeyword: true, wordAbbrevMode: undefined});
+    expect(tokens[2]).toEqual({value: 'c', isKeyword: false});
+  });
+
+  it('spelling invalid word does not trigger AE', async () => {
+    enterKeysIntoComponent('abc');
+    const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+    spellButton.nativeElement.click();
+    fixture.detectChanges();
+    fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+    spyOn(fixture.componentInstance, 'isValidWord').and.returnValue(false);
+    await fixture.componentInstance.onChipTextChanged({text: 'bar'}, 1);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance
+               .inputStringIsCompatibleWithAbbreviationExpansion)
+        .toBeTrue();
+    expect(inFlightAbbreviationChangeEvents.length).toEqual(0);
+  });
+
+  it('entering word prefix triggers inckw AE', async () => {
+    await setEnableInckw(true);
+    enterKeysIntoComponent('abc');
+    const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+    spellButton.nativeElement.click();
+    fixture.detectChanges();
+    fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+    spyOn(fixture.componentInstance, 'isValidWord').and.returnValue(false);
+    await fixture.componentInstance.onChipTextChanged({text: 'br'}, 1);
+    fixture.detectChanges();
+
+    expect(inFlightAbbreviationChangeEvents.length).toEqual(1);
+    expect(inFlightAbbreviationChangeEvents[0].requestExpansion).toBeTrue();
+    const {abbreviationSpec} = inFlightAbbreviationChangeEvents[0];
+    expect(abbreviationSpec.tokens.length).toEqual(3);
+    expect(abbreviationSpec.readableString).toEqual('a br c');
+    const {tokens} = abbreviationSpec;
+    expect(tokens[0]).toEqual({value: 'a', isKeyword: false});
+    expect(tokens[1]).toEqual(
+        {value: 'br', isKeyword: true, wordAbbrevMode: 'PREFIX'});
+    expect(tokens[2]).toEqual({value: 'c', isKeyword: false});
+  });
+
+  it('entering length-1 prefix does not trigger inckw AE', async () => {
+    await setEnableInckw(true);
+    enterKeysIntoComponent('abc');
+    const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+    spellButton.nativeElement.click();
+    fixture.detectChanges();
+    fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+    spyOn(fixture.componentInstance, 'isValidWord').and.returnValue(false);
+    await fixture.componentInstance.onChipTextChanged({text: 'b'}, 1);
+    fixture.detectChanges();
+
+    expect(inFlightAbbreviationChangeEvents.length).toEqual(0);
+  });
 
   it('entering keys into text box issues inputStringChanged events', () => {
     enterKeysIntoComponent('hi');
@@ -452,14 +511,15 @@ fdescribe('InputBarComponent', () => {
     expect(inputStringChangedValues[1]).toEqual('hi');
   });
 
-  it('clicking abort after clicking spell resets state', () => {
+  it('clicking abort after clicking spell resets state', async () => {
     enterKeysIntoComponent('abc');
     const spellButton = fixture.debugElement.query(By.css('.spell-button'));
     spellButton.nativeElement.click();
     fixture.detectChanges();
     // The ending punctuation should be ignored by keyword AE.
     fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
-    fixture.componentInstance.onChipTextChanged({text: 'bit'}, 1);
+    spyOn(fixture.componentInstance, 'isValidWord').and.returnValue(true);
+    await fixture.componentInstance.onChipTextChanged({text: 'bit'}, 1);
     const abortButton = fixture.debugElement.query(By.css('.abort-button'));
     abortButton.nativeElement.click();
     fixture.detectChanges();
@@ -476,13 +536,10 @@ fdescribe('InputBarComponent', () => {
     const expandButton = fixture.debugElement.query(By.css('.expand-button'));
     expandButton.nativeElement.click();
 
-    expect(inputAbbreviationChangeEvents.length).toEqual(1);
-    expect(inputAbbreviationChangeEvents[0].requestExpansion).toBeTrue();
-    const {abbreviationSpec} = inputAbbreviationChangeEvents[0];
-    expect(abbreviationSpec.tokens.length).toEqual(1);
-    expect(abbreviationSpec.tokens[0].value).toEqual('abc');
-    expect(abbreviationSpec.tokens[0].isKeyword).toBeFalse();
-    expect(abbreviationSpec.readableString).toEqual('abc');
+    expect(inFlightAbbreviationChangeEvents.length).toEqual(1);
+    expect(inFlightAbbreviationChangeEvents[0].requestExpansion).toBeTrue();
+    const {abbreviationSpec} = inFlightAbbreviationChangeEvents[0];
+    expect(abbreviationSpec.tokens.length).toEqual(3);
   });
 
   it('chips are shown during refinement', () => {
@@ -1359,7 +1416,7 @@ fdescribe('InputBarComponent', () => {
          const input = fixture.debugElement.query(By.css('.base-text-area'));
          const event = new KeyboardEvent('keypress', {key: '\n'});
          input.nativeElement.value = 'hi\n';
-         fixture.componentInstance.onInputTextAreaKeyUp(event);
+         await fixture.componentInstance.onInputTextAreaKeyUp(event);
          fixture.detectChanges();
 
          expect(inputAbbreviationChangeEvents.length)

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -35,7 +35,7 @@ class SpeakFasterServiceForTest {
   }
 }
 
-describe('InputBarComponent', () => {
+fdescribe('InputBarComponent', () => {
   let testListener: TestListener;
   let studyManager: StudyManager;
   let textEntryEndSubject: Subject<TextEntryEndEvent>;
@@ -415,41 +415,34 @@ describe('InputBarComponent', () => {
     expect(testListener.numRequestSoftkeyboardResetCalls).toEqual(1);
   });
 
-  for (const triggerKey of [VIRTUAL_KEY.SPACE, VIRTUAL_KEY.ENTER]) {
-    for (const endPunctuation of ['.', '?', '!']) {
-      it('spelling word then enter trigger key triggers AE: ' +
-             `trigger key = ${triggerKey}; ` +
-             `ending punctuation = ${endPunctuation}`,
-         () => {
-           enterKeysIntoComponent('abc');
-           const spellButton =
-               fixture.debugElement.query(By.css('.spell-button'));
-           spellButton.nativeElement.click();
-           fixture.detectChanges();
-           // The ending punctuation should be ignored by keyword AE.
-           fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
-           fixture.componentInstance.onChipTextChanged({text: 'bit'}, 1);
-           fixture.detectChanges();
-           const expandButton =
-               fixture.debugElement.query(By.css('.expand-button'));
-           expandButton.nativeElement.click();
-           fixture.detectChanges();
+  fit('spelling word then enter trigger key triggers AE: ',
+      async () => {
+        enterKeysIntoComponent('abc');
+        const spellButton = fixture.debugElement.query(By.css('.spell-button'));
+        spellButton.nativeElement.click();
+        fixture.detectChanges();
+        // The ending punctuation should be ignored by keyword AE.
+        fixture.componentInstance.state = State.FOCUSED_ON_LETTER_CHIP;
+        fixture.componentInstance.onChipTextChanged({text: 'bit'}, 1);
+        fixture.detectChanges();
+        const expandButton =
+            fixture.debugElement.query(By.css('.expand-button'));
+        expandButton.nativeElement.click();
+        fixture.detectChanges();
 
-           expect(fixture.componentInstance
-                      .inputStringIsCompatibleWithAbbreviationExpansion)
-               .toBeTrue();
-           expect(inputAbbreviationChangeEvents.length).toEqual(1);
-           expect(inputAbbreviationChangeEvents[0].requestExpansion).toBeTrue();
-           const {abbreviationSpec} = inputAbbreviationChangeEvents[0];
-           expect(abbreviationSpec.tokens.length).toEqual(3);
-           expect(abbreviationSpec.readableString).toEqual('a bit c');
-           const {tokens} = abbreviationSpec;
-           expect(tokens[0]).toEqual({value: 'a', isKeyword: false});
-           expect(tokens[1]).toEqual({value: 'bit', isKeyword: true});
-           expect(tokens[2]).toEqual({value: 'c', isKeyword: false});
-         });
-    }
-  }
+        expect(fixture.componentInstance
+                   .inputStringIsCompatibleWithAbbreviationExpansion)
+            .toBeTrue();
+        expect(inputAbbreviationChangeEvents.length).toEqual(1);
+        expect(inputAbbreviationChangeEvents[0].requestExpansion).toBeTrue();
+        const {abbreviationSpec} = inputAbbreviationChangeEvents[0];
+        expect(abbreviationSpec.tokens.length).toEqual(3);
+        expect(abbreviationSpec.readableString).toEqual('a bit c');
+        const {tokens} = abbreviationSpec;
+        expect(tokens[0]).toEqual({value: 'a', isKeyword: false});
+        expect(tokens[1]).toEqual({value: 'bit', isKeyword: true});
+        expect(tokens[2]).toEqual({value: 'c', isKeyword: false});
+      });
 
   it('entering keys into text box issues inputStringChanged events', () => {
     enterKeysIntoComponent('hi');
@@ -1478,10 +1471,11 @@ describe('InputBarComponent', () => {
            [3, 'foo,', false],
            [3, 'foo bar,', false],
            [null, 'foo ,', false],
-  ] as Array<[number|null, string, boolean]>) {
+  ] as Array<[number | null, string, boolean]>) {
     it('inputStringHasOnlyPuncutationAfterSuggestionSpace return right answer',
        () => {
-         (fixture.componentInstance as any).suggestionBasedSpaceIndex = suggestionSpaceIndex;
+         (fixture.componentInstance as any).suggestionBasedSpaceIndex =
+             suggestionSpaceIndex;
          fixture.componentInstance.inputString = string;
          expect(fixture.componentInstance
                     .inputStringHasOnlyPuncutationAfterSuggestionSpace())

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -323,7 +323,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  onInputTextAreaKeyUp(event: KeyboardEvent) {
+  async onInputTextAreaKeyUp(event: KeyboardEvent) {
     this.inputString = this.inputTextArea.nativeElement.value;
     if (this.inputStringHasOnlyPuncutationAfterSuggestionSpace()) {
       this.updateInputString(
@@ -349,7 +349,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
           !this.studyManager.isAbbreviationMode) &&
         this.inputStringIsCompatibleWithAbbreviationExpansion) {
       // NOTE(#337): Under the full mode of study, AE should not be triggered.
-      this.triggerAbbreviationExpansion();
+      await this.triggerAbbreviationExpansion();
     }
   }
 
@@ -547,7 +547,6 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   async onChipTextChanged(event: {text: string}, i: number) {
-    console.log('*** onChipTextChanged A100');  // DEBUG
     this.ensureChipTypedTextCreated();
     const spelledString = event.text.trim();
     this._chipTypedText![i] = spelledString;
@@ -558,17 +557,20 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
         if (isValidWordOrIncompleteKeyword) {
           console.log(`Spelled string is an incommplete keyword: trigger AE`);
         }
-      } else if (LexiconComponent.isValidWord(spelledString.trim())) {
+      } else if (this.isValidWord(spelledString.trim())) {
         console.log(
             `Spelled string is valid word '${spelledString}': trigger AE`);
         isValidWordOrIncompleteKeyword = true;
       }
-      console.log('*** onChipTextChanged A120:', isValidWordOrIncompleteKeyword);  // DEBUG
       if (isValidWordOrIncompleteKeyword) {
         await this.triggerAbbreviationExpansion(/* isInFlight= */ true);
       }
     }
     updateButtonBoxesForElements(this.instanceId, this.buttons);
+  }
+
+  isValidWord(str: string): boolean {
+    return LexiconComponent.isValidWord(str);
   }
 
   onChipClicked(index: number) {

--- a/webui/src/app/settings/settings.component.ts
+++ b/webui/src/app/settings/settings.component.ts
@@ -1,6 +1,6 @@
-/** Quick phrase list for direct selection. */
+/** Settings component. */
 import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, ViewChildren} from '@angular/core';
-import {getHostInfo, REMOVE_ALL_GAZE_BUTTONS_DIRECTIVE, removeAllButtonBoxes, requestQuitApp, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
+import {getHostInfo, removeAllButtonBoxes, requestQuitApp, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
 import {createUuid} from 'src/utils/uuid';
 
 import {HttpEventLogger} from '../event-logger/event-logger-impl';

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -236,11 +236,17 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
     const keywordIndices: number[] = [];
     let wordAbbrevMode: string|null = null;
     for (let i = 0; i < abbreviationSpec.tokens.length; ++i) {
-      if (abbreviationSpec.tokens[i].isKeyword) {
+      const token = abbreviationSpec.tokens[i];
+      if (token.isKeyword) {
         keywordIndices.push(i);
-
-        if (abbreviationSpec.tokens[i].wordAbbrevMode) {
-          wordAbbrevMode = abbreviationSpec.tokens[i].wordAbbrevMode as string;
+        if (wordAbbrevMode === null) {
+          if (token.wordAbbrevMode) {
+            wordAbbrevMode = token.wordAbbrevMode as string;
+          }
+        } else if (wordAbbrevMode !== token.wordAbbrevMode) {
+          throw new Error(
+              `Incompatible word abbrev modes: ${wordAbbrevMode} ` +
+              `and ${token.wordAbbrevMode}`);
         }
       }
     }

--- a/webui/src/app/types/abbreviation.ts
+++ b/webui/src/app/types/abbreviation.ts
@@ -2,6 +2,8 @@
 
 import {VIRTUAL_KEY} from '../external/external-events.component';
 
+export type WordAbbrevMode = 'PREFIX'|'CONSONANTS_WITH_INITIAL_VOWEL';
+
 /**
  * A token in an abbreviation. In the context of abbreviation, a token is
  * defined as a unit that represents a word. It can be:
@@ -16,6 +18,10 @@ export interface AbbreviationToken {
 
   // Whether this token is word in its literal form, i.e., a keyword.
   readonly isKeyword: boolean;
+
+  // Word abbreviation mode. If undefined and `isKeyword` is true, this means
+  // this token is a complete keyword.
+  readonly wordAbbrevMode?: WordAbbrevMode;
 }
 
 /**


### PR DESCRIPTION
- The incopmlete keyword AE mode currently is disabled by default. It is enabled only when the user goes to Settings > AI Settings and enables the model explicitly
- Once enabled, in Spelling mode of the input bar, each keypress triggers an AE call (with throttling)

