### PR TITLE
[WebUI] Update authentication in a backward compatible way

### DIFF
--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -126,7 +126,7 @@ app-text-to-speech-component {
        handling keyboard events. -->
   <app-keyboard-component></app-keyboard-component>
 
-  <div *ngIf="!hasAccessToken()" class="auth-area">
+  <div *ngIf="!hasAccessToken" class="auth-area">
     <app-auth-component (newAccessToken)="onNewAccessToken($event)"></app-auth-component>
   </div>
 
@@ -144,7 +144,7 @@ app-text-to-speech-component {
 
   <div
       class="minimized-area"
-      *ngIf="hasAccessToken() && appState === 'MINIBAR'">
+      *ngIf="hasAccessToken && appState === 'MINIBAR'">
     <app-mini-bar-component
       [appState]="appState"
       (appStateDeminimized)="onAppStateDeminimized()">
@@ -152,13 +152,13 @@ app-text-to-speech-component {
   </div>
 
   <app-metrics-component
-      *ngIf="showMetrics && hasAccessToken() && appState !== 'MINIBAR'"
+      *ngIf="showMetrics && hasAccessToken && appState !== 'MINIBAR'"
       [textEntryBeginSubject]="textEntryBeginSubject"
       [textEntryEndSubject]="textEntryEndSubject">
   </app-metrics-component>
 
   <app-lexicon-component
-      *ngIf="hasAccessToken()"
+      *ngIf="hasAccessToken"
       [languageCode]="languageCode"
       [userId]="userId"
       [loadPrefixedLexiconRequestSubject]="loadPrefixedLexiconRequestSubject"
@@ -166,7 +166,7 @@ app-text-to-speech-component {
 
   <div
       class="main-area"
-      *ngIf="hasAccessToken()"
+      *ngIf="hasAccessToken"
       [ngClass]="{'main-area-hidden': appState === 'MINIBAR', 'study-mode': isStudyOn}">
     <div class="main-left-pane">
       <div class="side-pane-button-container">

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -58,6 +58,10 @@ app-text-to-speech-component {
   overflow-y: hidden;
 }
 
+.error-message {
+  color: red;
+}
+
 .main-area {
   align-items: flex-start;
   display: flex;
@@ -198,6 +202,8 @@ app-text-to-speech-component {
     </div>
 
     <div class="main-right-pane">
+      <div *ngIf="errorMessage" class="error-message">{{errorMessage}}</div>
+
       <app-context-component
         [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION'}"
         [userId]="userId"

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -134,6 +134,8 @@ app-text-to-speech-component {
     <app-auth-component (newAccessToken)="onNewAccessToken($event)"></app-auth-component>
   </div>
 
+  <div *ngIf="errorMessage" class="error-message">{{errorMessage}}</div>
+
   <app-external-events-component
       #externalEvents
       [textEntryBeginSubject]="textEntryBeginSubject"
@@ -202,7 +204,6 @@ app-text-to-speech-component {
     </div>
 
     <div class="main-right-pane">
-      <div *ngIf="errorMessage" class="error-message">{{errorMessage}}</div>
 
       <app-context-component
         [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION'}"

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -418,4 +418,19 @@ describe('AppComponent', () => {
         new MouseEvent('click'));
     expect(getAppState()).toEqual(AppState.AI_SETTINGS);
   });
+
+  it('Initially does not show error message', () => {
+    setAppState(AppState.ABBREVIATION_EXPANSION);
+    expect(fixture.componentInstance.errorMessage).toBeUndefined();
+    expect(fixture.debugElement.query(By.css('.error-message'))).toBeNull();
+  });
+
+  it('Shows error message when set to non-empty', () => {
+    setAppState(AppState.ABBREVIATION_EXPANSION);
+    (fixture.componentInstance as any)._errorMessage = 'Error: Foo';
+    fixture.detectChanges();
+    expect(fixture.componentInstance.errorMessage).toEqual('Error: Foo');
+    const errorMessage = fixture.debugElement.query(By.css('.error-message'));
+    expect(errorMessage.nativeElement.innerText).toEqual('Error: Foo');
+  });
 });

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -433,4 +433,14 @@ describe('AppComponent', () => {
     const errorMessage = fixture.debugElement.query(By.css('.error-message'));
     expect(errorMessage.nativeElement.innerText).toEqual('Error: Foo');
   });
+
+  it('hasAccessToken initially returns false', () => {
+    expect(fixture.componentInstance.hasAccessToken).toBeFalse();
+  });
+
+  it('hasAccessToken returns true if access_token is provided', () => {
+    fixture.componentInstance.onNewAccessToken('foo_access_token');
+    expect(fixture.componentInstance.hasAccessToken).toBeTrue();
+  });
+
 });

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {Subject} from 'rxjs';
 

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -323,7 +323,6 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   get errorMessage(): string|undefined {
-    // TODO(cais): Add unit tests. DO NOT SUBMIT.
     return this._errorMessage;
   }
 

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -124,6 +124,9 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
         const oauth2Helper = new OAuth2Helper(params['client_id'], {
           onSuccess: (accessToken: string, user: gapi.auth2.GoogleUser) => {
             this.onNewAccessToken(accessToken);
+            this._userEmail = user.getBasicProfile().getEmail();
+            this._userGivenName = user.getBasicProfile().getGivenName();
+            this.getUserId();
           },
           onInvalidClientId: (invalidClientId) => {
             this._errorMessage = 'Error: invalid OAuth2 client ID';
@@ -147,7 +150,21 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
       console.log(`Got user email from URL parameters: ${userEmail}`);
       if (userEmail && userEmail !== this._userEmail) {
         this._userEmail = userEmail;
-        this.speakFasterService.getUserId(userEmail).subscribe(
+        this.getUserId();
+      }
+      const userGivenName = params['user_given_name'];
+      if (userGivenName && userGivenName !== this._userGivenName) {
+        this._userGivenName = userGivenName;
+      }
+    });
+  }
+
+  private getUserId() {
+    if (!this._userEmail) {
+      return;
+    }
+    this.speakFasterService.getUserId(this._userEmail)
+        .subscribe(
             (response: GetUserIdResponse) => {
               if (response.error) {
                 console.error(
@@ -165,12 +182,6 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
               console.error(
                   'Failed to convert user email to user ID:', this.userEmail);
             });
-      }
-      const userGivenName = params['user_given_name'];
-      if (userGivenName && userGivenName !== this._userGivenName) {
-        this._userGivenName = userGivenName;
-      }
-    });
   }
 
   private stringValueMeansTrue(str: string): boolean {

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {Subject} from 'rxjs';
 
@@ -111,11 +111,12 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
         this._showMetrics = this.stringValueMeansTrue(params['show_metrics']);
       }
       if (params['client_id']) {
-        const oauth2helper =
-            new OAuth2Helper(params['client_id'], this.onNewAccessToken.bind(this));
+        const oauth2helper = new OAuth2Helper(
+            params['client_id'], this.onNewAccessToken.bind(this));
         // const oauth2helper =
         //     new OAuth2Helper(params['client_id'], (accessToken) => {
-        //       console.log('New access token from oauth2Helper:', accessToken);  // DEBUG
+        //       console.log('New access token from oauth2Helper:',
+        //       accessToken);  // DEBUG
         //     });
         console.log('*** oauth2helper:', oauth2helper);  // DEBUG
         oauth2helper.init();
@@ -304,14 +305,16 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   onNewAccessToken(accessToken: string) {
     this._accessToken = accessToken;
-    console.log('*** Configuration access token:', accessToken, this.endpoint);  // DEBUG
+    console.log(
+        '*** Configuration access token:', accessToken,
+        this.endpoint);  // DEBUG
     configureService({
       endpoint: this.endpoint,
       accessToken,
     });
   }
 
-  hasAccessToken(): boolean {
+  get hasAccessToken(): boolean {
     return !this.useAccessToken || this._accessToken !== '';
   }
 

--- a/webui/src/app/app.component.ts
+++ b/webui/src/app/app.component.ts
@@ -5,6 +5,7 @@ import {Subject} from 'rxjs';
 import {bindCefSharpListener, bringFocusAppToForeground, bringWindowToForeground, EYE_TRACKER_STATUS, registerExternalAccessTokenHook, registerExternalKeypressHook, registerEyeTrackerStatusHook, registerHostWindowFocusHook, resizeWindow, setHostEyeGazeOptions, toggleGazeButtonsState, updateButtonBoxesForElements, updateButtonBoxesToEmpty} from '../utils/cefsharp';
 import {createUuid} from '../utils/uuid';
 
+import {OAuth2Helper} from './auth/oauth2-helper';
 import {HttpEventLogger} from './event-logger/event-logger-impl';
 import {ExternalEventsComponent} from './external/external-events.component';
 import {InputBarControlEvent} from './input-bar/input-bar.component';
@@ -108,6 +109,17 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
       }
       if (params['show_metrics']) {
         this._showMetrics = this.stringValueMeansTrue(params['show_metrics']);
+      }
+      if (params['client_id']) {
+        const oauth2helper =
+            new OAuth2Helper(params['client_id'], this.onNewAccessToken.bind(this));
+        // const oauth2helper =
+        //     new OAuth2Helper(params['client_id'], (accessToken) => {
+        //       console.log('New access token from oauth2Helper:', accessToken);  // DEBUG
+        //     });
+        console.log('*** oauth2helper:', oauth2helper);  // DEBUG
+        oauth2helper.init();
+        // oauth2helper.signIn();
       }
       const useOauth = params['use_oauth'];
       if (typeof useOauth === 'string' &&
@@ -292,8 +304,9 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   onNewAccessToken(accessToken: string) {
     this._accessToken = accessToken;
+    console.log('*** Configuration access token:', accessToken, this.endpoint);  // DEBUG
     configureService({
-      endpoint: this._endpoint,
+      endpoint: this.endpoint,
       accessToken,
     });
   }

--- a/webui/src/app/auth/auth.component.spec.ts
+++ b/webui/src/app/auth/auth.component.spec.ts
@@ -67,17 +67,17 @@ describe('AuthComponent', () => {
            'Cannot authenticate. Missing client ID.', 'error');
      });
 
-  it('clicking authenticate button without client_secret leads to error snackbar',
+  it('clicking authenticate button without client_secret does not call error snackbar',
      () => {
        mockActivatedRoute.testParams = {
          client_id: 'foo_client_id',
+         // Notice missing client_secret.
        };
        fixture.detectChanges();
        const spy = spyOn(component, 'showSnackBar').and.callThrough();
        const button = fixture.debugElement.query(By.css('#authenticate'));
        button.triggerEventHandler('click', null);
-       expect(spy).toHaveBeenCalledWith(
-           'Cannot authenticate. Missing client secret.', 'error');
+       expect(spy).not.toHaveBeenCalled();
      });
 
   it('clicking authenticate button should call device code route and display url and user code',

--- a/webui/src/app/auth/auth.component.ts
+++ b/webui/src/app/auth/auth.component.ts
@@ -77,8 +77,6 @@ export class AuthComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
     if (this.clientSecret === '') {
-      // TODO(cais): Confirm. Update unit test.
-      // this.showSnackBar('Cannot authenticate. Missing client secret.', 'error');
       return;
     }
     this.authService.getDeviceCode(this.clientId)

--- a/webui/src/app/auth/auth.component.ts
+++ b/webui/src/app/auth/auth.component.ts
@@ -77,7 +77,8 @@ export class AuthComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
     if (this.clientSecret === '') {
-      this.showSnackBar('Cannot authenticate. Missing client secret.', 'error');
+      // TODO(cais): Confirm. Update unit test.
+      // this.showSnackBar('Cannot authenticate. Missing client secret.', 'error');
       return;
     }
     this.authService.getDeviceCode(this.clientId)

--- a/webui/src/app/auth/oauth2-helper.ts
+++ b/webui/src/app/auth/oauth2-helper.ts
@@ -9,6 +9,11 @@ export class OAuth2Helper {
   private user?: gapi.auth2.GoogleUser;
   private _accessToken: string|null = null;
 
+  /** Singleton access. Requires a unique client ID. */
+  public getInstance(client_id: string) {
+
+  }
+
   constructor(
       private readonly clientId: string,
       private onNewAccessToken: (token: string) => void) {}

--- a/webui/src/app/auth/oauth2-helper.ts
+++ b/webui/src/app/auth/oauth2-helper.ts
@@ -10,51 +10,49 @@ export class OAuth2Helper {
   private _accessToken: string|null = null;
 
   /** Singleton access. Requires a unique client ID. */
-  public getInstance(client_id: string) {
+  public getInstance(client_id: string) {}
 
-  }
-
-  constructor(
-      private readonly clientId: string,
-      private onNewAccessToken: (token: string) => void) {}
+  constructor(private readonly clientId: string, private callbacks: {
+    onSuccess: (token: string, user: gapi.auth2.GoogleUser) => void,
+    onInvalidClientId: (clientId: string) => void,
+    onInvalidUserInfo: () => void,
+    onUserNotAuthorized: () => void,
+    onNoGapiError: () => void,
+    onMiscError: (error: Error) => void,
+  }) {}
 
   public init() {
-    gapi.load('client:auth2', () => {
-      if (!this.clientId) {
-        //  TODO(cais): Turn into callback.
-        //   this._errorMessage = 'Missing client ID. Check URL.';
-        //   this.cdr.detectChanges();
-        //   return;
-      }
-      // TODO(cais): Turn into callback.
-      // this.state = State.SIGNING_IN;
-      gapi.client
-          .init({
-            // TODO(cais): DO NOT SUBMIT. Remove. Use client secret param instead.
-            // apiKey,
-            clientId: this.clientId,
-            scope: GOOGLE_AUTH_SCOPE,
-            discoveryDocs: [DISCOVERY_URL],
-          })
-          .then(() => {
-            console.log(
-                '*** gapi client is created. Creating google auth instance.');
-            this.googleAuth = gapi.auth2.getAuthInstance();
-            console.log('*** Created google auth instance:', this.googleAuth);
-            this.googleAuth.isSignedIn.listen(() => {
-              console.log('*** google auth is signed in.');
+    if ((window as any).gapi) {
+      gapi.load('client:auth2', () => {
+        if (!this.clientId) {
+          this.callbacks.onInvalidClientId(this.clientId);
+        }
+        gapi.client
+            .init({
+              clientId: this.clientId,
+              scope: GOOGLE_AUTH_SCOPE,
+              discoveryDocs: [DISCOVERY_URL],
+            })
+            .then(() => {
+              console.log(
+                  '*** gapi client is created. Creating google auth instance.');
+              this.googleAuth = gapi.auth2.getAuthInstance();
+              console.log('*** Created google auth instance:', this.googleAuth);
+              this.googleAuth.isSignedIn.listen(() => {
+                console.log('*** google auth is signed in.');
+                this.getUserInfo();
+              });
               this.getUserInfo();
+            })
+            .catch((error) => {
+              this.callbacks.onMiscError(error);
+              this.signIn();
             });
-            console.log('*** B100');  // DEBUG
-            this.getUserInfo();
-          })
-          .catch((error) => {
-            console.log('*** In catch:', error);  // DEBUG
-            this.signIn();
-          });
-      //  TODO(cais): Turn into callback.
-      //   this.cdr.detectChanges();
-    });
+      });
+    } else {
+      console.error('gapi is not defined. cannot perform authentication.');
+      this.callbacks.onNoGapiError();
+    }
   }
 
   private getUserInfo(): void {
@@ -63,64 +61,28 @@ export class OAuth2Helper {
       console.log('Got current user:', this.user);
     }
     if (!this.user) {
-      // TODO(cais): Turn into callback.
-      //   this._errorMessage = 'Failed to get current user';
-      //   this.resetPartnerInfo();
-      //   this.state = State.NOT_SIGNED_IN;
-      //   this.cdr.detectChanges();
       console.error('Failed to get current user');
+      this.callbacks.onInvalidUserInfo();
       return;
     }
     const isAuthorized = this.user.hasGrantedScopes(GOOGLE_AUTH_SCOPE);
     if (!isAuthorized) {
-      // TODO(cais): Turn into callback.
-      //   this._errorMessage = 'Not authorized for given scope';
-      //   this.resetPartnerInfo();
-      //   this.state = State.NOT_SIGNED_IN;
-      //   this.cdr.detectChanges();
+      this.callbacks.onUserNotAuthorized();
       console.error('*** User is not authorized for given scope');
       this.signIn();  // TODO(cais): Confirm.
       return;
     }
     this._accessToken = this.user.getAuthResponse().access_token;
-    this.onNewAccessToken(this._accessToken);
+    this.callbacks.onSuccess(this._accessToken, this.user);
     console.log('*** Got user access token:', this._accessToken);
-    // this.newAccessToken.emit(this._accessToken);
-    const userProfile = this.user.getBasicProfile();
-    // this._partnerEmail = userProfile.getEmail();
-    // this._partnerGivenName = userProfile.getGivenName();
-    // this._partnerProfileImageUrl = userProfile.getImageUrl();
-    // this.state = State.GETTING_AAC_USER_LIST;
-    // console.log('Getting partner users...');
-    // this.speakFasterService.getPartnerUsers(this._partnerEmail!)
-    //     .subscribe(
-    //         (partnerUsersResonse: PartnerUsersResponse) => {
-    //           this._userIds.splice(0);
-    //           this._userIds.push(...partnerUsersResonse.user_ids);
-    //           console.log('Added user IDs:', this._userIds);
-    //           this.state = State.READY;
-    //           this.cdr.detectChanges();
-    //         },
-    //         (error) => {
-    //           this._errorMessage =
-    //               'Failed to get partner users. Using default.';
-    //           this._userIds.splice(0);
-    //           this._userIds.push(...DEFAULT_USER_IDS);
-    //           this.state = State.READY;
-    //           this.cdr.detectChanges();
-    //           console.warn(
-    //               'Retrieving partner user IDs failed, using default user
-    //               IDs:', this._userIds);
-    //         });
-    // this._errorMessage = null;
-    // if (this.turnTextInput) {
-    //   setTimeout(() => this.turnTextInput.nativeElement.focus());
-    // }
-    // this.cdr.detectChanges();
   }
 
   public signIn() {
     console.log('*** Calling signIn():', this.googleAuth);  // DEBUG
     this.googleAuth!.signIn();
+  }
+
+  public signOut() {
+    this.googleAuth!.signOut();
   }
 }

--- a/webui/src/app/auth/oauth2-helper.ts
+++ b/webui/src/app/auth/oauth2-helper.ts
@@ -1,0 +1,121 @@
+import {} from 'gapi.auth2';
+
+const GOOGLE_AUTH_SCOPE = 'https://www.googleapis.com/auth/userinfo.email';
+const DISCOVERY_URL =
+    'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest';
+
+export class OAuth2Helper {
+  private googleAuth?: gapi.auth2.GoogleAuth;
+  private user?: gapi.auth2.GoogleUser;
+  private _accessToken: string|null = null;
+
+  constructor(
+      private readonly clientId: string,
+      private onNewAccessToken: (token: string) => void) {}
+
+  public init() {
+    gapi.load('client:auth2', () => {
+      if (!this.clientId) {
+        //  TODO(cais): Turn into callback.
+        //   this._errorMessage = 'Missing client ID. Check URL.';
+        //   this.cdr.detectChanges();
+        //   return;
+      }
+      // TODO(cais): Turn into callback.
+      // this.state = State.SIGNING_IN;
+      gapi.client
+          .init({
+            // TODO(cais): DO NOT SUBMIT. Remove. Use client secret param instead.
+            // apiKey,
+            clientId: this.clientId,
+            scope: GOOGLE_AUTH_SCOPE,
+            discoveryDocs: [DISCOVERY_URL],
+          })
+          .then(() => {
+            console.log(
+                '*** gapi client is created. Creating google auth instance.');
+            this.googleAuth = gapi.auth2.getAuthInstance();
+            console.log('*** Created google auth instance:', this.googleAuth);
+            this.googleAuth.isSignedIn.listen(() => {
+              console.log('*** google auth is signed in.');
+              this.getUserInfo();
+            });
+            console.log('*** B100');  // DEBUG
+            this.getUserInfo();
+          })
+          .catch((error) => {
+            console.log('*** In catch:', error);  // DEBUG
+            this.signIn();
+          });
+      //  TODO(cais): Turn into callback.
+      //   this.cdr.detectChanges();
+    });
+  }
+
+  private getUserInfo(): void {
+    if (!this.user) {
+      this.user = this.googleAuth!.currentUser.get();
+      console.log('Got current user:', this.user);
+    }
+    if (!this.user) {
+      // TODO(cais): Turn into callback.
+      //   this._errorMessage = 'Failed to get current user';
+      //   this.resetPartnerInfo();
+      //   this.state = State.NOT_SIGNED_IN;
+      //   this.cdr.detectChanges();
+      console.error('Failed to get current user');
+      return;
+    }
+    const isAuthorized = this.user.hasGrantedScopes(GOOGLE_AUTH_SCOPE);
+    if (!isAuthorized) {
+      // TODO(cais): Turn into callback.
+      //   this._errorMessage = 'Not authorized for given scope';
+      //   this.resetPartnerInfo();
+      //   this.state = State.NOT_SIGNED_IN;
+      //   this.cdr.detectChanges();
+      console.error('*** User is not authorized for given scope');
+      this.signIn();  // TODO(cais): Confirm.
+      return;
+    }
+    this._accessToken = this.user.getAuthResponse().access_token;
+    this.onNewAccessToken(this._accessToken);
+    console.log('*** Got user access token:', this._accessToken);
+    // this.newAccessToken.emit(this._accessToken);
+    const userProfile = this.user.getBasicProfile();
+    // this._partnerEmail = userProfile.getEmail();
+    // this._partnerGivenName = userProfile.getGivenName();
+    // this._partnerProfileImageUrl = userProfile.getImageUrl();
+    // this.state = State.GETTING_AAC_USER_LIST;
+    // console.log('Getting partner users...');
+    // this.speakFasterService.getPartnerUsers(this._partnerEmail!)
+    //     .subscribe(
+    //         (partnerUsersResonse: PartnerUsersResponse) => {
+    //           this._userIds.splice(0);
+    //           this._userIds.push(...partnerUsersResonse.user_ids);
+    //           console.log('Added user IDs:', this._userIds);
+    //           this.state = State.READY;
+    //           this.cdr.detectChanges();
+    //         },
+    //         (error) => {
+    //           this._errorMessage =
+    //               'Failed to get partner users. Using default.';
+    //           this._userIds.splice(0);
+    //           this._userIds.push(...DEFAULT_USER_IDS);
+    //           this.state = State.READY;
+    //           this.cdr.detectChanges();
+    //           console.warn(
+    //               'Retrieving partner user IDs failed, using default user
+    //               IDs:', this._userIds);
+    //         });
+    // this._errorMessage = null;
+    // if (this.turnTextInput) {
+    //   setTimeout(() => this.turnTextInput.nativeElement.focus());
+    // }
+    // this.cdr.detectChanges();
+  }
+
+  public signIn() {
+    console.log('*** Calling signIn():', this.googleAuth);  // DEBUG
+    this.googleAuth!.signIn();
+  }
+}

--- a/webui/src/app/auth/oauth2-helper.ts
+++ b/webui/src/app/auth/oauth2-helper.ts
@@ -9,9 +9,6 @@ export class OAuth2Helper {
   private user?: gapi.auth2.GoogleUser;
   private _accessToken: string|null = null;
 
-  /** Singleton access. Requires a unique client ID. */
-  public getInstance(client_id: string) {}
-
   constructor(private readonly clientId: string, private callbacks: {
     onSuccess: (token: string, user: gapi.auth2.GoogleUser) => void,
     onInvalidClientId: (clientId: string) => void,
@@ -69,7 +66,7 @@ export class OAuth2Helper {
     if (!isAuthorized) {
       this.callbacks.onUserNotAuthorized();
       console.error('*** User is not authorized for given scope');
-      this.signIn();  // TODO(cais): Confirm.
+      this.signIn();
       return;
     }
     this._accessToken = this.user.getAuthResponse().access_token;
@@ -78,7 +75,6 @@ export class OAuth2Helper {
   }
 
   public signIn() {
-    console.log('*** Calling signIn():', this.googleAuth);  // DEBUG
     this.googleAuth!.signIn();
   }
 

--- a/webui/src/app/input-bar-chip/input-bar-chip.component.html
+++ b/webui/src/app/input-bar-chip/input-bar-chip.component.html
@@ -46,6 +46,7 @@
     (click)="onMainButtonClicked($event)">
   <input
       #inputBox
+      autocomplete="off"
       class="input-box"
       (keyup)="onInputBoxKeyUp($event)" />
 </button>

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -215,6 +215,7 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
 
   ping() {
     const {headers, withCredentials} = this.getServerCallParams();
+    // TODO(cais): Migrate to compat.
     return this.http.get<PingResponse>(configuration!.endpoint, {
       params: {
         mode: 'ping',
@@ -261,12 +262,6 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
     if (keywordIndices && wordAbbrevMode) {
       (params as any)['wordAbbrevMode'] = wordAbbrevMode;
     }
-    const body = {json: JSON.stringify(params)};
-
-    // this.http
-    //     .post<AbbreviationExpansionRespnose>(endpoint, body, {
-    //       headers,
-    //     })
     return invokeEndpointCompat<AbbreviationExpansionRespnose>(
                endpoint, this.http, params, headers, withCredentials)
         .pipe(
@@ -302,12 +297,8 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
     if (textPredictionRequest.allowedTags) {
       params['allowedTags'] = textPredictionRequest.allowedTags.join(',');
     }
-    return this.http
-        .get<TextPredictionResponse>(endpoint, {
-          params,
-          withCredentials,
-          headers,
-        })
+    return invokeEndpointCompat<TextPredictionResponse>(
+               endpoint, this.http, params, headers, withCredentials)
         .pipe(timeout(TEXT_PREDICTION_TIMEOUT_MILLIS), catchError(error => {
                 return throwError(makeTimeoutErrorMessage(
                     'Text prediction', TEXT_PREDICTION_TIMEOUT_MILLIS));
@@ -325,12 +316,8 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
           request.contextualPhrase.tags.join(',') :
           undefined,
     };
-    return this.http
-        .get<AddContextualPhraseResponse>(endpoint, {
-          params,
-          withCredentials,
-          headers,
-        })
+    return invokeEndpointCompat<AddContextualPhraseResponse>(
+               endpoint, this.http, params, headers, withCredentials)
         .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
                 return throwError(makeTimeoutErrorMessage(
                     'Add context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
@@ -345,12 +332,8 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       userId: request.userId,
       phraseId: request.phraseId,
     };
-    return this.http
-        .get<DeleteContextualPhraseResponse>(endpoint, {
-          params,
-          withCredentials,
-          headers,
-        })
+    return invokeEndpointCompat<DeleteContextualPhraseResponse>(
+               endpoint, this.http, params, headers, withCredentials)
         .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
                 return throwError(makeTimeoutErrorMessage(
                     'Delete context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
@@ -367,12 +350,8 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       text: request.text,
       displayText: request.displayText,
     };
-    return this.http
-        .get<EditContextualPhraseResponse>(endpoint, {
-          params,
-          withCredentials,
-          headers,
-        })
+    return invokeEndpointCompat<EditContextualPhraseResponse>(
+               endpoint, this.http, params, headers, withCredentials)
         .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
                 return throwError(makeTimeoutErrorMessage(
                     'Edit context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
@@ -388,12 +367,8 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       phraseId: request.phraseId,
       lastUsedTimestamp: new Date().toISOString(),
     };
-    return this.http
-        .get<MarkContextualPhraseUsageResponse>(endpoint, {
-          params,
-          withCredentials,
-          headers,
-        })
+    return invokeEndpointCompat<MarkContextualPhraseUsageResponse>(
+               endpoint, this.http, params, headers, withCredentials)
         .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
                 return throwError(makeTimeoutErrorMessage(
                     'Mark context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
@@ -407,31 +382,27 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       speechContent: trimStringAtHead(
           request.speechContent, FILL_MASK_CONTEXT_MAX_LENGTH_CHARS),
     };
-    return this.http
-        .get<FillMaskResponse>(endpoint, {
-          params: {
-            mode: 'fill_mask',
-            ...request,
-          },
-          withCredentials,
-          headers,
-        })
+    const params = {
+      mode: 'fill_mask',
+      ...request,
+    };
+    return invokeEndpointCompat<FillMaskResponse>(
+               endpoint, this.http, params, headers, withCredentials)
         .pipe(timeout(FILL_MASK_TIMEOUT_MILLIS), catchError(error => {
                 return throwError(makeTimeoutErrorMessage(
                     'Word replacement', FILL_MASK_TIMEOUT_MILLIS));
               }));
   }
 
-  retrieveContext(userId: string) {
+  retrieveContext(userId: string): Observable<RetrieveContextResponse> {
     const {endpoint, headers, withCredentials} = this.getServerCallParams();
-    return this.http.get<RetrieveContextResponse>(endpoint, {
-      params: {
-        mode: 'retrieve_context',
-        userId: userId,
-      },
-      withCredentials,
-      headers,
-    });
+    const params = {
+      mode: 'retrieve_context',
+      userId: userId,
+    };
+    // TODO(cais): Add time out? DO NOT SUBMIT.
+    return invokeEndpointCompat<RetrieveContextResponse>(
+        endpoint, this.http, params, headers, withCredentials);
   }
 
   registerContext(
@@ -441,18 +412,17 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
     const {endpoint, headers, withCredentials} = this.getServerCallParams();
     startTimestamp = startTimestamp || new Date();
     timezone = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return this.http.get<RegisterContextResponse>(endpoint, {
-      params: {
-        mode: 'register_context',
-        userId: userId,
-        speechContent: speechContent,
-        startTimestamp: startTimestamp.toISOString(),
-        timezone: timezone,
-        speakerId: partnerName,
-      },
-      withCredentials,
-      headers,
-    });
+    const params = {
+      mode: 'register_context',
+      userId: userId,
+      speechContent: speechContent,
+      startTimestamp: startTimestamp.toISOString(),
+      timezone: timezone,
+      speakerId: partnerName,
+    }
+    // TODO(cais): Add time out? DO NOT SUBMIT.
+    return invokeEndpointCompat<RegisterContextResponse>(
+        endpoint, this.http, params, headers, withCredentials)
   }
 
   getUserId(userEmail: string): Observable<GetUserIdResponse> {
@@ -477,16 +447,15 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
 
   getLexicon(request: GetLexiconRequest): Observable<GetLexiconResponse> {
     const {endpoint, headers, withCredentials} = this.getServerCallParams();
-    return this.http.get<GetLexiconResponse>(endpoint, {
-      params: {
-        mode: 'get_lexicon',
-        languageCode: request.languageCode,
-        subset: request.subset || '',
-        prefix: request.prefix || '',
-      },
-      withCredentials,
-      headers,
-    });
+    const params = {
+      mode: 'get_lexicon',
+      languageCode: request.languageCode,
+      subset: request.subset || '',
+      prefix: request.prefix || '',
+    }
+    // TODO(cais): Add time out? DO NOT SUBMIT.
+    return invokeEndpointCompat<GetLexiconResponse>(
+        endpoint, this.http, params, headers, withCredentials);
   }
 
   private getServerCallParams(): {

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -215,7 +215,6 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
 
   ping() {
     const {headers, withCredentials} = this.getServerCallParams();
-    // TODO(cais): Migrate to compat.
     return this.http.get<PingResponse>(configuration!.endpoint, {
       params: {
         mode: 'ping',
@@ -505,7 +504,6 @@ export function invokeEndpointCompat<T>(
   }
 }
 
-// TODO(cais): Add unit test.
 export function maybeStripJsonField(response: any) {
   if (response.json) {
     if (typeof response.json === 'string') {

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -1,12 +1,12 @@
 /** HTTP service of SpeakFaster. */
 
-import {HttpClient, HttpParams} from '@angular/common/http';
+import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable, throwError} from 'rxjs';
 import {catchError, map, timeout} from 'rxjs/operators';
 import {trimStringAtHead} from 'src/utils/text-utils';
 
-import {AbbreviationSpec, WordAbbrevMode} from './types/abbreviation';
+import {AbbreviationSpec} from './types/abbreviation';
 import {ContextSignal} from './types/context';
 import {AddContextualPhraseRequest, AddContextualPhraseResponse, ContextualPhrase, DeleteContextualPhraseRequest, DeleteContextualPhraseResponse, EditContextualPhraseRequest, EditContextualPhraseResponse, MarkContextualPhraseUsageRequest, MarkContextualPhraseUsageResponse} from './types/contextual_phrase';
 
@@ -482,8 +482,7 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
 }
 
 /**
- * Invoke API endpoint in a backward-compatible way.
- * @param endpoint
+ * Invokes API endpoint in a backward-compatible way.
  */
 export function invokeEndpointCompat<T>(
     endpoint: string, http: HttpClient, params: any, headers: any,

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -197,6 +197,7 @@ const ABBREVIATION_EXPANSION_TIMEOUT_MILLIS = 6000;
 const TEXT_PREDICTION_TIMEOUT_MILLIS = 6000;
 const FILL_MASK_TIMEOUT_MILLIS = 6000;
 const CONTEXT_PHRASES_TIMEOUT_MILLIS = 10000;
+const LEXICON_TIMEOUT_MILLIS = 10000;
 
 const ABBREVIATION_EXPANSION_CONTEXT_MAX_LENGTH_CHARS = 1000;
 const ABBREVIATION_EXPANSION_WITH_KEYWORDS_CONTEXT_MAX_LENGTH_CHARS = 200;
@@ -262,14 +263,12 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       (params as any)['wordAbbrevMode'] = wordAbbrevMode;
     }
     return invokeEndpointCompat<AbbreviationExpansionRespnose>(
-               endpoint, this.http, params, headers, withCredentials)
-        .pipe(
-            timeout(ABBREVIATION_EXPANSION_TIMEOUT_MILLIS),
-            catchError(error => {
-              return throwError(makeTimeoutErrorMessage(
-                  'Abbreviation expansion',
-                  ABBREVIATION_EXPANSION_TIMEOUT_MILLIS));
-            }));
+               endpoint, this.http, params, headers, withCredentials,
+               ABBREVIATION_EXPANSION_TIMEOUT_MILLIS)
+        .pipe(catchError(error => {
+          return throwError(makeTimeoutErrorMessage(
+              'Abbreviation expansion', ABBREVIATION_EXPANSION_TIMEOUT_MILLIS));
+        }));
   }
 
   textPrediction(textPredictionRequest: TextPredictionRequest):
@@ -297,11 +296,12 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       params['allowedTags'] = textPredictionRequest.allowedTags.join(',');
     }
     return invokeEndpointCompat<TextPredictionResponse>(
-               endpoint, this.http, params, headers, withCredentials)
-        .pipe(timeout(TEXT_PREDICTION_TIMEOUT_MILLIS), catchError(error => {
-                return throwError(makeTimeoutErrorMessage(
-                    'Text prediction', TEXT_PREDICTION_TIMEOUT_MILLIS));
-              }));
+               endpoint, this.http, params, headers, withCredentials,
+               TEXT_PREDICTION_TIMEOUT_MILLIS)
+        .pipe(catchError(error => {
+          return throwError(makeTimeoutErrorMessage(
+              'Text prediction', TEXT_PREDICTION_TIMEOUT_MILLIS));
+        }));
   }
 
   addContextualPhrase(request: AddContextualPhraseRequest):
@@ -316,11 +316,12 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
           undefined,
     };
     return invokeEndpointCompat<AddContextualPhraseResponse>(
-               endpoint, this.http, params, headers, withCredentials)
-        .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
-                return throwError(makeTimeoutErrorMessage(
-                    'Add context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
-              }));
+               endpoint, this.http, params, headers, withCredentials,
+               CONTEXT_PHRASES_TIMEOUT_MILLIS)
+        .pipe(catchError(error => {
+          return throwError(makeTimeoutErrorMessage(
+              'Add context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
+        }));
   }
 
   deleteContextualPhrase(request: DeleteContextualPhraseRequest):
@@ -350,11 +351,12 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       displayText: request.displayText,
     };
     return invokeEndpointCompat<EditContextualPhraseResponse>(
-               endpoint, this.http, params, headers, withCredentials)
-        .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
-                return throwError(makeTimeoutErrorMessage(
-                    'Edit context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
-              }));
+               endpoint, this.http, params, headers, withCredentials,
+               CONTEXT_PHRASES_TIMEOUT_MILLIS)
+        .pipe(catchError(error => {
+          return throwError(makeTimeoutErrorMessage(
+              'Edit context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
+        }));
   }
 
   markContextualPhraseUsage(request: MarkContextualPhraseUsageRequest):
@@ -367,11 +369,12 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       lastUsedTimestamp: new Date().toISOString(),
     };
     return invokeEndpointCompat<MarkContextualPhraseUsageResponse>(
-               endpoint, this.http, params, headers, withCredentials)
-        .pipe(timeout(CONTEXT_PHRASES_TIMEOUT_MILLIS), catchError(error => {
-                return throwError(makeTimeoutErrorMessage(
-                    'Mark context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
-              }));
+               endpoint, this.http, params, headers, withCredentials,
+               CONTEXT_PHRASES_TIMEOUT_MILLIS)
+        .pipe(catchError(error => {
+          return throwError(makeTimeoutErrorMessage(
+              'Mark context phrase', CONTEXT_PHRASES_TIMEOUT_MILLIS));
+        }));
   }
 
   fillMask(request: FillMaskRequest): Observable<FillMaskResponse> {
@@ -386,11 +389,12 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       ...request,
     };
     return invokeEndpointCompat<FillMaskResponse>(
-               endpoint, this.http, params, headers, withCredentials)
-        .pipe(timeout(FILL_MASK_TIMEOUT_MILLIS), catchError(error => {
-                return throwError(makeTimeoutErrorMessage(
-                    'Word replacement', FILL_MASK_TIMEOUT_MILLIS));
-              }));
+               endpoint, this.http, params, headers, withCredentials,
+               FILL_MASK_TIMEOUT_MILLIS)
+        .pipe(catchError(error => {
+          return throwError(makeTimeoutErrorMessage(
+              'Word replacement', FILL_MASK_TIMEOUT_MILLIS));
+        }));
   }
 
   retrieveContext(userId: string): Observable<RetrieveContextResponse> {
@@ -399,9 +403,9 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       mode: 'retrieve_context',
       userId: userId,
     };
-    // TODO(cais): Add time out? DO NOT SUBMIT.
     return invokeEndpointCompat<RetrieveContextResponse>(
-        endpoint, this.http, params, headers, withCredentials);
+        endpoint, this.http, params, headers, withCredentials,
+        CONTEXT_PHRASES_TIMEOUT_MILLIS);
   }
 
   registerContext(
@@ -418,10 +422,10 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       startTimestamp: startTimestamp.toISOString(),
       timezone: timezone,
       speakerId: partnerName,
-    }
-    // TODO(cais): Add time out? DO NOT SUBMIT.
+    };
     return invokeEndpointCompat<RegisterContextResponse>(
-        endpoint, this.http, params, headers, withCredentials)
+        endpoint, this.http, params, headers, withCredentials,
+        CONTEXT_PHRASES_TIMEOUT_MILLIS);
   }
 
   getUserId(userEmail: string): Observable<GetUserIdResponse> {
@@ -451,10 +455,10 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
       languageCode: request.languageCode,
       subset: request.subset || '',
       prefix: request.prefix || '',
-    }
-    // TODO(cais): Add time out? DO NOT SUBMIT.
+    };
     return invokeEndpointCompat<GetLexiconResponse>(
-        endpoint, this.http, params, headers, withCredentials);
+        endpoint, this.http, params, headers, withCredentials,
+        LEXICON_TIMEOUT_MILLIS);
   }
 
   private getServerCallParams(): {
@@ -485,16 +489,20 @@ export class SpeakFasterService implements SpeakFasterServiceStub {
  */
 export function invokeEndpointCompat<T>(
     endpoint: string, http: HttpClient, params: any, headers: any,
-    withCredentials: boolean): Observable<T> {
+    withCredentials: boolean, timeoutMillis?: number): Observable<T> {
   if (endpoint.endsWith(':call')) {  // New POST endpoint.
     const body = {json: JSON.stringify(params)};
-    return http
-        .post<T>(endpoint, body, {
-          headers,
-        })
-        .pipe(
-            map(response => maybeStripJsonField(response) as T),
-        );
+    let observable =
+        http.post<T>(endpoint, body, {
+              headers,
+            })
+            .pipe(
+                map(response => maybeStripJsonField(response) as T),
+            );
+    if (timeoutMillis) {
+      observable = observable.pipe(timeout(timeoutMillis));
+    }
+    return observable;
   } else {  // Old GET endpoint.
     return http.get<T>(endpoint, {
       params,

--- a/webui/src/app/types/speakfaster-service.spec.ts
+++ b/webui/src/app/types/speakfaster-service.spec.ts
@@ -1,0 +1,21 @@
+import {maybeStripJsonField} from '../speakfaster-service';
+
+describe('SpeakFaster service', () => {
+  it('maybeStripJsonField strips json: string value', () => {
+    expect(maybeStripJsonField({
+      json: JSON.stringify({pingResponse: 'okay'})
+    })).toEqual({pingResponse: 'okay'});
+  });
+
+  it('maybeStripJsonField strips json: object value', () => {
+    expect(maybeStripJsonField({json: {pingResponse: 'okay'}})).toEqual({
+      pingResponse: 'okay'
+    });
+  });
+
+  it('maybeStripJsonField: works for no-json case', () => {
+    expect(maybeStripJsonField({pingResponse: 'okay'})).toEqual({
+      pingResponse: 'okay'
+    });
+  });
+});


### PR DESCRIPTION
- Accommodate new API endpoint format
- Support getting access token from OAuth2 (non limited input device) 
- When access token is available, do not use cookie-based credentials (`withCredentaisl`)
