### PR TITLE
[WebUI] In study mode, emphasize speak button in phrases

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -292,6 +292,7 @@ mat-progress-spinner {
           [scaleFontSize]="true"
           [showInjectButton]="!isStudyOn"
           [showFavoriteButton]="!isStudyOn"
+          [emphasizeSpeakButton]="isStudyOn"
           [color]="phraseBackgroundColor"
           [isTextClickable]="true"
           (textClicked)="onTextClicked($event)"

--- a/webui/src/app/abbreviation/abbreviation.component.spec.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.spec.ts
@@ -309,4 +309,22 @@ describe('AbbreviationComponent', () => {
     expect(fixture.componentInstance.isStudyOn).toBeFalse();
   });
 
+  it('displays expansion options with emphasized speak button during study', () => {
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    populateAbbreviationOptions(['what time is it', 'we took it in']);
+    fixture.componentInstance.state = State.CHOOSING_EXPANSION;
+    fixture.detectChanges();
+    const expansions =
+        fixture.debugElement.queryAll(By.css('app-phrase-component'));
+    expect(expansions.length).toEqual(2);
+    expect(expansions[0].nativeElement.innerText).toEqual('what time is it');
+    expect(expansions[1].nativeElement.innerText).toEqual('we took it in');
+
+    const phraseComponents =
+        fixture.debugElement.queryAll(By.css('app-phrase-component'));
+    expect(phraseComponents.length).toEqual(2);
+    expect(phraseComponents[0].componentInstance.emphasizeSpeakButton).toBeTrue();
+    expect(phraseComponents[1].componentInstance.emphasizeSpeakButton).toBeTrue();
+  });
+
 });

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -28,7 +28,7 @@ app-text-to-speech-component {
 }
 
 .app-context-compact {
-  height: wrap-content;
+  height: 72px;
 }
 
 .auth-area {

--- a/webui/src/app/app.component.html
+++ b/webui/src/app/app.component.html
@@ -16,7 +16,7 @@ app-abbreviation-component {
 
 app-context-component {
   display: block;
-  height: wrap-content;
+  height: 84px;
 }
 
 app-text-to-speech-component {
@@ -25,6 +25,10 @@ app-text-to-speech-component {
 
 .app-context-component-area-hidden {
   display: none;
+}
+
+.app-context-compact {
+  height: wrap-content;
 }
 
 .auth-area {
@@ -206,7 +210,7 @@ app-text-to-speech-component {
     <div class="main-right-pane">
 
       <app-context-component
-        [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION'}"
+        [ngClass]="{'app-context-component-area-hidden': appState !== 'ABBREVIATION_EXPANSION', 'app-context-compact': isStudyOn}"
         [userId]="userId"
         [isStudyOn]="isStudyOn"
         [textEntryEndSubject]="textEntryEndSubject"

--- a/webui/src/app/app.component.spec.ts
+++ b/webui/src/app/app.component.spec.ts
@@ -347,6 +347,16 @@ describe('AppComponent', () => {
     expect(fixture.componentInstance.isStudyOn).toBeFalse();
   });
 
+  it('isStudyOn sets compact context component', () => {
+    fixture.componentInstance.onNewAccessToken('foo-access-token');
+    setAppState(AppState.ABBREVIATION_EXPANSION);
+    studyManager.maybeHandleRemoteControlCommand('study on');
+    fixture.detectChanges();
+
+    const mainArea = fixture.debugElement.query(By.css('.main-area'));
+    expect(mainArea.query(By.css('.app-context-compact'))).not.toBeNull();
+  });
+
   it('supportsAbbrevationExpansion reflects study manager full mode',
      async () => {
        setAppState(AppState.ABBREVIATION_EXPANSION);

--- a/webui/src/app/input-bar/input-bar.component.ts
+++ b/webui/src/app/input-bar/input-bar.component.ts
@@ -107,7 +107,7 @@ export class InputBarComponent implements OnInit, AfterViewInit, OnDestroy {
   // keywords.
   private static readonly ABBREVIATION_MAX_TOTAL_LENGTH = 50;
   // TODO(cais): Switch to the wait-and-send mode.
-  private static readonly IN_FLIGHT_AE_TRIGGER_DEBOUNCE_MILLIS = 500;
+  private static readonly IN_FLIGHT_AE_TRIGGER_DEBOUNCE_MILLIS = 600;
 
   // NOTE(cais): If abbreviation expansion with mid-sentence comma is
   // prioritized, retsore the following ignore key sequence. This is

--- a/webui/src/app/phrase/phrase.component.html
+++ b/webui/src/app/phrase/phrase.component.html
@@ -59,6 +59,12 @@
   width: 76px;
 }
 
+.speak-button-emphasized {
+  background-color: #20AE69;
+  border: 1px solid #eee;
+  border-radius: 8px;
+}
+
 </style>
 
 <div class="phrase-container"
@@ -78,6 +84,7 @@
       #clickableButton
       *ngIf="!isEditing"
       class="action-button speak-button"
+      [ngClass]="{'speak-button-emphasized': emphasizeSpeakButton}"
       (click)="onSpeakButtonClicked($event)">
     <img class="button-image" src="/assets/images/speak.png" alt="speak phrase" />
   </button>

--- a/webui/src/app/phrase/phrase.component.spec.ts
+++ b/webui/src/app/phrase/phrase.component.spec.ts
@@ -275,4 +275,22 @@ describe('PhraseComponent', () => {
        const phrase = fixture.debugElement.query(By.css('.phrase'));
        expect(phrase.nativeElement.style.fontSize).toEqual('20px');
      });
+
+  it('emphasizeSpeakButton is false by default', () => {
+    fixture.componentInstance.phraseText = 'Hello';
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.emphasizeSpeakButton).toBeFalse();
+    expect(fixture.debugElement.query(By.css('.speak-button-emphasized')))
+        .toBeNull();
+  });
+
+  it('Setting emphasizeSpeakButton to true sets correct CSS class', () => {
+    fixture.componentInstance.phraseText = 'Hello';
+    fixture.componentInstance.emphasizeSpeakButton = true;
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.speak-button-emphasized')))
+        .not.toBeNull();
+  });
 });

--- a/webui/src/app/phrase/phrase.component.ts
+++ b/webui/src/app/phrase/phrase.component.ts
@@ -4,7 +4,6 @@ import {updateButtonBoxesForElements, updateButtonBoxesToEmpty} from 'src/utils/
 import {createUuid} from 'src/utils/uuid';
 
 import {SpeakFasterService} from '../speakfaster-service';
-import {StudyManager} from '../study/study-manager';
 
 export enum State {
   READY = 'READY',

--- a/webui/src/app/phrase/phrase.component.ts
+++ b/webui/src/app/phrase/phrase.component.ts
@@ -37,6 +37,7 @@ export class PhraseComponent implements AfterViewInit, OnDestroy {
   @Input() scaleFontSize = false;
   @Input() isTextClickable: boolean = false;
   @Input() isEditing: boolean = false;
+  @Input() emphasizeSpeakButton: boolean = false;
   @Output()
   textClicked: EventEmitter<{phraseText: string, phraseIndex: number}> =
       new EventEmitter();


### PR DESCRIPTION
Put a consistent green background on the speak buttons in the PhraseComponents.

Also in this PR:
- Increase sample time from 500 to 600 ms.