### PR TITLE
[WebUI] During word replacement, preserve word-end punctuation

### DIFF
--- a/webui/src/app/abbreviation-refinement/abbreviation-refinement.component.ts
+++ b/webui/src/app/abbreviation-refinement/abbreviation-refinement.component.ts
@@ -1,6 +1,7 @@
 import {AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, QueryList, SimpleChanges, ViewChildren} from '@angular/core';
 import {Subscription} from 'rxjs';
 import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/cefsharp';
+import {extractEndPunctuation} from 'src/utils/text-utils';
 import {createUuid} from 'src/utils/uuid';
 
 import {getAbbreviationExpansionResponseStats, HttpEventLogger} from '../event-logger/event-logger-impl';
@@ -116,8 +117,20 @@ export class AbbreviationRefinementComponent implements OnInit, AfterViewInit,
     const replacement = this._replacements[index];
     this.eventLogger.logAbbreviationExpansionWordRefinementSelection(
         replacement.length, index);
+    const tokens = this.fillMaskRequest.phraseWithMask.split(/\s+/);
+    let newPhrase: string = '';
+    tokens.forEach((token, i) => {
+      if (token === '_') {
+        const endPunctuation =
+            extractEndPunctuation(this.fillMaskRequest.originalChipStrings[i]);
+        newPhrase += replacement + endPunctuation + ' ';
+
+      } else {
+        newPhrase += token + ' ';
+      }
+    });
     this.refinementResult.emit({
-      phrase: this.fillMaskRequest.phraseWithMask.replace('_', replacement),
+      phrase: newPhrase.trim(),
       isAbort: false,
     });
   }

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -93,6 +93,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
     this.fillMaskRequestTriggersSubscription =
         this.fillMaskTriggers.subscribe((request: FillMaskRequest) => {
           this.fillMaskRequest = request;
+          // console.log('*** Going into word replacement:', this.abbreviationOptions[this._selectedAbbreviationIndex]);  // DEBUG
           this.state = State.REFINING_EXPANSION;
           this.cdr.detectChanges();
         });
@@ -232,6 +233,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   }
 
   onRefinementResult(refinementResult: RefinementResult) {
+    console.log('*** refinementResult:', refinementResult);  // DEBUG
     if (!refinementResult.isAbort) {
       this.responseError = null;
       this.abbreviationOptions.splice(0);

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -93,7 +93,6 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
     this.fillMaskRequestTriggersSubscription =
         this.fillMaskTriggers.subscribe((request: FillMaskRequest) => {
           this.fillMaskRequest = request;
-          // console.log('*** Going into word replacement:', this.abbreviationOptions[this._selectedAbbreviationIndex]);  // DEBUG
           this.state = State.REFINING_EXPANSION;
           this.cdr.detectChanges();
         });
@@ -233,7 +232,6 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   }
 
   onRefinementResult(refinementResult: RefinementResult) {
-    console.log('*** refinementResult:', refinementResult);  // DEBUG
     if (!refinementResult.isAbort) {
       this.responseError = null;
       this.abbreviationOptions.splice(0);

--- a/webui/src/app/input-bar/input-bar.component.spec.ts
+++ b/webui/src/app/input-bar/input-bar.component.spec.ts
@@ -641,6 +641,7 @@ describe('InputBarComponent', () => {
          speechContent: 'How are you',
          phraseWithMask: 'i feel _',
          maskInitial: 'g',
+         originalChipStrings: ['i', 'feel', 'great'],
        });
        expect(testListener.numRequestSoftkeyboardResetCalls).toEqual(1);
      });

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -599,13 +599,15 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
       tokens[index] = '_';
       const phraseWithMask = tokens.join(' ');
       const maskInitial = this._chips[index].text[0];
+      const originalChipStrings = this._chips.map(chip => chip.text);
       this.eventLogger.logAbbreviatonExpansionWordRefinementRequest(
-          getPhraseStats(this._chips.map(chip => chip.text).join(' ')),
+          getPhraseStats(originalChipStrings.join(' ')),
           this._focusChipIndex);
       this.fillMaskTriggers.next({
         speechContent: this.contextStrings.join('|'),
         phraseWithMask,
         maskInitial,
+        originalChipStrings,
       });
       this.state = State.FOCUSED_ON_WORD_CHIP;
     }

