### PR TITLE
[WebUI] When auto AE trigger is on, require 2 clicks for word replacement

### DIFF
--- a/webui/src/app/abbreviation/abbreviation.component.html
+++ b/webui/src/app/abbreviation/abbreviation.component.html
@@ -293,7 +293,7 @@ mat-progress-spinner {
           [showInjectButton]="!isStudyOn"
           [showFavoriteButton]="!isStudyOn"
           [emphasizeSpeakButton]="isStudyOn"
-          [color]="phraseBackgroundColor"
+          [color]="getPhraseBackgroundColor(i)"
           [isTextClickable]="true"
           (textClicked)="onTextClicked($event)"
           (speakButtonClicked)="onSpeakOptionButtonClicked($event)"

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -72,6 +72,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   private abbreviationExpansionTriggersSubscription?: Subscription;
   private fillMaskRequestTriggersSubscription?: Subscription;
   private testEntryEndSubscription?: Subscription;
+  private highlightedPhraseIndex: number|null = null;
 
   constructor(
       public speakFasterService: SpeakFasterService,
@@ -192,7 +193,14 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   }
 
   onTextClicked(event: {phraseText: string; phraseIndex: number}) {
-    this.inputBarControlSubject.next(this.phraseToChips(event.phraseText));
+    const {phraseText, phraseIndex} = event;
+    if (this.highlightedPhraseIndex !== null &&
+        this.highlightedPhraseIndex === phraseIndex) {
+      this.inputBarControlSubject.next(this.phraseToChips(phraseText));
+      this.highlightedPhraseIndex = null;
+    } else {
+      this.highlightedPhraseIndex = phraseIndex;
+    }
   }
 
   onSpeakOptionButtonClicked(event: {phraseText: string, phraseIndex: number}) {
@@ -279,6 +287,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
     this.replacementTokens.splice(0);
     this.manualTokenString = '';
     this.reconstructedText = '';
+    this.highlightedPhraseIndex = null;
     this.state = State.PRE_CHOOSING_EXPANSION;
     this.cdr.detectChanges();
   }
@@ -344,8 +353,13 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
     this.cdr.detectChanges();
   }
 
-  get phraseBackgroundColor(): string {
-    return '#057bad';
+  getPhraseBackgroundColor(i: number): string {
+    if (this.highlightedPhraseIndex !== null &&
+        i === this.highlightedPhraseIndex) {
+      return '#006400';
+    } else {
+      return '#057bad';
+    }
   }
 
   get usedContextStrings(): string[] {

--- a/webui/src/app/abbreviation/abbreviation.component.ts
+++ b/webui/src/app/abbreviation/abbreviation.component.ts
@@ -34,6 +34,8 @@ const MAX_NUM_TEXT_PREDICTIONS = 4;
 export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
                                               AfterViewInit {
   private static readonly _NAME = 'AbbreviationComponent';
+  static readonly PHRASE_BG_COLOR_DEFAULT = '#057bad';
+  static readonly PHRASE_BG_COLOR_HIGHLIGHTED = '#006400';
 
   private readonly instanceId =
       AbbreviationComponent._NAME + '_' + createUuid();
@@ -87,7 +89,7 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
               if (!event.requestExpansion) {
                 return;
               }
-              this.highlightedPhraseIndex = null;  // TODO(cais): Add unit test.
+              this.highlightedPhraseIndex = null;
               this.abbreviation = event.abbreviationSpec;
               this.expandAbbreviation();
             });
@@ -369,9 +371,9 @@ export class AbbreviationComponent implements OnDestroy, OnInit, OnChanges,
   getPhraseBackgroundColor(i: number): string {
     if (this.highlightedPhraseIndex !== null &&
         i === this.highlightedPhraseIndex) {
-      return '#006400';
+      return AbbreviationComponent.PHRASE_BG_COLOR_HIGHLIGHTED;
     } else {
-      return '#057bad';
+      return AbbreviationComponent.PHRASE_BG_COLOR_DEFAULT;
     }
   }
 

--- a/webui/src/app/settings-ai/settings-ai.component.html
+++ b/webui/src/app/settings-ai/settings-ai.component.html
@@ -138,7 +138,7 @@
 <div
     *ngIf="appSettings !== null"
     class="settings-section enable-ae-auto-fire-section">
-    <div class="section-title">Trigger AE after every keystroke:</div>
+    <div class="section-title">AE auto fire + 2-click word replacement:</div>
 
     <button
         #clickableButton

--- a/webui/src/app/settings/settings.ts
+++ b/webui/src/app/settings/settings.ts
@@ -1,7 +1,6 @@
 /** Data types and logic related to app settings. */
 
 import {VERSION} from '@angular/core';
-import {ObjectUnsubscribedError} from 'rxjs';
 import {loadSettings, saveSettings} from 'src/utils/cefsharp';
 
 export type TtsVoiceType = 'PERSONALIZED'|'GENERIC';


### PR DESCRIPTION
* Rationale: Prevent unintended entry to the word replacement mode when used with eye gaze.
* This is now tied to the `enableAbbrevExpansionAutoFire` property in the settings. The rationale is that eye gaze users need both this new feature and the existing auto AE trigger feature, whereas mobile (touch) users need neither.