### PR TITLE
[DataManager] Add checks for missing and extraneous keypresses

### DIFF
--- a/Observer/SpeakFasterObserver Decoder/data_manager.py
+++ b/Observer/SpeakFasterObserver Decoder/data_manager.py
@@ -996,7 +996,7 @@ def upload_curated_freeform_text(window,
     f.write(redacted_freeform_txt)
   destination_blob_prefix = "/".join(
       [GCS_CURATED_FREEFORM_UPLOAD_PREFIX] +
-      [item for item in container_rpefix.split("/") if item] +
+      [item for item in container_prefix.split("/") if item] +
       ["freeform_text_%s" % datetime.datetime.now().isoformat()])
   uploaded_file_names = [
       os.path.relpath(metadata_json_path, tmp_dir),

--- a/Observer/SpeakFasterObserver Decoder/file_naming.py
+++ b/Observer/SpeakFasterObserver Decoder/file_naming.py
@@ -24,6 +24,8 @@ CURATED_PROCESSED_SPEECH_ONLY_TSV_FILENAME = (
 
 SPEAKER_ID_CONFIG_JSON_FILENAME = "speaker_id_config.json"
 
+KEYPRESS_CHECKS_TSV_FILENAME = "keypress_checks.tsv"
+
 
 def parse_timestamp(timestamp):
   """Parse timestamp into a Python datetime.datetime object.

--- a/Observer/SpeakFasterObserver Decoder/process_keypresses.py
+++ b/Observer/SpeakFasterObserver Decoder/process_keypresses.py
@@ -1044,7 +1044,6 @@ def write_extra_and_missing_keypresses_to_tsv(
             f.write("Extra\t%d\t%.3f\t%s\n" %
                     (index, timestamp_s, extra_keypress))
         for index, timestamp_s, missing_keypress in missing_keypresses:
-            print(index, type(timestamp_s), missing_keypress)
             f.write("Missing\t%d\t%.3f\t%s\n" %
                     (index, timestamp_s, missing_keypress))
 

--- a/Observer/SpeakFasterObserver Decoder/process_keypresses.py
+++ b/Observer/SpeakFasterObserver Decoder/process_keypresses.py
@@ -3,8 +3,6 @@ Processes keypress protobuffers to generate visualized results.
 Can generate various statistics (WPM, KSR, Error Rate) as well
 as output files capable of being used in other tools.
 """
-from typing import List, Tuple
-
 import argparse
 import csv
 import datetime
@@ -1032,7 +1030,6 @@ def keypress_in_keypresses(keypress, keypresses):
         timestamps = [item[0] for item in keypresses]
         return keypress[0] in timestamps
     return keypress in keypresses
-
 
 
 def write_extra_and_missing_keypresses_to_tsv(

--- a/Observer/SpeakFasterObserver Decoder/process_keypresses_test.py
+++ b/Observer/SpeakFasterObserver Decoder/process_keypresses_test.py
@@ -1,6 +1,7 @@
 """Unit tests for the process_keypresses module."""
 import csv
 from datetime import datetime
+import os
 import tempfile
 import unittest
 
@@ -424,6 +425,7 @@ class PhraseTest(unittest.TestCase):
     self.assertEqual(rows[2], ["Missing", "20", "10.800", "b"])
     self.assertEqual(rows[3], ["Missing", "20", "10.800", "c"])
     self.assertEqual(rows[4], ["Missing", "20", "10.801", "d"])
+    os.remove(temp_tsv_path)
 
 
 if __name__ == "__main__":

--- a/Observer/SpeakFasterObserver Decoder/process_keypresses_test.py
+++ b/Observer/SpeakFasterObserver Decoder/process_keypresses_test.py
@@ -384,6 +384,29 @@ class PhraseTest(unittest.TestCase):
     with self.assertRaisesRegexp(ValueError, "Mismatch in the first entry"):
         process_keypresses.check_keypresses(ref_keypresses, proc_keypresses)
 
+  def testCheckKeypresses_redactedKeysAreIgnored_equality(self):
+    ref_keypresses = [(0.100, "b"), (1.100, "a"), (1.100, "r")]
+    proc_keypresses = [(0.100, "[RedactedKey]"), (1.100, "a"), (1.100, "r")]
+    extra_keypresses, missing_keypresses = process_keypresses.check_keypresses(
+        ref_keypresses, proc_keypresses)
+    self.assertEqual(extra_keypresses, [])
+    self.assertEqual(missing_keypresses, [])
+
+  def testCheckKeypresses_redactedKeysAreIgnored_returnsMissingKey(self):
+    ref_keypresses = [(0.100, "b"), (1.100, "a"), (1.100, "r")]
+    proc_keypresses = [(0.100, "[RedactedKey]"), (1.100, "r")]
+    extra_keypresses, missing_keypresses = process_keypresses.check_keypresses(
+        ref_keypresses, proc_keypresses)
+    self.assertEqual(extra_keypresses, [])
+    self.assertEqual(missing_keypresses, [(1, 1.100, "a")])
+
+  def testCheckKeypresses_firstRedactedKeyIsShiftedSlightly(self):
+    ref_keypresses = [(0.100, "b"), (1.100, "a"), (1.100, "r")]
+    proc_keypresses = [(0.115, "[RedactedKey]"), (1.100, "a"), (1.100, "r")]
+    with self.assertRaisesRegexp(ValueError, "Mismatch in the first entry"):
+      process_keypresses.check_keypresses(
+          ref_keypresses, proc_keypresses)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Add button "Check keypresses". When this button is clicked, the data manager goes over the merged.tsv and curated_postprocessed.tsv files and look for any keypresses that are missing from the latter. It generates a new tsv file
called keypress_checks.tsv and write it to the session folder, followed by GCS upload. Redacted keys are ignored. Sessions
without a merged.tsv or curated_postprocessed.tsv files are ignored.