### PR TITLE
[WebUI] Make TTS selection logic work for browsers without TTS

### DIFF
--- a/webui/src/app/text-to-speech/text-to-speech.component.spec.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.spec.ts
@@ -4,7 +4,7 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {of, Subject, throwError} from 'rxjs';
 import {BOUND_LISTENER_NAME} from 'src/utils/cefsharp';
 
-import {clearSettings, setTtsVoiceType} from '../settings/settings';
+import {clearSettings, getAppSettings, setTtsVoiceType} from '../settings/settings';
 import {TextEntryEndEvent} from '../types/text-entry';
 
 import {getCloudTextToSpeechVolumeGainDb, getLocalTextToSpeechVolume, TextToSpeechComponent, TextToSpeechEvent, TextToSpeechListener} from './text-to-speech.component';
@@ -262,4 +262,14 @@ describe('TextToSpeechCmponent', () => {
        expect(component.ttsAudioElements.first.nativeElement.src)
            .toEqual('data:audio/wav;base64,0123abcd');
      }));
+
+  it('Initializes to cloud (personalized) TTS if speechSynthesis is unavailable',
+      async () => {
+        setTtsVoiceType('GENERIC');
+        spyOn(fixture.componentInstance, 'getSpeechSynthesis')
+            .and.returnValue(undefined);
+        fixture.componentInstance.ngOnInit();
+        await fixture.whenStable();
+        expect((await getAppSettings()).ttsVoiceType).toEqual('PERSONALIZED');
+      });
 });

--- a/webui/src/app/text-to-speech/text-to-speech.component.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.ts
@@ -142,7 +142,6 @@ export class TextToSpeechComponent implements OnInit {
    * Send Cloud call for speech synthesis and then play the synthesized audio.
    */
   private doCloudTextToSpeech(text: string, appSettings: AppSettings) {
-    console.log('*** C100:', text);  // DEBUG
     if (this.accessToken.length === 0) {
       TextToSpeechComponent.listeners.forEach(listener => {
         listener({state: 'ERROR', errorMessage: 'No access token'});

--- a/webui/src/app/text-to-speech/text-to-speech.component.ts
+++ b/webui/src/app/text-to-speech/text-to-speech.component.ts
@@ -100,8 +100,8 @@ export class TextToSpeechComponent implements OnInit {
   ngOnInit() {
     // NOTE: Reference getVoice() at the beginning because the voices are
     // populated lazily in some browsers and WebViews.
-    if (window.speechSynthesis) {
-      window.speechSynthesis.getVoices();
+    if (this.getSpeechSynthesis()) {
+      this.getSpeechSynthesis()!.getVoices();
     } else {
       console.warn(
           'window.speechSynthesis is unavailable; ' +
@@ -216,7 +216,7 @@ export class TextToSpeechComponent implements OnInit {
     utterance.volume = getLocalTextToSpeechVolume(appSettings);
     utterance.rate = appSettings.ttsSpeakingRate || 1.0;
     if (!this.audioPlayDisabledForTest) {
-      window.speechSynthesis.speak(utterance);
+      this.getSpeechSynthesis()!.speak(utterance);
     }
   }
 
@@ -232,5 +232,9 @@ export class TextToSpeechComponent implements OnInit {
 
   get audioPlayCallCount(): number {
     return this._audioPlayCallCount;
+  }
+
+  getSpeechSynthesis(): SpeechSynthesis|undefined {
+    return window.speechSynthesis;
   }
 }


### PR DESCRIPTION
TTS, i.e., `window.speechSynthesis`, may be unavailable for certain browsers (e.g., Opera on Android), . If that is the case, we fallback to personalized (cloud) TTS voice automatically.