--- a/webui/src/app/speakfaster-service.ts
+++ b/webui/src/app/speakfaster-service.ts
@@ -66,7 +66,9 @@ export interface FillMaskRequest {
 
   phraseWithMask: string;
 
-  maskInitial: string
+  maskInitial: string;
+
+  originalChipStrings: string[];
 }
 
 export interface FillMaskResponse {

--- a/webui/src/utils/text-utils.spec.ts
+++ b/webui/src/utils/text-utils.spec.ts
@@ -1,6 +1,6 @@
 /** Test utils for text-utils. */
 
-import {endsWithPunctuation, keySequenceEndsWith, limitStringLength, removePunctuation, trimStringAtHead} from './text-utils';
+import {endsWithPunctuation, extractEndPunctuation, keySequenceEndsWith, limitStringLength, removePunctuation, trimStringAtHead} from './text-utils';
 
 describe('text-utils', () => {
   describe('limitStringLength', () => {
@@ -90,6 +90,29 @@ describe('text-utils', () => {
       expect(endsWithPunctuation(' ')).toBeFalse();
       expect(endsWithPunctuation('wait')).toBeFalse();
       expect(endsWithPunctuation('wait; ')).toBeFalse();
+    });
+  });
+
+  describe('extractEndPunctuation', () => {
+    it('returns correct empty string', () => {
+      expect(extractEndPunctuation('')).toEqual('');
+      expect(extractEndPunctuation('foo')).toEqual('');
+      expect(extractEndPunctuation(',foo')).toEqual('');
+      expect(extractEndPunctuation(',foo ')).toEqual('');
+      expect(extractEndPunctuation('foo-bar-')).toEqual('');
+    });
+
+    it('returns correct punctuation', () => {
+      expect(extractEndPunctuation(',')).toEqual(',');
+      expect(extractEndPunctuation(':,')).toEqual(':,');
+      expect(extractEndPunctuation('foo,')).toEqual(',');
+      expect(extractEndPunctuation('foo,,')).toEqual(',,');
+      expect(extractEndPunctuation('foo;')).toEqual(';');
+      expect(extractEndPunctuation('foo:')).toEqual(':');
+      expect(extractEndPunctuation('foo...')).toEqual('...');
+      expect(extractEndPunctuation('foo!')).toEqual('!');
+      expect(extractEndPunctuation('foo?')).toEqual('?');
+      expect(extractEndPunctuation('foo!?')).toEqual('!?');
     });
   });
 });

--- a/webui/src/utils/text-utils.ts
+++ b/webui/src/utils/text-utils.ts
@@ -65,7 +65,16 @@ export function endsWithSentenceEndPunctuation(text: string): boolean {
  * sentence-end).
  */
 export function endsWithPunctuation(text: string): boolean {
-  return text.match(/.*[\,\;\:\.\!\?]$/) !== null;
+  return extractEndPunctuation(text) !== '';
+}
+
+export function extractEndPunctuation(text: string): string {
+  const searchIndex = text.search(/[\,\;\:\.\!\?]+$/);
+  if (searchIndex === -1) {
+    return '';
+  } else {
+    return text.substring(searchIndex);
+  }
 }
 
 /**

--- a/webui/src/utils/text-utils.ts
+++ b/webui/src/utils/text-utils.ts
@@ -70,11 +70,7 @@ export function endsWithPunctuation(text: string): boolean {
 
 export function extractEndPunctuation(text: string): string {
   const searchIndex = text.search(/[\,\;\:\.\!\?]+$/);
-  if (searchIndex === -1) {
-    return '';
-  } else {
-    return text.substring(searchIndex);
-  }
+  return searchIndex === -1 ? '' : text.substring(searchIndex);
 }
 
 /**


### PR DESCRIPTION
E.g., if the "great" in "I'm great, thanks" is replaced with the word option "good", the comma at the end of the original word should be preserved, leading to the new phrase "I'm good, thanks". Previously, the comma was discarded.
